### PR TITLE
Allow moving off bounds in projected gradient

### DIFF
--- a/SimPEG/Optimization.py
+++ b/SimPEG/Optimization.py
@@ -888,6 +888,8 @@ class ProjectedGNCG(BFGS, Minimize, Remember):
     maxIterCG = 5
     tolCG = 1e-1
 
+    stepOffBoundsFact = 0.1 # perturbation of the inactive set off the bounds
+
     lower = -np.inf
     upper = np.inf
 
@@ -998,7 +1000,8 @@ class ProjectedGNCG(BFGS, Minimize, Remember):
                 dm_i = max( abs( delx ) )
                 dm_a = max( abs(rhs_a) )
 
-                delx = delx + rhs_a * dm_i / dm_a /10.
+                # perturb inactive set off of bounds so that they are included in the step
+                delx = delx + self.stepOffBoundsFact * (rhs_a * dm_i / dm_a)
 
             # Only keep gradients going in the right direction on the active set
             indx = ((self.xc<=self.lower) & (delx < 0)) | ((self.xc>=self.upper) & (delx > 0))

--- a/SimPEG/Optimization.py
+++ b/SimPEG/Optimization.py
@@ -990,4 +990,18 @@ class ProjectedGNCG(BFGS, Minimize, Remember):
                     cgFlag = 1
                 # End CG Iterations
 
+            # Take a gradient step on the active cells if exist
+            if temp != self.xc.size:
+
+                rhs_a = (Active) * -self.g
+
+                dm_i = max( abs( delx ) )
+                dm_a = max( abs(rhs_a) )
+
+                delx = delx + rhs_a * dm_i / dm_a /10.
+
+            # Only keep gradients going in the right direction on the active set
+            indx = ((self.xc<=self.lower) & (delx < 0)) | ((self.xc>=self.upper) & (delx > 0))
+            delx[indx] = 0.
+
             return delx


### PR DESCRIPTION
The current implementation does not allow you to move off the
bounds (lower/upper) once you have gotten on them, this allows you
to move off of the bound.

Please note that more testing should be done to ensure that this does
not introduce oscillations into the optimization routine.