### PR TITLE
Feat/plot with mirroring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - 3.4
+  - 3.5
   # - 2.7
 
 sudo: false

--- a/SimPEG/Examples/Mesh_Plot_Cyl.py
+++ b/SimPEG/Examples/Mesh_Plot_Cyl.py
@@ -30,7 +30,7 @@ def run(plotIt=True):
     h = Utils.meshTensor([(cs, nc)])
 
     # define a mesh
-    mesh = Mesh.CylMesh([h, 1, h], x0 = np.r_[0., 0., -h.sum()/2.])
+    mesh = Mesh.CylMesh([h, 1, h], x0='00C')
 
     # Put the model on the mesh
     sigma = sig_air*np.ones(mesh.nC)  # start with air cells

--- a/SimPEG/Examples/Mesh_Plot_Cyl.py
+++ b/SimPEG/Examples/Mesh_Plot_Cyl.py
@@ -1,0 +1,66 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from SimPEG import Mesh, Utils, Maps
+
+# Set a nice colormap!
+plt.set_cmap(plt.get_cmap('viridis'))
+
+
+def run(plotIt=True):
+    """
+        Plot Mirrored Cylindrically Symmetric Model
+        ===========================================
+
+        Here, we demonstrate plotting a model on a cylindrically
+        symmetric mesh with the plotting symmetric about x=0.
+    """
+
+    sig_halfspace = 1e-6
+    sig_sphere = 1e0
+    sig_air = 1e-8
+
+    sphere_z = -50.
+    sphere_radius = 30.
+
+    # x-direction
+    cs = 1
+    nc = np.ceil(2.5*(- (sphere_z-sphere_radius))/cs)
+
+    # cell spacings in the x and z directions
+    h = Utils.meshTensor([(cs, nc)])
+
+    # define a mesh
+    mesh = Mesh.CylMesh([h, 1, h], x0 = np.r_[0., 0., -h.sum()/2.])
+
+    # Put the model on the mesh
+    sigma = sig_air*np.ones(mesh.nC)  # start with air cells
+    sigma[mesh.gridCC[:, 2] < 0.] = sig_halfspace  # cells below the earth
+
+    # indices of the sphere
+    sphere_ind = (
+        (mesh.gridCC[:, 0]**2 + (mesh.gridCC[:, 2] - sphere_z)**2) <=
+        sphere_radius**2
+    )
+    sigma[sphere_ind] = sig_sphere  # sphere
+
+    # Plot a cross section through the mesh
+    fig, ax = plt.subplots(2, 1)
+    plt.colorbar(mesh.plotImage(np.log10(sigma), ax=ax[0])[0], ax=ax[0])
+    ax[0].set_title('mirror = False')
+    ax[0].axis('equal')
+    ax[0].set_xlim([-200., 200.])
+
+    plt.colorbar(
+        mesh.plotImage(np.log10(sigma), ax=ax[1], mirror=True)[0], ax=ax[1]
+    )
+    ax[1].set_title('mirror = True')
+    ax[1].axis('equal')
+    ax[1].set_xlim([-200., 200.])
+
+    plt.tight_layout()
+
+if __name__ == '__main__':
+    run()
+    plt.show()
+
+

--- a/SimPEG/Examples/__init__.py
+++ b/SimPEG/Examples/__init__.py
@@ -24,6 +24,7 @@ from SimPEG.Examples import Mesh_Basic_ForwardDC
 from SimPEG.Examples import Mesh_Basic_PlotImage
 from SimPEG.Examples import Mesh_Basic_Types
 from SimPEG.Examples import Mesh_Operators_CahnHilliard
+from SimPEG.Examples import Mesh_Plot_Cyl
 from SimPEG.Examples import Mesh_QuadTree_Creation
 from SimPEG.Examples import Mesh_QuadTree_FaceDiv
 from SimPEG.Examples import Mesh_QuadTree_HangingNodes
@@ -35,7 +36,7 @@ from SimPEG.Examples import PF_Magnetics_Inversion_Linear
 from SimPEG.Examples import Utils_plot2Ddata
 from SimPEG.Examples import Utils_surface2ind_topo
 
