### PR TITLE
fixed install on python3

### DIFF
--- a/SimPEG/Maps.py
+++ b/SimPEG/Maps.py
@@ -11,7 +11,6 @@ from . import Utils
 import numpy as np, scipy.sparse as sp
 from scipy.sparse.linalg import LinearOperator
 from .Tests import checkDerivative
-from .PropMaps import PropMap, Property
 from numpy.polynomial import polynomial
 from scipy.interpolate import UnivariateSpline
 import warnings
@@ -985,9 +984,3 @@ class SplineMap(IdentityMap):
         else :
             raise Exception
         return sp.csr_matrix(np.c_[g1,g2,g3])
-
-
-
-
-
-

--- a/SimPEG/Utils/matutils.py
+++ b/SimPEG/Utils/matutils.py
@@ -9,6 +9,7 @@ from builtins import object
 import numpy as np
 import scipy.sparse as sp
 from .codeutils import isScalar
+from past.utils import old_div
 
 def mkvc(x, numDims=1):
     """Creates a vector with the number of dimension specified
@@ -472,5 +473,3 @@ class Identity(object):
     def __ne__(self, v):return (not (1 == v))if self._positive else (not (-1 == v))
     def __ge__(self, v):return 1 >= v if self._positive else -1 >= v
     def __gt__(self, v):return 1 >  v if self._positive else -1 >  v
-
-

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ args = sys.argv[1:]
 
 # Make a `cleanall` rule to get rid of intermediate and library files
 if "cleanall" in args:
-    print "Deleting cython files..."
+    print("Deleting cython files...")
     # Just in case the build directory was created by accident,
     # note that shell=True should be OK here because the command is constant.
     subprocess.Popen("rm -rf build", shell=True, executable="/bin/bash")
@@ -53,7 +53,7 @@ try:
     from Cython.Build import cythonize
     from Cython.Distutils import build_ext
     USE_CYTHON = True
-except Exception, e:
+except Exception as e:
     USE_CYTHON = False
 
 class NumpyBuild(build_ext):


### PR DESCRIPTION
I tried install the Python3 branch but it had errors. These changes fixe them:
- 2to3 on setup.py
- removed uneeded circular import in Maps.py
- added missing old_div in mathutils (created by 2to3)