### PR TITLE
use `f` for fields and `u` for a solution vector

### DIFF
--- a/SimPEG/DCIP/BaseDC.py
+++ b/SimPEG/DCIP/BaseDC.py
@@ -200,11 +200,11 @@ class ProblemDC_CC(Problem.BaseProblem):
 
         return F
 
-    def Jvec(self, m, v, u=None):
+    def Jvec(self, m, v, f=None):
         """
             :param numpy.array m: model
             :param numpy.array v: vector to multiply
-            :param numpy.array u: fields
+            :param Fields f: fields
             :rtype: numpy.array
             :return: Jv
 
@@ -225,11 +225,10 @@ class ProblemDC_CC(Problem.BaseProblem):
         # Set current model; clear dependent property $\mathbf{A(m)}$
         self.curModel = m
         sigma = self.curModel.transform # $\sigma = \mathcal{M}(\m)$
-        if u is None:
+        if f is None:
             # Run forward simulation if $u$ not provided
-            u = self.fields(self.curModel)[self.survey.srcList, 'phi_sol']
-        else:
-            u = u[self.survey.srcList, 'phi_sol']
+            f = self.fields(self.curModel)
+        u = f[self.survey.srcList, 'phi_sol']
 
         D = self.mesh.faceDiv
         G = self.mesh.cellGrad
@@ -251,19 +250,18 @@ class ProblemDC_CC(Problem.BaseProblem):
         if self.Ainv is None:
             self.Ainv = self.Solver(dA_du, **self.solverOpts)
 
-        P        = self.survey.getP(self.mesh)
+        P     = self.survey.getP(self.mesh)
         Jv    = - P * mkvc( self.Ainv * dCdm_x_v )
         return Jv
 
-    def Jtvec(self, m, v, u=None):
+    def Jtvec(self, m, v, f=None):
 
         self.curModel = m
         sigma = self.curModel.transform # $\sigma = \mathcal{M}(\m)$
-        if u is None:
-            # Run forward simulation if $u$ not provided
-            u = self.fields(self.curModel)[self.survey.srcList, 'phi_sol']
-        else:
-            u = u[self.survey.srcList, 'phi_sol']
+        if f is None:
+            # Run forward simulation if $f$ not provided
+            f = self.fields(self.curModel)
+        u = f[self.survey.srcList, 'phi_sol']
 
         shp = u.shape
         P = self.survey.getP(self.mesh)

--- a/SimPEG/DCIP/BaseIP.py
+++ b/SimPEG/DCIP/BaseIP.py
@@ -14,12 +14,12 @@ class SurveyIP(SurveyDC):
         Survey.BaseSurvey.__init__(self, **kwargs)
         self._Ps = {}
 
-    def dpred(self, m, u=None):
+    def dpred(self, m, f=None):
         """
             Predicted data.
 
             .. math::