-__examples__ = ["DC_Analytic_Dipole", "DC_Forward_PseudoSection", "EM_FDEM_1D_Inversion", "EM_FDEM_Analytic_MagDipoleWholespace", "EM_Heagyetal2016_Casing", "EM_Heagyetal2016_CylInversions", "EM_NSEM_1D_ForwardAndInversion", "EM_NSEM_3D_Foward", "EM_Schenkel_Morrison_Casing", "EM_TDEM_1D_Inversion", "EM_TDEM_1D_Inversion_RawWaveform", "FLOW_Richards_1D_Celia1990", "Inversion_Linear", "Inversion_Linear_IRLS", "Maps_ComboMaps", "Maps_Mesh2Mesh", "Maps_ParametrizedBlockInLayer", "Maps_ParametrizedLayer", "Mesh_Basic_ForwardDC", "Mesh_Basic_PlotImage", "Mesh_Basic_Types", "Mesh_Operators_CahnHilliard", "Mesh_QuadTree_Creation", "Mesh_QuadTree_FaceDiv", "Mesh_QuadTree_HangingNodes", "Mesh_Tensor_Creation", "PF_Gravity_Inversion_Linear", "PF_Gravity_Laguna_del_Maule_Inversion", "PF_Magnetics_Analytics", "PF_Magnetics_Inversion_Linear", "Utils_plot2Ddata", "Utils_surface2ind_topo"]
+__examples__ = ["DC_Analytic_Dipole", "DC_Forward_PseudoSection", "EM_FDEM_1D_Inversion", "EM_FDEM_Analytic_MagDipoleWholespace", "EM_Heagyetal2016_Casing", "EM_Heagyetal2016_CylInversions", "EM_NSEM_1D_ForwardAndInversion", "EM_NSEM_3D_Foward", "EM_Schenkel_Morrison_Casing", "EM_TDEM_1D_Inversion", "EM_TDEM_1D_Inversion_RawWaveform", "FLOW_Richards_1D_Celia1990", "Inversion_Linear", "Inversion_Linear_IRLS", "Maps_ComboMaps", "Maps_Mesh2Mesh", "Maps_ParametrizedBlockInLayer", "Maps_ParametrizedLayer", "Mesh_Basic_ForwardDC", "Mesh_Basic_PlotImage", "Mesh_Basic_Types", "Mesh_Operators_CahnHilliard", "Mesh_Plot_Cyl", "Mesh_QuadTree_Creation", "Mesh_QuadTree_FaceDiv", "Mesh_QuadTree_HangingNodes", "Mesh_Tensor_Creation", "PF_Gravity_Inversion_Linear", "PF_Gravity_Laguna_del_Maule_Inversion", "PF_Magnetics_Analytics", "PF_Magnetics_Inversion_Linear", "Utils_plot2Ddata", "Utils_surface2ind_topo"]
 
 ##### AUTOIMPORTS #####
 

--- a/SimPEG/Mesh/View.py
+++ b/SimPEG/Mesh/View.py
@@ -514,11 +514,6 @@ class CylView(object):
         # Just create a TM and use its view.
         from SimPEG.Mesh import TensorMesh
 
-        # if mirroring about the x-axis
-
-        # v, vType='CC',
-        #           normal='Z', ind=None, grid=False, view='real',
-
         mirror = kwargs.pop('mirror', None)
         if mirror is True:
             if kwargs.get('vType', None) is not None:
@@ -535,11 +530,6 @@ class CylView(object):
 
             # mirror the data
             if len(args) > 0:
-                # if len(args) > 1:
-                #     raise NotImplementedError(
-                #         'More than one input argument is not supported when '
-                #         'mirroring'
-                #     )
                 tmp = args[0].reshape(self.vnC[0], self.vnC[2], order='F')
                 tmp = mkvc(np.vstack([np.flipud(tmp), tmp]))
                 args = (tmp,) + args[1:]

--- a/SimPEG/Mesh/View.py
+++ b/SimPEG/Mesh/View.py
@@ -513,7 +513,38 @@ class CylView(object):
         # Hackity Hack:
         # Just create a TM and use its view.
         from SimPEG.Mesh import TensorMesh
-        M = TensorMesh([self.hx, self.hz], x0=[self.x0[0], self.x0[2]])
+
+        # if mirroring about the x-axis
+
+        # v, vType='CC',
+        #           normal='Z', ind=None, grid=False, view='real',
+
+        mirror = kwargs.pop('mirror', None)
+        if mirror is True:
+            if kwargs.get('vType', None) is not None:
+                if kwargs.get('vType', None) != 'CC':
+                    raise NotImplementedError(
+                        'Mirroring has not yet been implemented for non-cell '
+                        'centered values'
+                    )
+
+            # create a mirrored mesh
+            hx = np.hstack([np.flipud(self.hx), self.hx])
+            x00 = self.x0[0] - self.hx.sum()
+            M = TensorMesh([hx, self.hz], x0=[x00, self.x0[2]])
+
+            # mirror the data
+            if len(args) > 0:
+                # if len(args) > 1:
+                #     raise NotImplementedError(
+                #         'More than one input argument is not supported when '
+                #         'mirroring'
+                #     )
+                tmp = args[0].reshape(self.vnC[0], self.vnC[2], order='F')
+                tmp = mkvc(np.vstack([np.flipud(tmp), tmp]))
+                args = (tmp,) + args[1:]
+        else:
+            M = TensorMesh([self.hx, self.hz], x0=[self.x0[0], self.x0[2]])
 
         ax = kwargs.get('ax', None)
         if ax is None:
