### PR TITLE
Naming conventions in Maps (re #231)

### DIFF
--- a/SimPEG/Examples/EM_FDEM_1D_Inversion.py
+++ b/SimPEG/Examples/EM_FDEM_1D_Inversion.py
@@ -21,8 +21,8 @@ def run(plotIt=True):
 
     active = mesh.vectorCCz<0.
     layer = (mesh.vectorCCz<0.) & (mesh.vectorCCz>=layerz)
-    actMap = Maps.ActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
-    mapping = Maps.ExpMap(mesh) * Maps.Vertical1DMap(mesh) * actMap
+    actMap = Maps.InjectActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
+    mapping = Maps.ExpMap(mesh) * Maps.SurjectVertical1D(mesh) * actMap
     sig_half = 2e-2
     sig_air = 1e-8
     sig_layer = 1e-2

--- a/SimPEG/Examples/EM_TDEM_1D_Inversion.py
+++ b/SimPEG/Examples/EM_TDEM_1D_Inversion.py
@@ -19,8 +19,8 @@ def run(plotIt=True):
 
     active = mesh.vectorCCz<0.
     layer = (mesh.vectorCCz<0.) & (mesh.vectorCCz>=-100.)
-    actMap = Maps.ActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
-    mapping = Maps.ExpMap(mesh) * Maps.Vertical1DMap(mesh) * actMap
+    actMap = Maps.InjectActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
+    mapping = Maps.ExpMap(mesh) * Maps.SurjectVertical1D(mesh) * actMap
     sig_half = 2e-3
     sig_air = 1e-8
     sig_layer = 1e-3

--- a/SimPEG/Maps.py
+++ b/SimPEG/Maps.py
@@ -4,6 +4,7 @@ from Tests import checkDerivative
 from PropMaps import PropMap, Property
 from numpy.polynomial import polynomial
 from scipy.interpolate import UnivariateSpline
+import warnings
 
 class IdentityMap(object):
     """
@@ -327,6 +328,12 @@ class SurjectFull(IdentityMap):
         """
         return np.ones([self.mesh.nC,1])
 
+class FullMap(SurjectFull):
+    def __init__(self,mesh,**kwargs):
+        warnings.warn(
+            "`FullMap` is deprecated and will be removed in future versions. Use `SurjectFull` instead",
+            FutureWarning)
+        SurjectFull.__init__(self,mesh,**kwargs)
 
 class SurjectVertical1D(IdentityMap):
     """SurjectVertical1DMap
@@ -369,6 +376,12 @@ class SurjectVertical1D(IdentityMap):
                     ), shape=(repNum, 1))
         return sp.kron(sp.identity(self.nP), repVec)
 
+class Vertical1DMap(SurjectVertical1D):
+    def __init__(self,mesh,**kwargs):
+        warnings.warn(
+            "`Vertical1DMap` is deprecated and will be removed in future versions. Use `SurjectVertical1D` instead",
+            FutureWarning)
+        SurjectVertical1D.__init__(self,mesh,**kwargs)
 
 class Surject2Dto3D(IdentityMap):
     """Map2Dto3D
@@ -424,6 +437,13 @@ class Surject2Dto3D(IdentityMap):
                     (range(nC), inds)
                 ), shape=(nC, nP))
         return P
+
+class Map2Dto3D(Surject2Dto3D):
+    def __init__(self,mesh,**kwargs):
+        warnings.warn(
+            "`Map2Dto3D` is deprecated and will be removed in future versions. Use `Surject2Dto3D` instead",
+            FutureWarning)
+        Surject2Dto3D.__init__(self,mesh,**kwargs)
 
 class Mesh2Mesh(IdentityMap):
     """
@@ -506,6 +526,13 @@ class InjectActiveCells(IdentityMap):
     def deriv(self, m):
         return self.P
 
+class ActiveCells(InjectActiveCells):
+    def __init__(self, mesh, indActive, valInactive, nC=None):
+        warnings.warn(
+            "`ActiveCells` is deprecated and will be removed in future versions. Use `InjectActiveCells` instead",
+            FutureWarning)
+        InjectActiveCells.__init__(self, mesh, indActive, valInactive, nC)
+
 class InjectActiveCellsTopo(IdentityMap):
     """
         Active model parameters. Extend for cells on topography to air cell (only works for tensor mesh)
