### PR TITLE
Add Cython dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
     version = "0.1.3",
     packages = find_packages(),
     install_requires = ['numpy>=1.7',
-                        'scipy>=0.13'
+                        'scipy>=0.13',
+                        'Cython'
                        ],
     author = "Rowan Cockett",
     author_email = "rowan@3ptscience.com",


### PR DESCRIPTION
This should really be dependent on Cython, if we're going to call `cythonize` directly in the build script, and if Cython is needed for good performance. Or, if not, we would need to make the import of `cythonize` conditional, and then skip building the extension if Cython isn't installed. Alternatively, don't build the .pyx file, and check in a compiled .c file; then make the following changes to setup.py:

- replace `from Cython.Build import cythonize` on Line 10 with `from setuptools.extension import Extension`
- replace `ext_modules = cythonize('SimPEG/Utils/interputils_cython.pyx')` on Line 53 with `ext_modules = [Extension('interputils_cython', sources=['SimPEG/Utils/interputils_cython.c'])]`