-                d_\\text{pred} = Pu(m)
+                d_\\text{pred} = Pf(m)
         """
 
         return self.prob.forward(m)
@@ -143,10 +143,10 @@ class ProblemIP(Problem.BaseProblem):
         J_x_v    = - P * mkvc( self.Ainv * dCdm_x_v )
         return -J_x_v
 
-    def Jvec(self, m, v, u=None):
+    def Jvec(self, m, v, f=None):
         return self.forward(v)
 
-    def Jtvec(self, m, v, u=None):
+    def Jtvec(self, m, v, f=None):
 
         self.curModel = m
         # sigma = self.curModel.transform # $\sigma = \mathcal{M}(\m)$

--- a/SimPEG/DataMisfit.py
+++ b/SimPEG/DataMisfit.py
@@ -123,5 +123,5 @@ class l2_DataMisfit(BaseDataMisfit):
     @Utils.timeIt
     def eval2Deriv(self, m, v, f=None):
         "eval2Deriv(m, v, f=None)"
-        if f is None: f = prob.fields(m)
-        return self.prob.Jtvec_approx(m, self.Wd * (self.Wd * prob.Jvec_approx(m, v, f=f)), f=f)
+        if f is None: f = self.prob.fields(m)
+        return self.prob.Jtvec_approx(m, self.Wd * (self.Wd * self.prob.Jvec_approx(m, v, f=f)), f=f)

--- a/SimPEG/DataMisfit.py
+++ b/SimPEG/DataMisfit.py
@@ -22,11 +22,11 @@ class BaseDataMisfit(object):
         Utils.setKwargs(self,**kwargs)
 
     @Utils.timeIt
-    def eval(self, m, u=None):
-        """eval(m, u=None)
+    def eval(self, m, f=None):
+        """eval(m, f=None)
 
             :param numpy.array m: geophysical model
-            :param numpy.array u: fields
+            :param Fields f: fields
             :rtype: float
             :return: data misfit
 
@@ -34,11 +34,11 @@ class BaseDataMisfit(object):
         raise NotImplementedError('This method should be overwritten.')
 
     @Utils.timeIt
-    def evalDeriv(self, m, u=None):
-        """evalDeriv(m, u=None)
+    def evalDeriv(self, m, f=None):
+        """evalDeriv(m, f=None)
 
             :param numpy.array m: geophysical model
-            :param numpy.array u: fields
+            :param Fields f: fields
             :rtype: numpy.array
             :return: data misfit derivative
 
@@ -47,12 +47,12 @@ class BaseDataMisfit(object):
 
 
     @Utils.timeIt
-    def eval2Deriv(self, m, v, u=None):
-        """eval2Deriv(m, v, u=None)
+    def eval2Deriv(self, m, v, f=None):
+        """eval2Deriv(m, v, f=None)
 
             :param numpy.array m: geophysical model
             :param numpy.array v: vector to multiply
-            :param numpy.array u: fields
+            :param Fields f: fields
             :rtype: numpy.array
             :return: data misfit derivative
 
@@ -108,24 +108,20 @@ class l2_DataMisfit(BaseDataMisfit):
         self._Wd = value
 
     @Utils.timeIt
-    def eval(self, m, u=None):
-        "eval(m, u=None)"
-        prob   = self.prob
-        survey = self.survey
-        R = self.Wd * survey.residual(m, u)
+    def eval(self, m, f=None):
+        "eval(m, f=None)"
+        if f is None: f = self.prob.fields(m)
+        R = self.Wd * self.survey.residual(m, f)
         return 0.5*np.vdot(R, R)
 
     @Utils.timeIt
-    def evalDeriv(self, m, u=None):
-        "evalDeriv(m, u=None)"
-        prob   = self.prob
-        survey = self.survey
-        if u is None: u = prob.fields(m)
-        return prob.Jtvec(m, self.Wd * (self.Wd * survey.residual(m, u)), u)
+    def evalDeriv(self, m, f=None):
+        "evalDeriv(m, f=None)"
+        if f is None: f = self.prob.fields(m)
+        return self.prob.Jtvec(m, self.Wd * (self.Wd * self.survey.residual(m, f=f)), f=f)
 
     @Utils.timeIt
-    def eval2Deriv(self, m, v, u=None):
-        "eval2Deriv(m, v, u=None)"
-        prob   = self.prob
-        if u is None: u = prob.fields(m)
-        return prob.Jtvec_approx(m, self.Wd * (self.Wd * prob.Jvec_approx(m, v, u=u)), u)
+    def eval2Deriv(self, m, v, f=None):
+        "eval2Deriv(m, v, f=None)"
+        if f is None: f = prob.fields(m)
+        return self.prob.Jtvec_approx(m, self.Wd * (self.Wd * prob.Jvec_approx(m, v, f=f)), f=f)

--- a/SimPEG/Directives.py
+++ b/SimPEG/Directives.py
@@ -123,10 +123,10 @@ class BetaEstimate_ByEig(InversionDirective):
         if self.debug: print 'Calculating the beta0 parameter.'
 
         m = self.invProb.curModel
-        u = self.invProb.getFields(m, store=True, deleteWarmstart=False)
+        f = self.invProb.getFields(m, store=True, deleteWarmstart=False)
 
         x0 = np.random.rand(*m.shape)
-        t = x0.dot(self.dmisfit.eval2Deriv(m,x0,u=u))
+        t = x0.dot(self.dmisfit.eval2Deriv(m,x0,f=f))
         b = x0.dot(self.reg.eval2Deriv(m, v=x0))
         self.beta0 = self.beta0_ratio*(t/b)
 

--- a/SimPEG/EM/FDEM/SurveyFDEM.py
+++ b/SimPEG/EM/FDEM/SurveyFDEM.py
@@ -67,7 +67,7 @@ class Rx(SimPEG.Survey.BaseRx):
         """Grid Location projection (e.g. Ex Fy ...)"""
         return u._GLoc(self.rxType[0]) + self.knownRxTypes[self.rxType][1]
 
-    def eval(self, src, mesh, u):
+    def eval(self, src, mesh, f):
         """
         Project fields to recievers to get data.
 