@@ -577,6 +604,12 @@ class InjectActiveCellsTopo(IdentityMap):
     def deriv(self, m):
         return self.P
 
+class ActiveCellsTopo(InjectActiveCellsTopo):
+    def __init__(self, mesh, indActive, valInactive, nC=None):
+        warnings.warn(
+            "`ActiveCellsTopo` is deprecated and will be removed in future versions. Use `InjectActiveCellsTopo` instead",
+            FutureWarning)
+        InjectActiveCellsTopo.__init__(self, mesh, indActive, valInactive, nC)
 
 class Weighting(IdentityMap):
     """

--- a/SimPEG/Maps.py
+++ b/SimPEG/Maps.py
@@ -296,11 +296,11 @@ class LogMap(IdentityMap):
     def inverse(self, m):
         return np.exp(Utils.mkvc(m))
 
-class FullMap(IdentityMap):
+class SurjectFull(IdentityMap):
     """
-    FullMap
+    SurjectFull
 
-    Given a scalar, the FullMap maps the value to the
+    Given a scalar, the SurjectFull maps the value to the
     full model space.
     """
 
@@ -328,8 +328,8 @@ class FullMap(IdentityMap):
         return np.ones([self.mesh.nC,1])
 
 
-class Vertical1DMap(IdentityMap):
-    """Vertical1DMap
+class SurjectVertical1D(IdentityMap):
+    """SurjectVertical1DMap
 
         Given a 1D vector through the last dimension
         of the mesh, this will extend to the full
@@ -370,7 +370,7 @@ class Vertical1DMap(IdentityMap):
         return sp.kron(sp.identity(self.nP), repVec)
 
 
-class Map2Dto3D(IdentityMap):
+class Surject2Dto3D(IdentityMap):
     """Map2Dto3D
 
         Given a 2D vector, this will extend to the full
@@ -458,7 +458,7 @@ class Mesh2Mesh(IdentityMap):
         return self.P
 
 
-class ActiveCells(IdentityMap):
+class InjectActiveCells(IdentityMap):
     """
         Active model parameters.
 
@@ -506,7 +506,7 @@ class ActiveCells(IdentityMap):
     def deriv(self, m):
         return self.P
 
-class ActiveCellsTopo(IdentityMap):
+class InjectActiveCellsTopo(IdentityMap):
     """
         Active model parameters. Extend for cells on topography to air cell (only works for tensor mesh)
 

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -5,8 +5,8 @@ from scipy.sparse.linalg import dsolve
 
 TOL = 1e-14
 
-MAPS_TO_TEST_2D = ["CircleMap", "ComplexMap", "ExpMap", "IdentityMap", "SurjectVertical1D", "Weighting", "SurjectFull"]
-MAPS_TO_TEST_3D = [             "ComplexMap", "ExpMap", "IdentityMap", "SurjectVertical1D", "Weighting", "SurjectFull"]
+MAPS_TO_TEST_2D = ["CircleMap", "ComplexMap", "ExpMap", "IdentityMap", "SurjectVertical1D", "Weighting", "SurjectFull","FullMap","Vertical1DMap"]
+MAPS_TO_TEST_3D = [             "ComplexMap", "ExpMap", "IdentityMap", "SurjectVertical1D", "Weighting", "SurjectFull","FullMap","Vertical1DMap"]
 
 class MapTests(unittest.TestCase):
 
@@ -83,16 +83,17 @@ class MapTests(unittest.TestCase):
     def test_activeCells(self):
         M = Mesh.TensorMesh([2,4],'0C')
         expMap = Maps.ExpMap(M)
