### PR TITLE
move examples right after getting started with SimPEG

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,15 @@ About SimPEG
    api_bigPicture
    api_installing
 
+Examples
+********
+
+.. toctree::
+   :maxdepth: 2
+
+   api_Examples
+   
+
 Packages
 ********
 
@@ -52,14 +61,6 @@ Packages
 
    em/index
    flow/index
-
-Examples
-********
-
-.. toctree::
-   :maxdepth: 2
-
-   api_Examples
 
 
 Finite Volume


### PR DESCRIPTION
put examples near the top of the docs