### PR TITLE
Ref/maps

### DIFF
--- a/SimPEG/Maps.py
+++ b/SimPEG/Maps.py
@@ -361,7 +361,7 @@ class Wires(object):
 
 ###############################################################################
 #                                                                             #
-#                    Mesh Independent Maps                                    #
+#                          Mesh Independent Maps                              #
 #                                                                             #
 ###############################################################################
 
@@ -499,6 +499,7 @@ class LogMap(IdentityMap):
     def inverse(self, m):
         return np.exp(Utils.mkvc(m))
 
+
 class Weighting(IdentityMap):
     """
         Model weight parameters.
@@ -579,7 +580,7 @@ class ComplexMap(IdentityMap):
 
 ###############################################################################
 #                                                                             #
-#            Surjection, Injection and Interpolation Maps                     #
+#                 Surjection, Injection and Interpolation Maps                #
 #                                                                             #
 ###############################################################################
 
@@ -841,7 +842,7 @@ class InjectActiveCells(IdentityMap):
 
 ###############################################################################
 #                                                                             #
-#                         Parametric Maps                                     #
+#                             Parametric Maps                                 #
 #                                                                             #
 ###############################################################################
 

--- a/SimPEG/Maps.py
+++ b/SimPEG/Maps.py
@@ -519,22 +519,24 @@ class Weighting(IdentityMap):
             weights = np.ones(self.nP)
 
         self.weights = np.array(weights, dtype=float)
-        self.P = Utils.sdiag(self.weights)
 
     @property
     def shape(self):
         return (self.nP, self.nP)
 
+    @property
+    def P(self):
+        return Utils.sdiag(self.weights)
+
     def _transform(self, m):
-        return self.P*m
+        return self.weights*m
 
     def inverse(self, D):
-        Pinv = Utils.sdiag(self.weights**(-1.))
-        return Pinv*D
+        return self.weights**(-1.) * D
 
     def deriv(self, m, v=None):
         if v is not None:
-            return self.P * v
+            return self.weights * v
         return self.P
 
 
@@ -545,7 +547,7 @@ class ComplexMap(IdentityMap):
 
     """
     def __init__(self, mesh=None, nP=None, **kwargs):
-        super(Weighting, self).__init__(mesh=mesh, nP=nP, **kwargs)
+        super(ComplexMap, self).__init__(mesh=mesh, nP=nP, **kwargs)
         if nP is not None:
             assert nP % 2 == 0, 'nP must be even.'
         self._nP = nP or (self.mesh.nC * 2)


### PR DESCRIPTION
- add comment to break up Maps.py file into 
    - Meshless Maps (eg. `ExpMap`, `LogMap`...) that do not require a mesh
    - Surjection, Injection and Interpolation Maps
    - Parametric Maps
- cleaned up init'ing so that meshless maps do not require a mesh. 
- moved the location of the `Weighting` map and `ComplexMap` so that they are under the Meshless Map header 