-        actMap = Maps.InjectActiveCells(M, M.vectorCCy <=0, 10, nC=M.nCy)
-        vertMap = Maps.SurjectVertical1D(M)
-        combo = vertMap * actMap
-        m = np.r_[1,2.]
-        mod = Models.Model(m,combo)
-        # import matplotlib.pyplot as plt
-        # plt.colorbar(M.plotImage(mod.transform)[0])
-        # plt.show()
-        self.assertLess(np.linalg.norm(mod.transform - np.r_[1,1,2,2,10,10,10,10.]), TOL)
-        self.assertLess((mod.transformDeriv - combo.deriv(m)).toarray().sum(), TOL)
+        for actMap in [Maps.InjectActiveCells(M, M.vectorCCy <=0, 10, nC=M.nCy), Maps.ActiveCells(M, M.vectorCCy <=0, 10, nC=M.nCy)]:
+        # actMap = Maps.InjectActiveCells(M, M.vectorCCy <=0, 10, nC=M.nCy)
+            vertMap = Maps.SurjectVertical1D(M)
+            combo = vertMap * actMap
+            m = np.r_[1,2.]
+            mod = Models.Model(m,combo)
+            # import matplotlib.pyplot as plt
+            # plt.colorbar(M.plotImage(mod.transform)[0])
+            # plt.show()
+            self.assertLess(np.linalg.norm(mod.transform - np.r_[1,1,2,2,10,10,10,10.]), TOL)
+            self.assertLess((mod.transformDeriv - combo.deriv(m)).toarray().sum(), TOL)
 
     def test_tripleMultiply(self):
         M = Mesh.TensorMesh([2,4],'0C')
@@ -115,29 +116,33 @@ class MapTests(unittest.TestCase):
         M2 = Mesh.TensorMesh([2,4])
         M3 = Mesh.TensorMesh([3,2,4])
         m = np.random.rand(M2.nC)
-        m2to3 = Maps.Surject2Dto3D(M3, normal='X')
-        m = np.arange(m2to3.nP)
-        self.assertTrue(m2to3.test())
-        self.assertTrue(np.all(Utils.mkvc( (m2to3 * m).reshape(M3.vnC,order='F')[0,:,:] ) == m))
+
+        for m2to3 in [Maps.Surject2Dto3D(M3, normal='X'), Maps.Map2Dto3D(M3, normal='X')]:
+        # m2to3 = Maps.Surject2Dto3D(M3, normal='X')
+            m = np.arange(m2to3.nP)
+            self.assertTrue(m2to3.test())
+            self.assertTrue(np.all(Utils.mkvc( (m2to3 * m).reshape(M3.vnC,order='F')[0,:,:] ) == m))
 
 
     def test_map2Dto3D_y(self):
         M2 = Mesh.TensorMesh([3,4])
         M3 = Mesh.TensorMesh([3,2,4])
         m = np.random.rand(M2.nC)
-        m2to3 = Maps.Surject2Dto3D(M3, normal='Y')
-        m = np.arange(m2to3.nP)
-        self.assertTrue(m2to3.test())
-        self.assertTrue(np.all(Utils.mkvc( (m2to3 * m).reshape(M3.vnC,order='F')[:,0,:] ) == m))
+        for m2to3 in [Maps.Surject2Dto3D(M3, normal='Y'),Maps.Map2Dto3D(M3, normal='Y')]:
+        # m2to3 = Maps.Surject2Dto3D(M3, normal='Y')
+            m = np.arange(m2to3.nP)
+            self.assertTrue(m2to3.test())
+            self.assertTrue(np.all(Utils.mkvc( (m2to3 * m).reshape(M3.vnC,order='F')[:,0,:] ) == m))
 
     def test_map2Dto3D_z(self):
         M2 = Mesh.TensorMesh([3,2])
         M3 = Mesh.TensorMesh([3,2,4])
         m = np.random.rand(M2.nC)
-        m2to3 = Maps.Surject2Dto3D(M3, normal='Z')
-        m = np.arange(m2to3.nP)
-        self.assertTrue(m2to3.test())
-        self.assertTrue(np.all(Utils.mkvc( (m2to3 * m).reshape(M3.vnC,order='F')[:,:,0] ) == m))
+        for m2to3 in [Maps.Surject2Dto3D(M3, normal='Z'),Maps.Map2Dto3D(M3, normal='Z')]:
+        # m2to3 = Maps.Surject2Dto3D(M3, normal='Z')
+            m = np.arange(m2to3.nP)
+            self.assertTrue(m2to3.test())
+            self.assertTrue(np.all(Utils.mkvc( (m2to3 * m).reshape(M3.vnC,order='F')[:,:,0] ) == m))
 
 
 if __name__ == '__main__':

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -5,8 +5,8 @@ from scipy.sparse.linalg import dsolve
 
 TOL = 1e-14
 
