### PR TITLE
bug fix and additional testing on cyl mesh

### DIFF
--- a/SimPEG/Mesh/CylMesh.py
+++ b/SimPEG/Mesh/CylMesh.py
@@ -366,7 +366,7 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
             return None
 
         if projType == 'E':
-                M = 0.5*M
+            M = 0.5*M
 
         if invMat:
             return Utils.sdInv(M)

--- a/SimPEG/Mesh/CylMesh.py
+++ b/SimPEG/Mesh/CylMesh.py
@@ -1,11 +1,10 @@
 import numpy as np
 import scipy.sparse as sp
 from scipy.constants import pi
-from SimPEG.Utils import mkvc, ndgrid, sdiag, kron3, speye, spzeros, ddx, av, avExtrap
+from SimPEG import Utils
 from TensorMesh import BaseTensorMesh, BaseRectangularMesh
 from InnerProducts import InnerProducts
 from View import CylView
-
 
 class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
     """
@@ -190,32 +189,32 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
     def faceDivx(self):
         """Construct divergence operator in the x component (face-stg to cell-centres)."""
         if getattr(self, '_faceDivx', None) is None:
-            D1 = kron3(speye(self.nCz), speye(self.nCy), ddx(self.nCx)[:,1:])
+            D1 = Utils.kron3(Utils.speye(self.nCz), Utils.speye(self.nCy), Utils.ddx(self.nCx)[:,1:])
             S = self.r(self.area, 'F', 'Fx', 'V')
             V = self.vol
-            self._faceDivx = sdiag(1/V)*D1*sdiag(S)
+            self._faceDivx = Utils.sdiag(1/V)*D1*Utils.sdiag(S)
         return self._faceDivx
 
     @property
     def faceDivy(self):
         """Construct divergence operator in the y component (face-stg to cell-centres)."""
-        raise NotImplementedError('Wrapping the ddx is not yet implemented.')
+        raise NotImplementedError('Wrapping the Utils.ddx is not yet implemented.')
         if getattr(self, '_faceDivy', None) is None:
             # TODO: this needs to wrap to join up faces which are connected in the cylinder
-            D2 = kron3(speye(self.nCz), ddx(self.nCy), speye(self.nCx))
+            D2 = Utils.kron3(Utils.speye(self.nCz), Utils.ddx(self.nCy), Utils.speye(self.nCx))
             S = self.r(self.area, 'F', 'Fy', 'V')
             V = self.vol
-            self._faceDivy = sdiag(1/V)*D2*sdiag(S)
+            self._faceDivy = Utils.sdiag(1/V)*D2*Utils.sdiag(S)
         return self._faceDivy
 
     @property
     def faceDivz(self):
         """Construct divergence operator in the z component (face-stg to cell-centres)."""
         if getattr(self, '_faceDivz', None) is None:
-            D3 = kron3(ddx(self.nCz), speye(self.nCy), speye(self.nCx))
+            D3 = Utils.kron3(Utils.ddx(self.nCz), Utils.speye(self.nCy), Utils.speye(self.nCx))
             S = self.r(self.area, 'F', 'Fz', 'V')
             V = self.vol
-            self._faceDivz = sdiag(1/V)*D3*sdiag(S)
+            self._faceDivz = Utils.sdiag(1/V)*D3*Utils.sdiag(S)
         return self._faceDivz
 
 
@@ -254,7 +253,7 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
             A = self.area
             E = self.edge
             #Edge curl operator
-            self._edgeCurl = sdiag(1/A)*sp.vstack((Dz, Dr))*sdiag(E)
+            self._edgeCurl = Utils.sdiag(1/A)*sp.vstack((Dz, Dr))*Utils.sdiag(E)
         return self._edgeCurl
 
     # @property
@@ -277,14 +276,14 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
             # The number of cell centers in each direction
             n = self.vnC
             if self.isSymmetric:
-                avR = av(n[0])[:,1:]
+                avR = Utils.av(n[0])[:, 1:]
                 avR[0,0] = 1.
-                self._aveE2CC = sp.kron(av(n[2]), avR, format="csr")
+                self._aveE2CC = sp.kron(Utils.av(n[2]), avR, format="csr")
             else:
                 raise NotImplementedError('wrapping in the averaging is not yet implemented')
-                # self._aveE2CC = (1./3)*sp.hstack((kron3(av(n[2]), av(n[1]), speye(n[0])),
-                #                                   kron3(av(n[2]), speye(n[1]), av(n[0])),
-                #                                   kron3(speye(n[2]), av(n[1]), av(n[0]))), format="csr")
+                # self._aveE2CC = (1./3)*sp.hstack((Utils.kron3(Utils.av(n[2]), Utils.av(n[1]), Utils.speye(n[0])),
+                #                                   Utils.kron3(Utils.av(n[2]), Utils.speye(n[1]), Utils.av(n[0])),
+                #                                   Utils.kron3(Utils.speye(n[2]), Utils.av(n[1]), Utils.av(n[0]))), format="csr")
         return self._aveE2CC
 
     @property
@@ -306,14 +305,14 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
         if getattr(self, '_aveF2CC', None) is None:
             n = self.vnC
             if self.isSymmetric:
-                avR = av(n[0])[:,1:]
+                avR = Utils.av(n[0])[:,1:]
                 avR[0,0] = 1.
-                self._aveF2CC = (0.5)*sp.hstack((sp.kron(speye(n[2]), avR), sp.kron(av(n[2]), speye(n[0]))), format="csr")
+                self._aveF2CC = (0.5)*sp.hstack((sp.kron(Utils.speye(n[2]), avR), sp.kron(Utils.av(n[2]), Utils.speye(n[0]))), format="csr")
             else:
                 raise NotImplementedError('wrapping in the averaging is not yet implemented')
-                # self._aveF2CC = (1./3.)*sp.hstack((kron3(speye(n[2]), speye(n[1]), av(n[0])),
-                #                                    kron3(speye(n[2]), av(n[1]), speye(n[0])),
-                #                                    kron3(av(n[2]), speye(n[1]), speye(n[0]))), format="csr")
+                # self._aveF2CC = (1./3.)*sp.hstack((Utils.kron3(Utils.speye(n[2]), Utils.speye(n[1]), Utils.av(n[0])),
+                #                                    Utils.kron3(Utils.speye(n[2]), Utils.av(n[1]), Utils.speye(n[0])),
+                #                                    Utils.kron3(Utils.av(n[2]), Utils.speye(n[1]), Utils.speye(n[0]))), format="csr")
         return self._aveF2CC
 
     @property
@@ -322,13 +321,112 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
         if getattr(self, '_aveF2CCV', None) is None:
             n = self.vnC
             if self.isSymmetric:
-                avR = av(n[0])[:,1:]
+                avR = Utils.av(n[0])[:,1:]
                 avR[0,0] = 1.
-                self._aveF2CCV = sp.block_diag((sp.kron(speye(n[2]), avR),
-                                                sp.kron(av(n[2]), speye(n[0]))), format="csr")
+                self._aveF2CCV = sp.block_diag((sp.kron(Utils.speye(n[2]), avR),
+                                                sp.kron(Utils.av(n[2]), Utils.speye(n[0]))), format="csr")
             else:
                 raise NotImplementedError('wrapping in the averaging is not yet implemented')
         return self._aveF2CCV
+
+
+    def _fastInnerProduct(self, projType, prop=None, invProp=False, invMat=False):
+        """
+            Fast version of getFaceInnerProduct.
+            This does not handle the case of a full tensor prop.
+
+            :param numpy.array prop: material property (tensor properties are possible) at each cell center (nC, (1, 3, or 6))
+            :param str projType: 'E' or 'F'
+            :param bool returnP: returns the projection matrices
+            :param bool invProp: inverts the material property
+            :param bool invMat: inverts the matrix
+            :rtype: scipy.sparse.csr_matrix
+            :return: M, the inner product matrix (nF, nF)
+        """
+        assert projType in ['F', 'E'], "projType must be 'F' for faces or 'E' for edges"
+
+        if prop is None:
+            prop = np.ones(self.nC)
+
+        if invProp:
+            prop = 1./prop
+
+        if Utils.isScalar(prop):
+            prop = prop*np.ones(self.nC)
+
+        if prop.size == self.nC:
+            Av = getattr(self, 'ave'+projType+'2CC')
+            Vprop = self.vol * Utils.mkvc(prop)
+            M = self.dim * Utils.sdiag(Av.T * Vprop)
+        elif prop.size == self.nC*self.dim:
+            Av = getattr(self, 'ave'+projType+'2CCV')
+            V = sp.kron(sp.identity(self.dim), Utils.sdiag(self.vol))
+            M = Utils.sdiag(Av.T * V * Utils.mkvc(prop))
+        else:
+            return None
+
+        if projType == 'E':
+                M = 0.5*M
+
+        if invMat:
+            return Utils.sdInv(M)
+        else:
+            return M
+
+    def _fastInnerProductDeriv(self, projType, prop, invProp=False, invMat=False):
+        """
+            :param str projType: 'E' or 'F'
+            :param TensorType tensorType: type of the tensor
+            :param bool invProp: inverts the material property
+            :param bool invMat: inverts the matrix
+            :rtype: function
+            :return: dMdmu, the derivative of the inner product matrix
+        """
+        assert projType in ['F', 'E'], "projType must be 'F' for faces or 'E' for edges"
+        tensorType = Utils.TensorType(self, prop)
+
+        dMdprop = None
+
+        if invMat:
+            MI = self._fastInnerProduct(projType, prop, invProp=invProp, invMat=invMat)
+
+        if tensorType == 0:
+            Av = getattr(self, 'ave'+projType+'2CC')
+            V = Utils.sdiag(self.vol)
+            ones = sp.csr_matrix((np.ones(self.nC), (range(self.nC), np.zeros(self.nC))), shape=(self.nC,1))
+            if not invMat and not invProp:
+                dMdprop = self.dim * Av.T * V * ones
+            elif invMat and invProp:
+                dMdprop =  self.dim * Utils.sdiag(MI.diagonal()**2) * Av.T * V * ones * Utils.sdiag(1./prop**2)
+
+        if tensorType == 1:
+            Av = getattr(self, 'ave'+projType+'2CC')
+            V = Utils.sdiag(self.vol)
+            if not invMat and not invProp:
+                dMdprop = self.dim * Av.T * V
+            elif invMat and invProp:
+                dMdprop =  self.dim * Utils.sdiag(MI.diagonal()**2) * Av.T * V * Utils.sdiag(1./prop**2)
+
+        if tensorType == 2: # anisotropic
+            Av = getattr(self, 'ave'+projType+'2CCV')
+            V = sp.kron(sp.identity(self.dim), Utils.sdiag(self.vol))
+            if not invMat and not invProp:
+                dMdprop = Av.T * V
+            elif invMat and invProp:
+                dMdprop =  Utils.sdiag(MI.diagonal()**2) * Av.T * V * Utils.sdiag(1./prop**2)
+
+        if projType == 'E':
+            dMdprop = 0.5*dMdprop
+
+        if dMdprop is not None:
+            def innerProductDeriv(v=None):
+                if v is None:
+                    print 'Depreciation Warning: TensorMesh.innerProductDeriv. You should be supplying a vector. Use: Utils.sdiag(u)*dMdprop'
+                    return dMdprop
+                return Utils.sdiag(v) * dMdprop
+            return innerProductDeriv
+        else:
+            return None
 
     def getInterpolationMatCartMesh(self, Mrect, locType='CC', locTypeTo=None):
         """