@@ -80,27 +80,27 @@ class Rx(SimPEG.Survey.BaseRx):
         # projGLoc = u._GLoc(self.knownRxTypes[self.rxType][0])
         # projGLoc += self.knownRxTypes[self.rxType][1]
 
-        P = self.getP(mesh, self.projGLoc(u))
-        u_part_complex = u[src, self.projField]
+        P = self.getP(mesh, self.projGLoc(f))
+        f_part_complex = f[src, self.projField]
         # get the real or imag component
         real_or_imag = self.projComp
-        u_part = getattr(u_part_complex, real_or_imag)
+        f_part = getattr(f_part_complex, real_or_imag)
 
-        return P*u_part
+        return P*f_part
 
-    def evalDeriv(self, src, mesh, u, v, adjoint=False):
+    def evalDeriv(self, src, mesh, f, v, adjoint=False):
         """
         Derivative of projected fields with respect to the inversion model times a vector.
 
         :param Source src: FDEM source
         :param Mesh mesh: mesh used
-        :param Fields u: fields object
+        :param Fields f: fields object
         :param numpy.ndarray v: vector to multiply
         :rtype: numpy.ndarray
         :return: fields projected to recievers
         """
 
-        P = self.getP(mesh, self.projGLoc(u))
+        P = self.getP(mesh, self.projGLoc(f))
 
         if not adjoint:
             Pv_complex = P * v

--- a/SimPEG/EM/TDEM/BaseTDEM.py
+++ b/SimPEG/EM/TDEM/BaseTDEM.py
@@ -108,11 +108,11 @@ class BaseTDEMProblem(BaseTimeProblem, BaseEMProblem):
         Ainv.clean()
         return F
 
-    def Jvec(self, m, v, u=None):
+    def Jvec(self, m, v, f=None):
         """
             :param numpy.array m: Conductivity model
             :param numpy.ndarray v: vector (model object)
-            :param simpegEM.TDEM.FieldsTDEM u: Fields resulting from m
+            :param simpegEM.TDEM.FieldsTDEM f: Fields resulting from m
             :rtype: numpy.ndarray
             :return: w (data object)
 
@@ -125,15 +125,15 @@ class BaseTDEMProblem(BaseTimeProblem, BaseEMProblem):
         """
         if self.verbose: print '%s\nCalculating J(v)\n%s'%('*'*50,'*'*50)
         self.curModel = m
-        if u is None:
-            u = self.fields(m)
-        p = self.Gvec(m, v, u)
+        if f is None:
+            f = self.fields(m)
+        p = self.Gvec(m, v, f)
         y = self.solveAh(m, p)
-        Jv = self.survey.evalDeriv(u, v=y)
+        Jv = self.survey.evalDeriv(f, v=y)
         if self.verbose: print '%s\nDone calculating J(v)\n%s'%('*'*50,'*'*50)
         return - mkvc(Jv)
 
