### PR TITLE
Bug/propmap

### DIFF
--- a/SimPEG/EM/Base.py
+++ b/SimPEG/EM/Base.py
@@ -169,9 +169,7 @@ class BaseEMProblem(Problem.BaseProblem):
 
         dMeSigmaI_dI = -self.MeSigmaI**2
         dMe_dsig = self.mesh.getEdgeInnerProductDeriv(self.curModel.sigma)(u)
-        dsig_dm = self.curModel.sigmaDeriv
-        return dMeSigmaI_dI * ( dMe_dsig * ( dsig_dm))
-        # return self.mesh.getEdgeInnerProductDeriv(self.curModel.sigma, invMat=True)(u)
+        return dMeSigmaI_dI * ( dMe_dsig * self.curModel.sigmaDeriv )
 
     @property
     def MfRho(self):
@@ -187,8 +185,7 @@ class BaseEMProblem(Problem.BaseProblem):
         """
             Derivative of :code:`MfRho` with respect to the model.
         """
-        return self.mesh.getFaceInnerProductDeriv(self.curModel.rho)(u) * (-Utils.sdiag(self.curModel.rho**2) * self.curModel.sigmaDeriv)
-        # self.curModel.rhoDeriv
+        return self.mesh.getFaceInnerProductDeriv(self.curModel.rho)(u) * self.curModel.rhoDeriv
 
     @property
     def MfRhoI(self):
@@ -208,9 +205,7 @@ class BaseEMProblem(Problem.BaseProblem):
 
         dMfRhoI_dI = -self.MfRhoI**2
         dMf_drho = self.mesh.getFaceInnerProductDeriv(self.curModel.rho)(u)
-        return dMfRhoI_dI * ( dMf_drho * (-Utils.sdiag(self.curModel.rho**2) * self.curModel.sigmaDeriv) )
-
-        # return self.mesh.getFaceInnerProductDeriv(self.curModel.rho, invMat=True)(u) * self.curModel.rhoDeriv
+        return dMfRhoI_dI * ( dMf_drho * self.curModel.rhoDeriv )
 
 class BaseEMSurvey(Survey.BaseSurvey):
 

--- a/SimPEG/PropMaps.py
+++ b/SimPEG/PropMaps.py
@@ -74,7 +74,7 @@ class Property(object):
                 if linkedMap is None:
                     return None
                 linkMap = linkMapClass(None) * linkedMap
-                m = getattr(self, '%s'%linkName)
+                m = getattr(self, '%sModel'%linkName)
                 return linkMap.deriv( m )
 
             m = getattr(self, '%sModel'%prop.name)
@@ -239,7 +239,7 @@ class PropMap(object):
             setattr(self, '%sMap'%name, mapping)
             setattr(self, '%sIndex'%name, slices.get(name, slice(nP, nP + mapping.nP)))
             nP += mapping.nP
-        self.nP = nP 
+        self.nP = nP
 
     @property
     def defaultInvProp(self):

--- a/tests/base/test_PropMaps.py
+++ b/tests/base/test_PropMaps.py
@@ -1,6 +1,7 @@
 import unittest
 from SimPEG import *
 from scipy.constants import mu_0
+from SimPEG import Tests
 
 
 class MyPropMap(Maps.PropMap):
@@ -186,6 +187,34 @@ class TestPropMaps(unittest.TestCase):
         self.assertRaises(AssertionError, MyReciprocalPropMap, [('sigma', iMap), ('rho', iMap)])
 
         MyReciprocalPropMap([('sigma', iMap), ('mu', iMap)]) # This should be fine
+
+    def test_linked_derivs_sigma(self):
+        mesh = Mesh.TensorMesh([4,5], x0='CC')
+
+        mapping = Maps.ExpMap(mesh)
+        propmap = MyReciprocalPropMap([('rho', mapping)])
+
+        x0 = np.random.rand(mesh.nC)
+        m  = propmap(x0)
+
+        # test Sigma
+        testme = lambda v: [1./(m.rhoMap*v), m.sigmaDeriv]
+        print 'Testing Rho from Sigma'
+        Tests.checkDerivative(testme, x0, dx=0.01*x0, num=5, plotIt=False)
+
+    def test_linked_derivs_rho(self):
+        mesh = Mesh.TensorMesh([4,5], x0='CC')
+
+        mapping = Maps.ExpMap(mesh)
+        propmap = MyReciprocalPropMap([('sigma', mapping)])
+
+        x0 = np.random.rand(mesh.nC)
+        m  = propmap(x0)
+
+        # test Sigma
+        testme = lambda v: [1./(m.sigmaMap*v), m.rhoDeriv]
+        print 'Testing Rho from Sigma'
+        Tests.checkDerivative(testme, x0, dx=0.01*x0, num=5, plotIt=False)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Fixed bug in propmap derivatives for linked properties as per issue #321. 
- Use fixed propmap in EM problem (cleans up mass matrices and ensures that derivs of linked properties are tested) 

![image](https://cloud.githubusercontent.com/assets/6361812/15594683/b757656e-236c-11e6-8ed5-c284af0eb095.png)