@@ -350,7 +448,7 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
         if locType == 'E':
             X = self.getInterpolationMatCartMesh(Mrect, locType='Ex', locTypeTo=locTypeTo+'x')
             Y = self.getInterpolationMatCartMesh(Mrect, locType='Ey', locTypeTo=locTypeTo+'y')
-            Z = spzeros(getattr(Mrect, 'n' + locTypeTo + 'z'), self.nE)
+            Z = Utils.spzeros(getattr(Mrect, 'n' + locTypeTo + 'z'), self.nE)
             return sp.vstack((X,Y,Z))
 
         grid = getattr(Mrect, 'grid' + locTypeTo)
@@ -385,7 +483,7 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
             interpType = 'Ey'
 
         Pc2r = self.getInterpolationMat(G, interpType)
-        Proj = sdiag(proj)
+        Proj = Utils.sdiag(proj)
         return Proj * Pc2r
 
 

--- a/SimPEG/Mesh/CylMesh.py
+++ b/SimPEG/Mesh/CylMesh.py
@@ -68,7 +68,7 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
         """
         Number of x-faces in each direction
 
-        :rtype: numpy.array 
+        :rtype: numpy.array
         :return: vnFx, (dim, )
         """
         return self.vnC
@@ -78,7 +78,7 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
         """
         Number of y-edges in each direction
 
-        :rtype: numpy.array 
+        :rtype: numpy.array
         :return: vnEy or None if dim < 2, (dim, )
         """
         nNx = self.nNx if self.isSymmetric else self.nNx - 1