-    def Jtvec(self, m, v, u=None):
+    def Jtvec(self, m, v, f=None):
         """
             :param numpy.array m: Conductivity model
             :param numpy.ndarray,SimPEG.Survey.Data v: vector (data object)
@@ -150,15 +150,15 @@ class BaseTDEMProblem(BaseTimeProblem, BaseEMProblem):
         """
         if self.verbose: print '%s\nCalculating J^T(v)\n%s'%('*'*50,'*'*50)
         self.curModel = m
-        if u is None:
-            u = self.fields(m)
+        if f is None:
+            f = self.fields(m)
 
         if not isinstance(v, self.dataPair):
             v = self.dataPair(self.survey, v)
 
-        p = self.survey.evalDeriv(u, v=v, adjoint=True)
+        p = self.survey.evalDeriv(f, v=v, adjoint=True)
         y = self.solveAht(m, p)
-        w = self.Gtvec(m, y, u)
+        w = self.Gtvec(m, y, f)
         if self.verbose: print '%s\nDone calculating J^T(v)\n%s'%('*'*50,'*'*50)
         return - mkvc(w)
 

--- a/SimPEG/MT/BaseMT.py
+++ b/SimPEG/MT/BaseMT.py
@@ -27,7 +27,7 @@ class BaseMTProblem(BaseFDEMProblem):
     # Might need to add more stuff here.
 
     ## NEED to clean up the Jvec and Jtvec to use Zero and Identities for None components.
-    def Jvec(self, m, v, u=None):
+    def Jvec(self, m, v, f=None):
         """
         Function to calculate the data sensitivities dD/dm times a vector.
 
@@ -39,8 +39,8 @@ class BaseMTProblem(BaseFDEMProblem):
         """
 
         # Calculate the fields
-        if u is None:
-           u = self.fields(m)
+        if f is None:
+           f= self.fields(m)
         # Set current model
         self.curModel = m
         # Initiate the Jv object
@@ -56,9 +56,9 @@ class BaseMTProblem(BaseFDEMProblem):
                 # We need fDeriv_m = df/du*du/dm + df/dm
                 # Construct du/dm, it requires a solve
                 # NOTE: need to account for the 2 polarizations in the derivatives.
-                u_src = u[src,:]
+                f_src = f[src,:]
                 # dA_dm and dRHS_dm should be of size nE,2, so that we can multiply by dA_duI. The 2 columns are each of the polarizations.
-                dA_dm = self.getADeriv_m(freq, u_src, v) # Size: nE,2 (u_px,u_py) in the columns.
+                dA_dm = self.getADeriv_m(freq, f_src, v) # Size: nE,2 (u_px,u_py) in the columns.
                 dRHS_dm = self.getRHSDeriv_m(freq, v) # Size: nE,2 (u_px,u_py) in the columns.
                 if dRHS_dm is None:
                     du_dm = dA_duI * ( -dA_dm )
@@ -68,13 +68,13 @@ class BaseMTProblem(BaseFDEMProblem):
                 for rx in src.rxList:
                     # Get the projection derivative
                     # v should be of size 2*nE (for 2 polarizations)
-                    PDeriv_u = lambda t: rx.evalDeriv(src, self.mesh, u, t) # wrt u, we don't have have PDeriv wrt m
+                    PDeriv_u = lambda t: rx.evalDeriv(src, self.mesh, f, t) # wrt u, we don't have have PDeriv wrt m
                     Jv[src, rx] = PDeriv_u(mkvc(du_dm))
             dA_duI.clean()
         # Return the vectorized sensitivities
         return mkvc(Jv)
 
-    def Jtvec(self, m, v, u=None):
+    def Jtvec(self, m, v, f=None):
         """
         Function to calculate the transpose of the data sensitivities (dD/dm)^T times a vector.
 
@@ -85,8 +85,8 @@ class BaseMTProblem(BaseFDEMProblem):
             :return: Data sensitivities wrt m
         """
 
-        if u is None:
-            u = self.fields(m)
+        if f is None:
+            f = self.fields(m)
 
         self.curModel = m
 