-MAPS_TO_TEST_2D = ["CircleMap", "ComplexMap", "ExpMap", "IdentityMap", "Vertical1DMap", "Weighting", "FullMap"]
-MAPS_TO_TEST_3D = [             "ComplexMap", "ExpMap", "IdentityMap", "Vertical1DMap", "Weighting", "FullMap"]
+MAPS_TO_TEST_2D = ["CircleMap", "ComplexMap", "ExpMap", "IdentityMap", "SurjectVertical1D", "Weighting", "SurjectFull"]
+MAPS_TO_TEST_3D = [             "ComplexMap", "ExpMap", "IdentityMap", "SurjectVertical1D", "Weighting", "SurjectFull"]
 
 class MapTests(unittest.TestCase):
 
@@ -52,7 +52,7 @@ class MapTests(unittest.TestCase):
     def test_mapMultiplication(self):
         M = Mesh.TensorMesh([2,3])
         expMap = Maps.ExpMap(M)
-        vertMap = Maps.Vertical1DMap(M)
+        vertMap = Maps.SurjectVertical1D(M)
         combo = expMap*vertMap
         m = np.arange(3.0)
         t_true = np.exp(np.r_[0,0,1,1,2,2.])
@@ -83,8 +83,8 @@ class MapTests(unittest.TestCase):
     def test_activeCells(self):
         M = Mesh.TensorMesh([2,4],'0C')
         expMap = Maps.ExpMap(M)
-        actMap = Maps.ActiveCells(M, M.vectorCCy <=0, 10, nC=M.nCy)
-        vertMap = Maps.Vertical1DMap(M)
+        actMap = Maps.InjectActiveCells(M, M.vectorCCy <=0, 10, nC=M.nCy)
+        vertMap = Maps.SurjectVertical1D(M)
         combo = vertMap * actMap
         m = np.r_[1,2.]
         mod = Models.Model(m,combo)
@@ -97,8 +97,8 @@ class MapTests(unittest.TestCase):
     def test_tripleMultiply(self):
         M = Mesh.TensorMesh([2,4],'0C')
         expMap = Maps.ExpMap(M)
-        vertMap = Maps.Vertical1DMap(M)
-        actMap = Maps.ActiveCells(M, M.vectorCCy <=0, 10, nC=M.nCy)
+        vertMap = Maps.SurjectVertical1D(M)
+        actMap = Maps.InjectActiveCells(M, M.vectorCCy <=0, 10, nC=M.nCy)
         m = np.r_[1,2.]
         t_true = np.exp(np.r_[1,1,2,2,10,10,10,10.])
         self.assertLess(np.linalg.norm((expMap * vertMap * actMap * m)-t_true,np.inf),TOL)
@@ -115,7 +115,7 @@ class MapTests(unittest.TestCase):
         M2 = Mesh.TensorMesh([2,4])
         M3 = Mesh.TensorMesh([3,2,4])
         m = np.random.rand(M2.nC)
-        m2to3 = Maps.Map2Dto3D(M3, normal='X')
+        m2to3 = Maps.Surject2Dto3D(M3, normal='X')
         m = np.arange(m2to3.nP)
         self.assertTrue(m2to3.test())
         self.assertTrue(np.all(Utils.mkvc( (m2to3 * m).reshape(M3.vnC,order='F')[0,:,:] ) == m))
@@ -125,7 +125,7 @@ class MapTests(unittest.TestCase):
         M2 = Mesh.TensorMesh([3,4])
         M3 = Mesh.TensorMesh([3,2,4])
         m = np.random.rand(M2.nC)
-        m2to3 = Maps.Map2Dto3D(M3, normal='Y')
+        m2to3 = Maps.Surject2Dto3D(M3, normal='Y')
         m = np.arange(m2to3.nP)
         self.assertTrue(m2to3.test())
         self.assertTrue(np.all(Utils.mkvc( (m2to3 * m).reshape(M3.vnC,order='F')[:,0,:] ) == m))
@@ -134,7 +134,7 @@ class MapTests(unittest.TestCase):
         M2 = Mesh.TensorMesh([3,2])
         M3 = Mesh.TensorMesh([3,2,4])
         m = np.random.rand(M2.nC)
-        m2to3 = Maps.Map2Dto3D(M3, normal='Z')
+        m2to3 = Maps.Surject2Dto3D(M3, normal='Z')
         m = np.arange(m2to3.nP)
         self.assertTrue(m2to3.test())
         self.assertTrue(np.all(Utils.mkvc( (m2to3 * m).reshape(M3.vnC,order='F')[:,:,0] ) == m))