@@ -89,7 +89,7 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
         """
         Number of z-edges in each direction
 
-        :rtype: numpy.array 
+        :rtype: numpy.array
         :return: vnEz or None if nCy > 1, (dim, )
         """
         if self.isSymmetric:
@@ -279,7 +279,7 @@ class CylMesh(BaseTensorMesh, BaseRectangularMesh, InnerProducts, CylView):
             if self.isSymmetric:
                 avR = av(n[0])[:,1:]
                 avR[0,0] = 1.
-                self._aveE2CC = (0.5)*sp.kron(av(n[2]), avR, format="csr")
+                self._aveE2CC = sp.kron(av(n[2]), avR, format="csr")
             else:
                 raise NotImplementedError('wrapping in the averaging is not yet implemented')
                 # self._aveE2CC = (1./3)*sp.hstack((kron3(av(n[2]), av(n[1]), speye(n[0])),

--- a/tests/em/fdem/forward/test_FDEM_analytics.py
+++ b/tests/em/fdem/forward/test_FDEM_analytics.py
@@ -5,6 +5,7 @@ from scipy.constants import mu_0
 
 tol_EBdipole = 1e-2
 
+plotIt = False
 if plotIt is True:
     import matplotlib.pylab as plt
 
@@ -173,7 +174,7 @@ class FDEM_analyticTests(unittest.TestCase):
         print '  bx:', np.linalg.norm(bxa), np.linalg.norm(bx), np.linalg.norm(bxa-bx), np.linalg.norm(bxa-bx)/np.linalg.norm(bxa)
         print '  bz:', np.linalg.norm(bza), np.linalg.norm(bz), np.linalg.norm(bza-bz), np.linalg.norm(bza-bz)/np.linalg.norm(bza)
 