@@ -103,15 +103,15 @@ class BaseMTProblem(BaseFDEMProblem):
 
             for src in self.survey.getSrcByFreq(freq):
                 ftype = self._fieldType + 'Solution'
-                u_src = u[src, :]
+                f_src = f[src, :]
 
                 for rx in src.rxList:
                     # Get the adjoint evalDeriv
                     # PTv needs to be nE,
-                    PTv = rx.evalDeriv(src, self.mesh, u, mkvc(v[src, rx],2), adjoint=True) # wrt u, need possibility wrt m
+                    PTv = rx.evalDeriv(src, self.mesh, f, mkvc(v[src, rx],2), adjoint=True) # wrt u, need possibility wrt m
                     # Get the
                     dA_duIT = ATinv * PTv
-                    dA_dmT = self.getADeriv_m(freq, u_src, mkvc(dA_duIT), adjoint=True)
+                    dA_dmT = self.getADeriv_m(freq, f_src, mkvc(dA_duIT), adjoint=True)
                     dRHS_dmT = self.getRHSDeriv_m(freq, mkvc(dA_duIT), adjoint=True)
                     # Make du_dmT
                     if dRHS_dmT is None:

--- a/SimPEG/MT/SurveyMT.py
+++ b/SimPEG/MT/SurveyMT.py
@@ -427,15 +427,15 @@ class Survey(SimPEGsurvey.BaseSurvey):
         assert freq in self._freqDict, "The requested frequency is not in this survey."
         return self._freqDict[freq]
 
-    def eval(self, u):
+    def eval(self, f):
         data = Data(self)
         for src in self.srcList:
             sys.stdout.flush()
             for rx in src.rxList:
-                data[src, rx] = rx.eval(src, self.mesh, u)
+                data[src, rx] = rx.eval(src, self.mesh, f)
         return data
 
-    def evalDeriv(self, u):
+    def evalDeriv(self, f):
         raise Exception('Use Transmitters to project fields deriv.')
 
 #################

--- a/SimPEG/Problem.py
+++ b/SimPEG/Problem.py
@@ -128,7 +128,7 @@ class BaseProblem(object):
             :rtype: numpy.array
             :return: approxJv
         """
-        return self.Jvec(m, v, u)
+        return self.Jvec(m, v, f)
 
     @Utils.timeIt
     def Jtvec_approx(self, m, v, f=None):
@@ -142,7 +142,7 @@ class BaseProblem(object):
             :rtype: numpy.array
             :return: JTv
         """
-        return self.Jtvec(m, v, u)
+        return self.Jtvec(m, v, f)
 
     def fields(self, m):
         """

--- a/SimPEG/Problem.py
+++ b/SimPEG/Problem.py
@@ -88,28 +88,28 @@ class BaseProblem(object):
         return self.survey is not None
 
     @Utils.timeIt
-    def Jvec(self, m, v, u=None):
-        """Jvec(m, v, u=None)
+    def Jvec(self, m, v, f=None):
+        """Jvec(m, v, f=None)
 
             Effect of J(m) on a vector v.
 
             :param numpy.array m: model
             :param numpy.array v: vector to multiply
-            :param numpy.array u: fields
+            :param Fields f: fields
             :rtype: numpy.array
             :return: Jv
         """
         raise NotImplementedError('J is not yet implemented.')
 
     @Utils.timeIt
-    def Jtvec(self, m, v, u=None):
-        """Jtvec(m, v, u=None)
+    def Jtvec(self, m, v, f=None):
+        """Jtvec(m, v, f=None)
 
             Effect of transpose of J(m) on a vector v.
 
             :param numpy.array m: model
             :param numpy.array v: vector to multiply
