### PR TITLE
Be compatible with outside metaclasses, for now

### DIFF
--- a/SimPEG/Utils/codeutils.py
+++ b/SimPEG/Utils/codeutils.py
@@ -3,10 +3,7 @@ import time
 import numpy as np
 from functools import wraps
 
-
-class SimPEGMetaClass(type):
-    def __new__(cls, name, bases, attrs):
-        return super(SimPEGMetaClass, cls).__new__(cls, name, bases, attrs)
+SimPEGMetaClass = type
 
 def memProfileWrapper(towrap, *funNames):
     """


### PR DESCRIPTION
Making this change would make SimPEG more compatible with multiple inheritance in outside code. Metaclass inheritance is tricky, and for the moment the SimPEG metaclass doesn't really do anything. Setting `SimPEGMetaClass = type` preserves all the existing functionality in SimPEG code, and plays a bit better with outside multiple inheritance involving metaclasses. In the future, this may need to be addressed in more detail.