### PR TITLE
Installation (i.e., setup.py) is no longer dependent on Numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,15 +5,16 @@ SimPEG is a python package for simulation and gradient based
 parameter estimation in the context of geophysical applications.
 """
 
-import numpy as np
-
 import os
 import sys
 import subprocess
 
 from distutils.core import setup
+from distutils.command.build_ext import build_ext
 from setuptools import find_packages
 from distutils.extension import Extension
+
+
 
 CLASSIFIERS = [
 'Development Status :: 4 - Beta',
@@ -51,11 +52,16 @@ if args.count("build_ext") > 0 and args.count("--inplace") == 0:
 try:
     from Cython.Build import cythonize
     from Cython.Distutils import build_ext
-    cythonKwargs = dict(cmdclass={'build_ext': build_ext})
     USE_CYTHON = True
 except Exception, e:
     USE_CYTHON = False
-    cythonKwargs = dict()
+
+class NumpyBuild(build_ext):
+    def finalize_options(self):
+        build_ext.finalize_options(self)
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
 
 ext = '.pyx' if USE_CYTHON else '.c'
 
@@ -94,8 +100,8 @@ setup(
     classifiers=CLASSIFIERS,
     platforms = ["Windows", "Linux", "Solaris", "Mac OS-X", "Unix"],
     use_2to3 = False,
-    include_dirs=[np.get_include()],
+    cmdclass={'build_ext':NumpyBuild},
+    setup_requires=['numpy'],
     ext_modules = extensions,
     scripts=scripts,
-    **cythonKwargs
 )


### PR DESCRIPTION
When we go to install SimPEG (or packages w/ SimPEG dependencies) on architecture that doesn't have `numpy` present already, it will fail to install. This happens because `setup.py` imports `numpy` before it's guaranteed to be setup on the system. This change implements a workaround that lets `distutils` get up and going before `numpy` is imported.

See [StackOverflow](http://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py)