-        if plotIt:
+        if plotIt is True:
             # Edipole
             plt.subplot(221)
             plt.plot(r,ex.real,'o',r,exa.real,linewidth=2)

--- a/tests/em/fdem/forward/test_FDEM_analytics.py
+++ b/tests/em/fdem/forward/test_FDEM_analytics.py
@@ -3,11 +3,10 @@ from SimPEG import *
 from SimPEG import EM
 from scipy.constants import mu_0
 
-plotIt = False
 tol_EBdipole = 1e-2
 
-if plotIt:
-    import matplotlib.pylab
+if plotIt is True:
+    import matplotlib.pylab as plt
 
 
 class FDEM_analyticTests(unittest.TestCase):
@@ -19,9 +18,9 @@ class FDEM_analyticTests(unittest.TestCase):
         npad = 4
         freq = 1e2
 
-        hx = [(cs,npad,-1.3), (cs,ncx), (cs,npad,1.3)]
-        hy = [(cs,npad,-1.3), (cs,ncy), (cs,npad,1.3)]
-        hz = [(cs,npad,-1.3), (cs,ncz), (cs,npad,1.3)]
+        hx = [(cs, npad, -1.3), (cs, ncx), (cs, npad, 1.3)]
+        hy = [(cs, npad, -1.3), (cs, ncy), (cs, npad, 1.3)]
+        hz = [(cs, npad, -1.3), (cs, ncz), (cs, npad, 1.3)]
         mesh = Mesh.TensorMesh([hx,hy,hz], 'CCC')
 
         mapping = Maps.ExpMap(mesh)
@@ -95,7 +94,7 @@ class FDEM_analyticTests(unittest.TestCase):
         csz, ncz, npadz = 5, 50, 25
         hx = Utils.meshTensor([(csx,ncx), (csx,npadx,1.3)])
         hz = Utils.meshTensor([(csz,npadz,-1.3), (csz,ncz), (csz,npadz,1.3)])
-        mesh = Mesh.CylMesh([hx,1,hz], [0.,0.,-hz.sum()/2]) # define the cylindrical mesh
+        mesh = Mesh.CylMesh([hx, 1, hz], [0., 0., -hz.sum()/2]) # define the cylindrical mesh
 
         if plotIt:
             mesh.plotGrid()
@@ -109,21 +108,21 @@ class FDEM_analyticTests(unittest.TestCase):
 
         # set up source
         # test electric dipole
-        src_loc = np.r_[0.,0.,0.]
-        s_ind = Utils.closestPoints(mesh,src_loc,'Fz') + mesh.nFx
+        src_loc = np.r_[0., 0., 0.]
+        s_ind = Utils.closestPoints(mesh, src_loc, 'Fz') + mesh.nFx
 
-        de = np.zeros(mesh.nF,dtype=complex)
+        de = np.zeros(mesh.nF, dtype=complex)
         de[s_ind] = 1./csz
-        de_p = [EM.FDEM.Src.RawVec_e([],freq,de/mesh.area)]
+        de_p = [EM.FDEM.Src.RawVec_e([], freq, de/mesh.area)]
 