@@ -533,7 +564,8 @@ class CylView(object):
         ax.set_xlabel('x')
         ax.set_ylabel('z')
 
-        if showIt: plt.show()
+        if showIt:
+            plt.show()
 
         return out
 

--- a/docs/content/examples/Mesh_Plot_Cyl.rst
+++ b/docs/content/examples/Mesh_Plot_Cyl.rst
@@ -1,0 +1,26 @@
+.. _examples_Mesh_Plot_Cyl:
+
+.. --------------------------------- ..
+..                                   ..
+..    THIS FILE IS AUTO GENEREATED   ..
+..                                   ..
+..    SimPEG/Examples/__init__.py    ..
+..                                   ..
+.. --------------------------------- ..
+
+
+Plot Mirrored Cylindrically Symmetric Model
+===========================================
+
+Here, we demonstrate plotting a model on a cylindrically
+symmetric mesh with the plotting symmetric about x=0.
+
+
+.. plot::
+
+    from SimPEG import Examples
+    Examples.Mesh_Plot_Cyl.run()
+
+.. literalinclude:: ../../../SimPEG/Examples/Mesh_Plot_Cyl.py
+    :language: python
+    :linenos:

--- a/tests/em/fdem/forward/test_FDEM_HeagyetalCasing.py
+++ b/tests/em/fdem/forward/test_FDEM_HeagyetalCasing.py
@@ -1,3 +1,6 @@
+import matplotlib
+matplotlib.use('Agg')
+
 from SimPEG.Examples import EM_Heagyetal2016_Casing as CasingExample
 import unittest
 import numpy as np

--- a/tests/em/fdem/forward/test_FDEM_analytics.py
+++ b/tests/em/fdem/forward/test_FDEM_analytics.py
@@ -8,16 +8,14 @@ from SimPEG import SolverLU
 from SimPEG import EM
 from scipy.constants import mu_0
 
-plotIt = False
-tol_Transect = 2e-1
-tol_EBdipole = 1e-2
-
-plotIt = False
-
 import matplotlib
 matplotlib.use('Agg')
 
 import matplotlib.pylab as plt
+
+plotIt = False
+tol_Transect = 2e-1
+tol_EBdipole = 1e-2
 
 
 class FDEM_analyticTests(unittest.TestCase):

--- a/tests/em/fdem/forward/test_FDEM_analytics.py
+++ b/tests/em/fdem/forward/test_FDEM_analytics.py
@@ -13,6 +13,7 @@ tol_Transect = 2e-1
 tol_EBdipole = 1e-2
 
 plotIt = False
+
 if plotIt is True:
     import matplotlib.pylab as plt
 
@@ -74,7 +75,7 @@ class FDEM_analyticTests(unittest.TestCase):
         print(' ... done')
         self.u = u
 
-    def test_Transect(self):
+    def test_Transect(self, plotIt=plotIt):
 
         for src in self.prb.survey.srcList:
             print(' --- testing {} --- '.format(src.__class__.__name__))
@@ -111,7 +112,7 @@ class FDEM_analyticTests(unittest.TestCase):
 
 class TestDipoles(unittest.TestCase):
 
-    def test_CylMeshEBDipoles(self):
+    def test_CylMeshEBDipoles(self, plotIt=plotIt):
         print ("Testing CylMesh Electric and Magnetic Dipoles in a wholespace-"
                " Analytic: J-formulation")
         sigmaback = 1.

--- a/tests/em/fdem/forward/test_FDEM_analytics.py
+++ b/tests/em/fdem/forward/test_FDEM_analytics.py
@@ -14,8 +14,10 @@ tol_EBdipole = 1e-2
 
 plotIt = False
 
-if plotIt is True:
-    import matplotlib.pylab as plt
+import matplotlib
+matplotlib.use('Agg')
+
+import matplotlib.pylab as plt
 
 
 class FDEM_analyticTests(unittest.TestCase):

--- a/tests/em/fdem/forward/test_FDEM_casing.py
+++ b/tests/em/fdem/forward/test_FDEM_casing.py
@@ -14,7 +14,6 @@ srcloc = np.r_[0., 0., 0.]
 xobs = np.random.rand(n)+10.
 yobs = np.zeros(n)
 zobs = np.random.randn(n)
-plotit = False
 
 def CasingMagDipoleDeriv_r(x):
     obsloc = np.vstack([x, yobs, zobs]).T

