### PR TITLE
Only clear the maps and props if the change is not undefined.

### DIFF
--- a/SimPEG/Props.py
+++ b/SimPEG/Props.py
@@ -71,7 +71,8 @@ class Mapping(properties.Property):
             if value is not properties.utils.undefined:
                 value = scope.validate(self, value)
             self._set(scope.name, value)
-            scope.clear_props(self)
+            if value is not properties.utils.undefined:
+                scope.clear_props(self)
 
         def fdel(self):
             self._set(scope.name, properties.utils.undefined)
@@ -165,7 +166,8 @@ class PhysicalProperty(properties.Property):
                 if scope.reciprocal:
                     delattr(self, scope.reciprocal.name)
             self._set(scope.name, value)
-            scope.clear_mappings(self)
+            if value is not properties.utils.undefined:
+                scope.clear_mappings(self)
 
         def fdel(self):
             self._set(scope.name, properties.utils.undefined)

--- a/tests/base/test_Props.py
+++ b/tests/base/test_Props.py
@@ -84,7 +84,7 @@ class ReciprocalPropExampleDefaults(HasModel):
 
     sigma = Props.PhysicalProperty(
         "Electrical conductivity (S/m)",
-        default = np.r_[1., 2., 3.]
+        default=np.r_[1., 2., 3.]
     )
 
     rho = Props.PhysicalProperty(
@@ -92,6 +92,24 @@ class ReciprocalPropExampleDefaults(HasModel):
     )
 
     Props.Reciprocal(sigma, rho)
+
+
+class ComplicatedInversion(HasModel):
+
+    Ks, KsMap, KsDeriv = Props.Invertible(
+        "Saturated hydraulic conductivity",
+        default=24.96
+    )
+
+    A, AMap, ADeriv = Props.Invertible(
+        "fitting parameter",
+        default=1.175e+06
+    )
+
+    gamma, gammaMap, gammaDeriv = Props.Invertible(
+        "fitting parameter",
+        default=4.74
+    )
 
 
 class TestPropMaps(unittest.TestCase):
@@ -206,12 +224,22 @@ class TestPropMaps(unittest.TestCase):
 
         PM = ReciprocalPropExampleDefaults()
         assert np.all(PM.sigma == np.r_[1., 2., 3.])
-        assert np.all(PM.rho == 1.0/ np.r_[1., 2., 3.])
+        assert np.all(PM.rho == 1.0 / np.r_[1., 2., 3.])
 
         rho = np.r_[2., 4., 6.]
         PM.rho = rho
         assert np.all(PM.rho == rho)
         assert np.all(PM.sigma == 1./rho)
+
+    def test_multi_parameter_inversion(self):
+        """The setup of the defaults should not invalidated the
+        mappings or other defaults.
+        """
+        PM = ComplicatedInversion()
+
+        assert PM.Ks == PM._props['Ks'].default
+        assert PM.gamma == PM._props['gamma'].default
+        assert PM.A == PM._props['A'].default
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Because the properties are setup on class `__new__`, the change
notification was firing and deleting some defaults leading to
unexpected (and difficult to track down) behavior.