-        dm_p = [EM.FDEM.Src.MagDipole([],freq,src_loc)]
-
+        dm_p = [EM.FDEM.Src.MagDipole([], freq, src_loc)]
 
         # Pair the problem and survey
         surveye = EM.FDEM.Survey(de_p)
         surveym = EM.FDEM.Survey(dm_p)
 
-        mapping = [('sigma', Maps.IdentityMap(mesh)),('mu', Maps.IdentityMap(mesh))]
+        mapping = [('sigma', Maps.IdentityMap(mesh)),
+                   ('mu', Maps.IdentityMap(mesh))]
 
         prbe = EM.FDEM.Problem3D_h(mesh, mapping=mapping)
         prbm = EM.FDEM.Problem3D_e(mesh, mapping=mapping)
@@ -136,9 +135,9 @@ class FDEM_analyticTests(unittest.TestCase):
         fieldsBackM = prbm.fields(np.r_[SigmaBack, MuBack]) # Done
 
 
-        rlim = [20.,500.]
+        rlim = [20., 500.]
         lookAtTx = de_p
-        r = mesh.vectorCCx[np.argmin(np.abs(mesh.vectorCCx-rlim[0])):np.argmin(np.abs(mesh.vectorCCx-rlim[1]))]
+        r = mesh.vectorCCx[np.argmin(np.abs(mesh.vectorCCx-rlim[0])) : np.argmin(np.abs(mesh.vectorCCx-rlim[1]))]
         z = 100.
 
         # where we choose to measure
@@ -157,15 +156,15 @@ class FDEM_analyticTests(unittest.TestCase):
         en = Rho*mesh.aveF2CCV*jn
         bn = mesh.aveF2CCV*bn
 
-        ex,ez = Pfx*en, Pfz*en
-        bx,bz = Pfx*bn, Pfz*bn
+        ex, ez = Pfx*en, Pfz*en
+        bx, bz = Pfx*bn, Pfz*bn
 
         # get analytic solution
         exa, eya, eza = EM.Analytics.FDEM.ElectricDipoleWholeSpace(XYZ, src_loc, sigmaback, freq,orientation='Z',mu= mur*mu_0)
-        exa, eya, eza = Utils.mkvc(exa,2), Utils.mkvc(eya,2), Utils.mkvc(eza,2)
+        exa, eya, eza = Utils.mkvc(exa, 2), Utils.mkvc(eya, 2), Utils.mkvc(eza, 2)
 
         bxa, bya, bza = EM.Analytics.FDEM.MagneticDipoleWholeSpace(XYZ, src_loc, sigmaback, freq,orientation='Z',mu= mur*mu_0)
-        bxa, bya, bza = Utils.mkvc(bxa,2), Utils.mkvc(bya,2), Utils.mkvc(bza,2)
+        bxa, bya, bza = Utils.mkvc(bxa, 2), Utils.mkvc(bya, 2), Utils.mkvc(bza, 2)
 
         print ' comp,       anayltic,       numeric,       num - ana,       (num - ana)/ana'
         print '  ex:', np.linalg.norm(exa), np.linalg.norm(ex), np.linalg.norm(exa-ex), np.linalg.norm(exa-ex)/np.linalg.norm(exa)

--- a/tests/em/fdem/forward/test_FDEM_casing.py
+++ b/tests/em/fdem/forward/test_FDEM_casing.py
@@ -22,7 +22,7 @@ def CasingMagDipoleDeriv_r(x):
     f = Casing._getCasingHertzMagDipole(srcloc,obsloc,freq,sigma,a,b,mu)
     g = Utils.sdiag(Casing._getCasingHertzMagDipoleDeriv_r(srcloc,obsloc,freq,sigma,a,b,mu))
 
-    return  f,g
+    return  f, g
 
 def CasingMagDipoleDeriv_z(z):
     obsloc = np.vstack([xobs, yobs, z]).T
@@ -30,7 +30,7 @@ def CasingMagDipoleDeriv_z(z):
     f = Casing._getCasingHertzMagDipole(srcloc,obsloc,freq,sigma,a,b,mu)
     g = Utils.sdiag(Casing._getCasingHertzMagDipoleDeriv_z(srcloc,obsloc,freq,sigma,a,b,mu))
 
-    return  f,g
+    return  f, g
 
 def CasingMagDipole2Deriv_z_r(x):
     obsloc = np.vstack([x, yobs, zobs]).T