--- a/tests/em/tdem/test_TDEM_b_DerivAdjoint.py
+++ b/tests/em/tdem/test_TDEM_b_DerivAdjoint.py
@@ -18,8 +18,8 @@ class TDEM_bDerivTests(unittest.TestCase):
         mesh = Mesh.CylMesh([hx,1,hy], '00C')
 
         active = mesh.vectorCCz<0.
-        activeMap = Maps.ActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
-        mapping = Maps.ExpMap(mesh) * Maps.Vertical1DMap(mesh) * activeMap
+        activeMap = Maps.InjectActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
+        mapping = Maps.ExpMap(mesh) * Maps.SurjectVertical1D(mesh) * activeMap
 
         rxOffset = 40.
         rx = EM.TDEM.RxTDEM(np.array([[rxOffset, 0., 0.]]), np.logspace(-4,-3, 20), 'bz')

--- a/tests/em/tdem/test_TDEM_b_MultiSrc_DerivAdjoint.py
+++ b/tests/em/tdem/test_TDEM_b_MultiSrc_DerivAdjoint.py
@@ -17,8 +17,8 @@ class TDEM_bDerivTests(unittest.TestCase):
         mesh = Mesh.CylMesh([hx,1,hy], '00C')
 
         active = mesh.vectorCCz<0.
-        activeMap = Maps.ActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
-        mapping = Maps.ExpMap(mesh) * Maps.Vertical1DMap(mesh) * activeMap
+        activeMap = Maps.InjectActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
+        mapping = Maps.ExpMap(mesh) * Maps.SurjectVertical1D(mesh) * activeMap
 
         rxOffset = 40.
         rx = EM.TDEM.RxTDEM(np.array([[rxOffset, 0., 0.]]), np.logspace(-4,-3, 20), 'bz')

--- a/tests/em/tdem/test_TDEM_combos.py
+++ b/tests/em/tdem/test_TDEM_combos.py
@@ -14,8 +14,8 @@ def getProb(meshType='CYL',rxTypes='bx,bz',nSrc=1):
     mesh = Mesh.CylMesh([hx,1,hy], '00C')
 
     active = mesh.vectorCCz<0.
-    activeMap = Maps.ActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
-    mapping = Maps.ExpMap(mesh) * Maps.Vertical1DMap(mesh) * activeMap
+    activeMap = Maps.InjectActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
+    mapping = Maps.ExpMap(mesh) * Maps.SurjectVertical1D(mesh) * activeMap
 
     rxOffset = 40.
 

--- a/tests/em/tdem/test_TDEM_forward_Analytic.py
+++ b/tests/em/tdem/test_TDEM_forward_Analytic.py
@@ -24,8 +24,8 @@ def halfSpaceProblemAnaDiff(meshType, sig_half=1e-2, rxOffset=50., bounds=[1e-5,
         mesh = Mesh.TensorMesh([hx,hy,hz], 'CCC')
 
     active = mesh.vectorCCz<0.
-    actMap = Maps.ActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
-    mapping = Maps.ExpMap(mesh) * Maps.Vertical1DMap(mesh) * actMap
+    actMap = Maps.InjectActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
+    mapping = Maps.ExpMap(mesh) * Maps.SurjectVertical1D(mesh) * actMap
 
     rx = EM.TDEM.RxTDEM(np.array([[rxOffset, 0., 0.]]), np.logspace(-5,-4, 21), 'bz')
     src = EM.TDEM.SrcTDEM_VMD_MVP([rx], loc=np.array([0., 0., 0.]))


### PR DESCRIPTION
- FullMap --> SurjectFull
- Vertical1DMap --> SurjectVertical1D
- Map2Dto3D --> Surject2Dto3D
- ActiveCells --> InjectActiveCells
- ActiveCellsTopo --> InjectActiveCellsTopo

to close #231 

@rowanc1 , @sgkang , @grosenkj : what do you guys think of this?

(I left ExpMap, IdentityMap, #231 talks about dropping the `Map` at the end, but this is a bit of a pain, and I do like having a verb in the name --> each of the maps is doing something, Mapping, Surjecting, Injecting) 