-            :param numpy.array u: fields
+            :param Fields f: fields
             :rtype: numpy.array
             :return: JTv
         """
@@ -117,28 +117,28 @@ class BaseProblem(object):
 
 
     @Utils.timeIt
-    def Jvec_approx(self, m, v, u=None):
-        """Jvec_approx(m, v, u=None)
+    def Jvec_approx(self, m, v, f=None):
+        """Jvec_approx(m, v, f=None)
 
             Approximate effect of J(m) on a vector v
 
             :param numpy.array m: model
             :param numpy.array v: vector to multiply
-            :param numpy.array u: fields
+            :param Fields f: fields
             :rtype: numpy.array
             :return: approxJv
         """
         return self.Jvec(m, v, u)
 
     @Utils.timeIt
-    def Jtvec_approx(self, m, v, u=None):
-        """Jtvec_approx(m, v, u=None)
+    def Jtvec_approx(self, m, v, f=None):
+        """Jtvec_approx(m, v, f=None)
 
             Approximate effect of transpose of J(m) on a vector v.
 
             :param numpy.array m: model
             :param numpy.array v: vector to multiply
-            :param numpy.array u: fields
+            :param Fields f: fields
             :rtype: numpy.array
             :return: JTv
         """
@@ -224,9 +224,9 @@ class LinearProblem(BaseProblem):
     def fields(self, m):
         return self.G.dot(m)
 
-    def Jvec(self, m, v, u=None):
+    def Jvec(self, m, v, f=None):
         return self.G.dot(v)
 
-    def Jtvec(self, m, v, u=None):
+    def Jtvec(self, m, v, f=None):
         return self.G.T.dot(v)
 

--- a/SimPEG/Survey.py
+++ b/SimPEG/Survey.py
@@ -313,20 +313,20 @@ class BaseSurvey(object):
 
 
     @Utils.count
-    def eval(self, u):
-        """eval(u)
+    def eval(self, f):
+        """eval(f)
 
             This function projects the fields onto the data space.
 
             .. math::
 
-                d_\\text{pred} = \mathbf{P} u(m)
+                d_\\text{pred} = \mathbf{P} f(m)
         """
         raise NotImplemented('eval is not yet implemented.')
 
     @Utils.count
-    def evalDeriv(self, u):
-        """evalDeriv(u)
+    def evalDeriv(self, f):
+        """evalDeriv(f)
 
             This function s the derivative of projects the fields onto the data space.
 
@@ -379,8 +379,8 @@ class BaseSurvey(object):
         return self.dobs
 
 class LinearSurvey(BaseSurvey):
-    def eval(self, u):
-        return u
+    def eval(self, f):
+        return f
 
     @property
     def nD(self):

--- a/SimPEG/Survey.py
+++ b/SimPEG/Survey.py
@@ -295,21 +295,21 @@ class BaseSurvey(object):
 
     @Utils.count
     @Utils.requires('prob')
-    def dpred(self, m, u=None):
-        """dpred(m, u=None)
+    def dpred(self, m, f=None):
+        """dpred(m, f=None)
 
             Create the projected data from a model.
-            The field, u, (if provided) will be used for the predicted data
+            The fields, f, (if provided) will be used for the predicted data
             instead of recalculating the fields (which may be expensive!).
 
             .. math::
 
-                d_\\text{pred} = P(u(m))
+                d_\\text{pred} = P(f(m))
 
             Where P is a projection of the fields onto the data space.
         """
-        if u is None: u = self.prob.fields(m)
-        return Utils.mkvc(self.eval(u))
+        if f is None: f = self.prob.fields(m)
+        return Utils.mkvc(self.eval(f))
 
 
     @Utils.count
@@ -337,11 +337,11 @@ class BaseSurvey(object):
         raise NotImplemented('eval is not yet implemented.')
 
     @Utils.count
-    def residual(self, m, u=None):
-        """residual(m, u=None)
+    def residual(self, m, f=None):
+        """residual(m, f=None)
 
             :param numpy.array m: geophysical model
-            :param numpy.array u: fields
+            :param numpy.array f: fields
             :rtype: numpy.array
             :return: data residual
 
@@ -352,14 +352,14 @@ class BaseSurvey(object):
                 \mu_\\text{data} = \mathbf{d}_\\text{pred} - \mathbf{d}_\\text{obs}
 
         """