@@ -38,7 +38,7 @@ def CasingMagDipole2Deriv_z_r(x):
     f = Casing._getCasingHertzMagDipoleDeriv_z(srcloc,obsloc,freq,sigma,a,b,mu)
     g = Utils.sdiag(Casing._getCasingHertzMagDipole2Deriv_z_r(srcloc,obsloc,freq,sigma,a,b,mu))
 
-    return f,g
+    return f, g
 
 def CasingMagDipole2Deriv_z_z(z):
     obsloc = np.vstack([xobs, yobs, z]).T
@@ -46,7 +46,7 @@ def CasingMagDipole2Deriv_z_z(z):
     f = Casing._getCasingHertzMagDipoleDeriv_z(srcloc,obsloc,freq,sigma,a,b,mu)
     g = Utils.sdiag(Casing._getCasingHertzMagDipole2Deriv_z_z(srcloc,obsloc,freq,sigma,a,b,mu))
 
-    return f,g
+    return f, g
 
 
 

--- a/tests/em/tdem/test_TDEM_forward_Analytic.py
+++ b/tests/em/tdem/test_TDEM_forward_Analytic.py
@@ -11,25 +11,29 @@ except ImportError, e:
 
 
 def halfSpaceProblemAnaDiff(meshType, sig_half=1e-2, rxOffset=50., bounds=None, showIt=False):
+
+    print '\nTesting sig_half = {0}, rxOffset= {1}'.format(sig_half, rxOffset)
+
     if bounds is None:
-        bounds = [1e-5,1e-3]
+        bounds = [1e-5, 1e-3]
     if meshType == 'CYL':
-        cs, ncx, ncz, npad = 5., 30, 10, 15
-        hx = [(cs,ncx), (cs,npad,1.3)]
-        hz = [(cs,npad,-1.3), (cs,ncz), (cs,npad,1.3)]
-        mesh = Mesh.CylMesh([hx,1,hz], '00C')
+        cs, ncx, ncz, npad = 5., 30, 10, 20
+        hx = [(cs, ncx), (cs, npad, 1.3)]
+        hz = [(cs, npad, -1.3), (cs, ncz), (cs, npad, 1.3)]
+        mesh = Mesh.CylMesh([hx, 1, hz], '00C')
     elif meshType == 'TENSOR':
         cs, nc, npad = 20., 13, 5
-        hx = [(cs,npad,-1.3), (cs,nc), (cs,npad,1.3)]
-        hy = [(cs,npad,-1.3), (cs,nc), (cs,npad,1.3)]
-        hz = [(cs,npad,-1.3), (cs,nc), (cs,npad,1.3)]
-        mesh = Mesh.TensorMesh([hx,hy,hz], 'CCC')
+        hx = [(cs, npad, -1.3), (cs, nc), (cs, npad, 1.3)]
+        hy = [(cs, npad, -1.3), (cs, nc), (cs, npad, 1.3)]
+        hz = [(cs, npad, -1.3), (cs, nc), (cs, npad, 1.3)]
+        mesh = Mesh.TensorMesh([hx, hy, hz], 'CCC')
 
-    active = mesh.vectorCCz<0.
+    active = mesh.vectorCCz < 0.
     actMap = Maps.InjectActiveCells(mesh, active, np.log(1e-8), nC=mesh.nCz)
     mapping = Maps.ExpMap(mesh) * Maps.SurjectVertical1D(mesh) * actMap
 
-    rx = EM.TDEM.RxTDEM(np.array([[rxOffset, 0., 0.]]), np.logspace(-5,-4, 21), 'bz')
+    rx = EM.TDEM.RxTDEM(np.array([[rxOffset, 0., 0.]]),
+                        np.logspace(-5, -4, 21), 'bz')
     src = EM.TDEM.SrcTDEM_VMD_MVP([rx], loc=np.array([0., 0., 0.]))
     # src = EM.TDEM.SrcTDEM([rx], loc=np.array([0., 0., 0.]))
 