--- a/tests/em/fdem/forward/test_FDEM_primsec.py
+++ b/tests/em/fdem/forward/test_FDEM_primsec.py
@@ -1,3 +1,6 @@
+import matplotlib
+matplotlib.use('Agg')
+
 from SimPEG import Mesh, Maps, Tests, Utils
 from SimPEG.EM import mu_0, FDEM, Analytics
 from SimPEG.EM.Utils import omega

--- a/tests/em/fdem/forward/test_FDEM_primsec.py
+++ b/tests/em/fdem/forward/test_FDEM_primsec.py
@@ -7,7 +7,6 @@ except ImportError:
     import Solver as SolverLU
 from SimPEG.Utils.io_utils import remoteDownload
 
-import matplotlib.pyplot as plt
 import time
 import os
 import numpy as np

--- a/tests/em/fdem/forward/test_FDEM_sources.py
+++ b/tests/em/fdem/forward/test_FDEM_sources.py
@@ -8,8 +8,10 @@ import warnings
 TOL = 0.5 # relative tolerance (to norm of soln)
 plotIt = False
 
-if plotIt is True:
-    import matplotlib.pyplot as plt
+import matplotlib
+matplotlib.use('Agg')
+
+import matplotlib.pyplot as plt
 
 
 class TestSimpleSourcePropertiesTensor(unittest.TestCase):

--- a/tests/em/fdem/forward/test_FDEM_sources.py
+++ b/tests/em/fdem/forward/test_FDEM_sources.py
@@ -32,17 +32,18 @@ class TestSimpleSourcePropertiesTensor(unittest.TestCase):
         self.prob_j = FDEM.Problem3D_j(self.mesh, sigmaMap=mapping)
 
         loc = np.r_[0., 0., 0.]
-        self.loc = Utils.mkvc(self.mesh.gridCC[Utils.closestPoints(self.mesh,
-                                                                   loc,
-                                                                   'CC'), :])
+        self.loc = Utils.mkvc(
+            self.mesh.gridCC[Utils.closestPoints(self.mesh, loc, 'CC'), :]
+        )
 
     def test_MagDipole(self):
 
         print('\ntesting MagDipole assignments')
 
         for orient in ['x', 'y', 'z', 'X', 'Y', 'Z']:
-            src = FDEM.Src.MagDipole([], freq=self.freq, loc=np.r_[0., 0., 0.],
-                                     orientation=orient)
+            src = FDEM.Src.MagDipole(
+                [], freq=self.freq, loc=np.r_[0., 0., 0.], orientation=orient
+            )
 
             # test assignments
             assert np.all(src.loc == np.r_[0., 0., 0.])
@@ -55,7 +56,11 @@ class TestSimpleSourcePropertiesTensor(unittest.TestCase):
             elif orient.upper() == 'Z':
                 orient_vec = np.r_[0., 0., 1.]
 
-            print (' {0} component. src: {1}, expected: {2}'.format(orient, src.orientation, orient_vec))
+            print (
+                ' {0} component. src: {1}, expected: {2}'.format(
+                    orient, src.orientation, orient_vec
+                )
+            )
             assert np.all(src.orientation == orient_vec)
 
     def test_MagDipoleSimpleFail(self):
@@ -71,19 +76,20 @@ class TestSimpleSourcePropertiesTensor(unittest.TestCase):
 
     def bPrimaryTest(self, src, probType):
         passed = True
-        print('\ntesting bPrimary {}, problem {}, mu {}'.format(src.__class__.__name__,
-                                                                probType,
-                                                                src.mu / mu_0))
+        print(
+            '\ntesting bPrimary {}, problem {}, mu {}'.format(
+                src.__class__.__name__, probType, src.mu / mu_0
+            )
+        )
         prob = getattr(self, 'prob_{}'.format(probType))
 
         bPrimary = src.bPrimary(prob)
 
         def ana_sol(XYZ):
-            return Analytics.FDEM.MagneticDipoleWholeSpace(XYZ, src.loc,
-                                                           0., 0.,
-                                                           moment=1.,
-                                                           orientation=src.orientation,
-                                                           mu=src.mu)
+            return Analytics.FDEM.MagneticDipoleWholeSpace(
+                XYZ, src.loc, 0., 0., moment=1., orientation=src.orientation,
+                mu=src.mu
+            )
 
         if probType in ['e', 'b']:
             # TODO: clean up how we call analytics


### PR DESCRIPTION
Add a `mirror` kwarg for the cyl mesh plotting so that when plotting a model on a cylindrically symmetric mesh we can look at a symmetric plot 

![image](https://cloud.githubusercontent.com/assets/6361812/21515361/34170f50-cc8c-11e6-84be-e204704f27b5.png)