-        return Utils.mkvc(self.dpred(m, u=u) - self.dobs)
+        return Utils.mkvc(self.dpred(m, f=f) - self.dobs)
 
     @property
     def isSynthetic(self):
         "Check if the data is synthetic."
         return self.mtrue is not None
 
-    def makeSyntheticData(self, m, std=0.05, u=None, force=False):
+    def makeSyntheticData(self, m, std=0.05, f=None, force=False):
         """
             Make synthetic data given a model, and a standard deviation.
 
@@ -372,7 +372,7 @@ class BaseSurvey(object):
         if getattr(self, 'dobs', None) is not None and not force:
             raise Exception('Survey already has dobs. You can use force=True to override this exception.')
         self.mtrue = m
-        self.dtrue = self.dpred(m, u=u)
+        self.dtrue = self.dpred(m, f=f)
         noise = std*abs(self.dtrue)*np.random.randn(*self.dtrue.shape)
         self.dobs = self.dtrue+noise
         self.std = self.dobs*0 + std
@@ -381,7 +381,7 @@ class BaseSurvey(object):
 class LinearSurvey(BaseSurvey):
     def eval(self, u):
         return u
-    
+
     @property
     def nD(self):
         return self.prob.G.shape[0]

--- a/tests/flow/test_Richards.py
+++ b/tests/flow/test_Richards.py
@@ -116,8 +116,8 @@ class RichardsTests1D(unittest.TestCase):
         v = np.random.rand(self.survey.nD)
         z = np.random.rand(self.M.nC)
         Hs = self.prob.fields(self.Ks)
-        vJz = v.dot(self.prob.Jvec(self.Ks,z,u=Hs))
-        zJv = z.dot(self.prob.Jtvec(self.Ks,v,u=Hs))
+        vJz = v.dot(self.prob.Jvec(self.Ks,z,f=Hs))
+        zJv = z.dot(self.prob.Jtvec(self.Ks,v,f=Hs))
         tol = TOL*(10**int(np.log10(np.abs(zJv))))
         passed = np.abs(vJz - zJv) < tol
         print 'Richards Adjoint Test - PressureHead'
@@ -188,8 +188,8 @@ class RichardsTests2D(unittest.TestCase):
         v = np.random.rand(self.survey.nD)
         z = np.random.rand(self.M.nC)
         Hs = self.prob.fields(self.Ks)
-        vJz = v.dot(self.prob.Jvec(self.Ks,z,u=Hs))
-        zJv = z.dot(self.prob.Jtvec(self.Ks,v,u=Hs))
+        vJz = v.dot(self.prob.Jvec(self.Ks,z,f=Hs))
+        zJv = z.dot(self.prob.Jtvec(self.Ks,v,f=Hs))
         tol = TOL*(10**int(np.log10(np.abs(zJv))))
         passed = np.abs(vJz - zJv) < tol
         print '2D: Richards Adjoint Test - PressureHead'
@@ -260,8 +260,8 @@ class RichardsTests3D(unittest.TestCase):
         v = np.random.rand(self.survey.nD)
         z = np.random.rand(self.M.nC)
         Hs = self.prob.fields(self.Ks)
-        vJz = v.dot(self.prob.Jvec(self.Ks,z,u=Hs))
-        zJv = z.dot(self.prob.Jtvec(self.Ks,v,u=Hs))
+        vJz = v.dot(self.prob.Jvec(self.Ks,z,f=Hs))
+        zJv = z.dot(self.prob.Jtvec(self.Ks,v,f=Hs))
         tol = TOL*(10**int(np.log10(np.abs(zJv))))
         passed = np.abs(vJz - zJv) < tol
         print '3D: Richards Adjoint Test - PressureHead'


### PR DESCRIPTION
Problem.Jvec, Problem.Jtvec, Problem.fields, DataMisfit,  survey.dpred all take a fields object, `f` not a solution vector `u`. DCIP will take some more clean-up, but this will be handled in the refactor of DC. These changes will close #271. This touches a lot of the repo, so a quick review by a few people would be much appreciated! 