### PR TITLE
Map Docs

### DIFF
--- a/SimPEG/Maps.py
+++ b/SimPEG/Maps.py
@@ -833,7 +833,7 @@ class ParametricCircleMap(IdentityMap):
 
         Parameterize the model space using a circle in a wholespace.
 
-        ..math::
+        .. math::
 
             \sigma(m) = \sigma_1 + (\sigma_2 - \sigma_1)\left(
             \\arctan\left(100*\sqrt{(\\vec{x}-x_0)^2 + (\\vec{y}-y_0)}-r
@@ -841,7 +841,7 @@ class ParametricCircleMap(IdentityMap):
 
         Define the model as:
 
-        ..math::
+        .. math::
 
             m = [\sigma_1, \sigma_2, x_0, y_0, r]
 
@@ -925,13 +925,13 @@ class ParametricPolyMap(IdentityMap):
 
         Parameterize the model space using a polynomials in a wholespace.
 
-        ..math::
+        .. math::
 
             y = \mathbf{V} c
 
         Define the model as:
 
-        ..math::
+        .. math::
 
             m = [\sigma_1, \sigma_2, c]
 
@@ -1071,13 +1071,13 @@ class ParametricSplineMap(IdentityMap):
         Parameterize the boundary of two geological units using
         a spline interpolation
 
-        ..math::
+        .. math::
 
             g = f(x)-y
 
         Define the model as:
 
-        ..math::
+        .. math::
 
             m = [\sigma_1, \sigma_2, y]
 

--- a/docs/content/api_core/api_Maps.rst
+++ b/docs/content/api_core/api_Maps.rst
@@ -1,8 +1,8 @@
 .. _api_Maps:
 
 
-SimPEG Maps
-***********
+Maps
+****
 
 That's not a map...?!
 =====================
@@ -103,15 +103,6 @@ When these are used in the inverse problem, this is extremely important!!
     expMap.test(m, plotIt=True)
 
 
-The API
-=======
-
-The :code:`IdentityMap` is the base class for all mappings, and it does absolutely nothing.
-
-.. autoclass:: SimPEG.Maps.IdentityMap
-    :members:
-    :undoc-members:
-
 
 Common Maps
 ===========
@@ -172,6 +163,17 @@ Remember, any time that you make your own combination of mappings
 be sure to test that the derivative is correct.
 
 .. autoclass:: SimPEG.Maps.ComboMap
+    :members:
+    :undoc-members:
+
+
+The API
+=======
+
+The :code:`IdentityMap` is the base class for all mappings, and it does absolutely nothing.
+
+.. automodule:: SimPEG.Maps
+    :show-inheritance:
     :members:
     :undoc-members:
 

--- a/docs/content/api_core/api_Utilities.rst
+++ b/docs/content/api_core/api_Utilities.rst
@@ -5,7 +5,6 @@ Utilities
    :maxdepth: 2
 
    api_Solver
-   api_Maps
    api_Props
    api_Utils
    api_Tests

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,14 @@ Inversion Components
 
    content/api_core/api_InversionComponents
 
+Maps
+****
+
+.. toctree::
+   :maxdepth: 3
+
+   content/api_core/api_Maps
+
 Utility Codes
 *************
 


### PR DESCRIPTION
- build all api docs for maps, 
- bring maps to top level of docs
- light cleanup of math formatting. sphinx needs `.. math::` not `..math::` (the space matters, cc @sgkang) 

closes #476 

![image](https://cloud.githubusercontent.com/assets/6361812/19693357/0ec76bb0-9a90-11e6-9beb-99f87bebdd20.png)