@@ -48,7 +52,7 @@ def halfSpaceProblemAnaDiff(meshType, sig_half=1e-2, rxOffset=50., bounds=None, 
 
     bz_calc = survey.dpred(sigma)
 
-    ind = np.logical_and(rx.times > bounds[0],rx.times < bounds[1])
+    ind = np.logical_and(rx.times > bounds[0], rx.times < bounds[1])
     log10diff = np.linalg.norm(np.log10(np.abs(bz_calc[ind])) - np.log10(np.abs(bz_ana[ind])))/np.linalg.norm(np.log10(np.abs(bz_ana[ind])))
     print 'Difference: ', log10diff
 
@@ -62,6 +66,9 @@ def halfSpaceProblemAnaDiff(meshType, sig_half=1e-2, rxOffset=50., bounds=None, 
 
 
 class TDEM_bTests(unittest.TestCase):
+
+    def test_analytic_p2_TENSOR_50m(self):
+        self.assertTrue(halfSpaceProblemAnaDiff('TENSOR', rxOffset=50., sig_half=1e+2) < 0.01)
 
     def test_analytic_p2_CYL_50m(self):
         self.assertTrue(halfSpaceProblemAnaDiff('CYL', rxOffset=50., sig_half=1e+2) < 0.01)

--- a/tests/em/tdem/test_TDEM_forward_Analytic.py
+++ b/tests/em/tdem/test_TDEM_forward_Analytic.py
@@ -67,8 +67,8 @@ def halfSpaceProblemAnaDiff(meshType, sig_half=1e-2, rxOffset=50., bounds=None, 
 
 class TDEM_bTests(unittest.TestCase):
 
-    def test_analytic_p2_TENSOR_50m(self):
-        self.assertTrue(halfSpaceProblemAnaDiff('TENSOR', rxOffset=50., sig_half=1e+2) < 0.01)
+    # def test_analytic_p2_TENSOR_50m(self):
+    #     self.assertTrue(halfSpaceProblemAnaDiff('TENSOR', rxOffset=50., sig_half=1e+2) < 0.01)
 
     def test_analytic_p2_CYL_50m(self):
         self.assertTrue(halfSpaceProblemAnaDiff('CYL', rxOffset=50., sig_half=1e+2) < 0.01)

--- a/tests/mesh/test_cylMesh.py
+++ b/tests/mesh/test_cylMesh.py
@@ -356,6 +356,116 @@ class TestEdgeCurl2D(Tests.OrderTest):
         self.orderTest()
 
 
+class TestAveragingSimple(unittest.TestCase):
+
+    def setUp(self):
+        hx = np.random.rand(10.)
+        hz = np.random.rand(10.)
+        self.mesh = Mesh.CylMesh([hx, 1,hz])
+
+    def test_constantEdges(self):
+        edge_vec = np.ones(self.mesh.nE)
+        assert all(self.mesh.aveE2CC * edge_vec == 1.)
+        assert all(self.mesh.aveE2CCV * edge_vec == 1.)
+
+    def test_constantFaces(self):
+        face_vec = np.ones(self.mesh.nF)
+        assert all(self.mesh.aveF2CC * face_vec == 1.)
+        assert all(self.mesh.aveF2CCV * face_vec == 1.)
+
+
+class TestAveE2CC(Tests.OrderTest):
+    name = "aveE2CC"
+    meshTypes = MESHTYPES
+    meshDimension = 2
+
+    def getError(self):
+
+        fun = lambda r, t, z: np.sin(2.*np.pi*z) * np.cos(np.pi*r)
+
+        E = call3(fun, self.M.gridEy)
+
+        aveE = self.M.aveE2CC * E
+        aveE_ana = call3(fun, self.M.gridCC)
+
+        err = np.linalg.norm((aveE-aveE_ana), np.inf)
+        return err
+
+    def test_order(self):
+        self.orderTest()
+
+
+class TestAveE2CCV(Tests.OrderTest):
+    name = "aveE2CCV"
+    meshTypes = MESHTYPES
+    meshDimension = 2
+
+    def getError(self):
+
+        fun = lambda r, t, z: np.sin(2.*np.pi*z) * np.cos(np.pi*r)
+
+        E = call3(fun, self.M.gridEy)
+
+        aveE = self.M.aveE2CCV * E
+        aveE_ana = call3(fun, self.M.gridCC)
+
+        err = np.linalg.norm((aveE-aveE_ana), np.inf)
+        return err
+
+    def test_order(self):
+        self.orderTest()
+
+
+class TestAveF2CCV(Tests.OrderTest):
+    name = "aveF2CCV"
+    meshTypes = MESHTYPES
+    meshDimension = 2
+
+    def getError(self):
+
+        funR = lambda r, z: np.sin(2.*np.pi*z) * np.cos(np.pi*r)
+        funZ = lambda r, z: np.sin(3.*np.pi*z) * np.cos(2.*np.pi*r)
+
+        Fc = cylF2(self.M, funR, funZ)
+        Fc = np.c_[Fc[:,0],np.zeros(self.M.nF), Fc[:,1]]
+        F = self.M.projectFaceVector(Fc)
+
+        aveF = self.M.aveF2CCV * F
+
+        aveF_anaR = funR(self.M.gridCC[:,0], self.M.gridCC[:,2])
+        aveF_anaZ = funZ(self.M.gridCC[:,0], self.M.gridCC[:,2])
+
+        aveF_ana = np.hstack([aveF_anaR, aveF_anaZ])
+
+        err = np.linalg.norm((aveF-aveF_ana), np.inf)
+        return err
+
+    def test_order(self):
+        self.orderTest()
+
+
+class TestAveF2CC(Tests.OrderTest):
+    name = "aveF2CC"
+    meshTypes = MESHTYPES
+    meshDimension = 2
+
+    def getError(self):
+
+        fun = lambda r, z: np.sin(2.*np.pi*z) * np.cos(np.pi*r)
+
+        Fc = cylF2(self.M, fun, fun)
+        Fc = np.c_[Fc[:,0],np.zeros(self.M.nF), Fc[:,1]]
+        F = self.M.projectFaceVector(Fc)
+
+        aveF = self.M.aveF2CC * F
+        aveF_ana = fun(self.M.gridCC[:,0], self.M.gridCC[:,2])
+
+        err = np.linalg.norm((aveF-aveF_ana), np.inf)
+        return err
+
+    def test_order(self):
+        self.orderTest()
+
 # class TestInnerProducts2D(Tests.OrderTest):
 #     """Integrate an function over a unit cube domain using edgeInnerProducts and faceInnerProducts."""
 

--- a/tests/mesh/test_operators.py
+++ b/tests/mesh/test_operators.py
@@ -2,6 +2,10 @@ import numpy as np
 import unittest
 from SimPEG.Tests import OrderTest
 import matplotlib.pyplot as plt
+from SimPEG import Mesh
+
+# Tolerance
+TOL = 1e-14
 
 #TODO: 'randomTensorMesh'
 MESHTYPES = ['uniformTensorMesh', 'uniformCurv', 'rotateCurv']
@@ -318,6 +322,24 @@ class TestNodalGrad2D(OrderTest):
     def test_order(self):
         self.orderTest()
 
+
+class TestAverating2DSimple(unittest.TestCase):
+    def setUp(self):
+        hx = np.random.rand(10.)
+        hy = np.random.rand(10.)
+        self.mesh = Mesh.TensorMesh([hx, hy])
+
+    def test_constantEdges(self):
+        edge_vec = np.ones(self.mesh.nE)
+        assert all(self.mesh.aveE2CC * edge_vec == 1.)
+        assert all(self.mesh.aveE2CCV * edge_vec == 1.)
+
+    def test_constantFaces(self):
+        face_vec = np.ones(self.mesh.nF)
+        assert all(self.mesh.aveF2CC * face_vec == 1.)
+        assert all(self.mesh.aveF2CCV * face_vec == 1.)
+
+
 class TestAveraging2D(OrderTest):
     name = "Averaging 2D"
     meshTypes = MESHTYPES
@@ -395,6 +417,23 @@ class TestAveraging2D(OrderTest):
         self.getThere = lambda M: np.r_[call2(funX, M.gridCC), call2(funY, M.gridCC)]
         self.getAve = lambda M: M.aveE2CCV
         self.orderTest()
+
+class TestAverating3DSimple(unittest.TestCase):
+    def setUp(self):
+        hx = np.random.rand(10.)
+        hy = np.random.rand(10.)
+        hz = np.random.rand(10.)
+        self.mesh = Mesh.TensorMesh([hx, hy, hz])
+
+    def test_constantEdges(self):
+        edge_vec = np.ones(self.mesh.nE)
+        assert all(np.absolute(self.mesh.aveE2CC * edge_vec - 1.) < TOL)
+        assert all(np.absolute(self.mesh.aveE2CCV * edge_vec - 1.) < TOL)
+
+    def test_constantFaces(self):
+        face_vec = np.ones(self.mesh.nF)
+        assert all(np.absolute(self.mesh.aveF2CC * face_vec - 1.) < TOL)
+        assert all(np.absolute(self.mesh.aveF2CCV * face_vec - 1.) < TOL)
 
 
 class TestAveraging3D(OrderTest):


### PR DESCRIPTION
- bug fix in `aveE2CC` and `aveE2CCV` that was dividing everything by 2 to close #367 
- testing on `aveE2CC`, `aveE2CCV`, `aveF2CC`, `aveF2CCV`

@micmitch : can you take a look at this? If you have any questions / anything is unclear, please let me know! 