### PR TITLE
Feat/mesh plotting

### DIFF
--- a/SimPEG/Examples/Mesh_View.py
+++ b/SimPEG/Examples/Mesh_View.py
@@ -1,0 +1,279 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.constants import mu_0
+
+from SimPEG import Mesh, Utils, Maps
+from SimPEG.EM import FDEM
+
+# Try importing PardisoSolver from pymatsolver
+# otherwise, use SolverLU from SimPEG
+try:
+    from pymatsolver import PardisoSolver as Solver
+except ImportError:
+    from SimPEG import SolverLU as Solver
+
+# Set a nice colormap!
+plt.set_cmap(plt.get_cmap('viridis'))
+
+
+
+def run(plotIt=True):
+    """
+        Mesh: Plotting with defining range
+        ==================================
+
+        When using a large Mesh with the cylindrical code, it is advantageous
+        to define a :code:`range_x` and :code:`range_y` when plotting with
+        vectors. In this case, only the region inside of the range is
+        interpolated. In particular, you often want to ignore padding cells.
+
+    """
+
+    # ## Model Parameters
+    #
+    # We define a
+    # - resistive halfspace and
+    # - conductive sphere
+    #    - radius of 30m
+    #    - center is 50m below the surface
+
+    # electrical conductivities in S/m
+    sig_halfspace = 1e-6
+    sig_sphere = 1e0
+    sig_air = 1e-8
+
+
+
+    # depth to center, radius in m
+    sphere_z = -50.
+    sphere_radius = 30.
+
+
+    # ## Survey Parameters
+    #
+    # - Transmitter and receiver 20m above the surface
+    # - Receiver offset from transmitter by 8m horizontally
+    # - 25 frequencies, logaritmically between $10$ Hz and $10^5$ Hz
+
+
+    boom_height = 20.
+    rx_offset = 8.
+    freqs = np.r_[1e1, 1e5]
+
+    # source and receiver location in 3D space
+    src_loc = np.r_[0., 0., boom_height]
+    rx_loc = np.atleast_2d(np.r_[rx_offset, 0., boom_height])
+
+
+
+    # print the min and max skin depths to make sure mesh is fine enough and
+    # extends far enough
+
+    def skin_depth(sigma, f):
+        return 500./np.sqrt(sigma * f)
+
+    print(
+        'Minimum skin depth (in sphere): {:.2e} m '.format(
+            skin_depth(sig_sphere, freqs.max())
+        )
+    )
+    print(
+        'Maximum skin depth (in background): {:.2e} m '.format(
+            skin_depth(sig_halfspace, freqs.min())
+        )
+    )
+
+
+    # ## Mesh
+    #
+    # Here, we define a cylindrically symmetric tensor mesh.
+    #
+    # ### Mesh Parameters
+    #
+    # For the mesh, we will use a cylindrically symmetric tensor mesh. To
+    # construct a tensor mesh, all that is needed is a vector of cell widths in
+    # the x and z-directions. We will define a core mesh region of uniform cell
+    # widths and a padding region where the cell widths expand "to infinity".
+
+    # x-direction
+    csx = 2  # core mesh cell width in the x-direction
+    ncx = np.ceil(1.2*sphere_radius/csx)  # number of core x-cells (uniform mesh slightly beyond sphere radius)
+    npadx = 50  # number of x padding cells
+
+    # z-direction
+    csz = 1  # core mesh cell width in the z-direction
+    ncz = np.ceil(1.2*(boom_height - (sphere_z-sphere_radius))/csz) # number of core z-cells (uniform cells slightly below bottom of sphere)
+    npadz = 52  # number of z padding cells
+
+    # padding factor (expand cells to infinity)
+    pf = 1.3
+
+    # cell spacings in the x and z directions
+    hx = Utils.meshTensor([(csx, ncx), (csx, npadx, pf)])
+    hz = Utils.meshTensor([(csz, npadz, -pf), (csz, ncz), (csz, npadz, pf)])
+
+    # define a SimPEG mesh
+    mesh = Mesh.CylMesh([hx, 1, hz], x0 = np.r_[0.,0., -hz.sum()/2.-boom_height])
+
+
+    # ### Plot the mesh
+    #
+    # Below, we plot the mesh. The cyl mesh is rotated around x=0. Ensure that
+    # each dimension extends beyond the maximum skin depth.
+    #
+    # Zoom in by changing the xlim and zlim.
+
+    # X and Z limits we want to plot to. Try
+    xlim = np.r_[0., 2.5e6]
+    zlim = np.r_[-2.5e6, 2.5e6]
+
+    fig, ax = plt.subplots(1,1)
+    mesh.plotGrid(ax=ax)
+
+    ax.set_title('Simulation Mesh')
+    ax.set_xlim(xlim)
+    ax.set_ylim(zlim)
+
+    print(
+        'The maximum skin depth is (in background): {:.2e} m. '
+        'Does the mesh go sufficiently past that?'.format(
+            skin_depth(sig_halfspace, freqs.min())
+        )
+    )
+
+
+    # ## Put Model on Mesh
+    #
+    # Now that the model parameters and mesh are defined, we can define
+    # electrical conductivity on the mesh.
+    #
+    # The electrical conductivity is defined at cell centers when using the
+    # finite volume method. So here, we define a vector that contains an
+    # electrical conductivity value for every cell center.
+
+    # create a vector that has one entry for every cell center
+    sigma = sig_air*np.ones(mesh.nC)  # start by defining the conductivity of the air everwhere
+    sigma[mesh.gridCC[:, 2] < 0.] = sig_halfspace  # assign halfspace cells below the earth
+
+    # indices of the sphere (where (x-x0)**2 + (z-z0)**2 <= R**2)
+    sphere_ind =(
+        (mesh.gridCC[:,0]**2 + (mesh.gridCC[:,2] - sphere_z)**2) <=
+        sphere_radius**2
+    )
+    sigma[sphere_ind] = sig_sphere  # assign the conductivity of the sphere
+
+    # Plot a cross section of the conductivity model
+    fig, ax = plt.subplots(1, 1)
+    cb = plt.colorbar(mesh.plotImage(np.log10(sigma), ax=ax, mirror=True)[0])
+
+    # plot formatting and titles
+    cb.set_label('$\log_{10}\sigma$', fontsize=13)
+    ax.axis('equal')
+    ax.set_xlim([-120., 120.])
+    ax.set_ylim([-100., 30.])
+    ax.set_title('Conductivity Model')
+
+
+    # ## Set up the Survey
+    #
+    # Here, we define sources and receivers. For this example, the receivers
+    # are magnetic flux recievers, and are only looking at the secondary field
+    # (eg. if a bucking coil were used to cancel the primary). The source is a
+    # vertical magnetic dipole with unit moment.
+
+
+    # Define the receivers, we will sample the real secondary magnetic flux
+    # density as well as the imaginary magnetic flux density
+
+    bz_r = FDEM.Rx.Point_bSecondary(
+        locs=rx_loc, orientation='z', component='real'
+    )  # vertical real b-secondary
+    bz_i = FDEM.Rx.Point_b(
+        locs=rx_loc, orientation='z', component='imag'
+    )  # vertical imag b (same as b-secondary)
+
+    rxList = [bz_r, bz_i]  # list of receivers
+
+
+    # Define the list of sources - one source for each frequency. The source is
+    # a point dipole oriented in the z-direction
+
+    srcList = [
+        FDEM.Src.MagDipole(rxList, f, src_loc, orientation='z') for f in freqs
+    ]
+
+    print(
+        'There are {nsrc} sources (same as the number of frequencies - {nfreq}). '
+        'Each source has {nrx} receivers sampling the resulting b-fields'.format(
+            nsrc = len(srcList),
+            nfreq = len(freqs),
+            nrx = len(rxList)
+        )
+    )
+
+
+    # ## Set up Forward Simulation
+    #
+    # A forward simulation consists of a paired SimPEG problem and Survey.
+    # For this example, we use the E-formulation of Maxwell's equations,
+    # solving the second-order system for the electric field, which is defined
+    # on the cell edges of the mesh. This is the `prob` variable below. The
+    # `survey` takes the source list which is used to construct the RHS for the
+    # problem. The source list also contains the receiver information, so the
+    # `survey` knows how to sample fields and fluxes that are produced by
+    # solving the `prob`.
+
+    # define a problem - the statement of which discrete pde system we want to
+    # solve
+    prob = FDEM.Problem3D_e(mesh, sigmaMap=Maps.IdentityMap(mesh))
+    prob.solver = Solver
+
+    survey = FDEM.Survey(srcList)
+
+    # tell the problem and survey about each other - so the RHS can be
+    # constructed for the problem and the
+    # resulting fields and fluxes can be sampled by the receiver.
+    prob.pair(survey)
+
+
+    # ### Solve the forward simulation
+    #
+    # Here, we solve the problem for the fields everywhere on the mesh.
+    fields = prob.fields(sigma)
+
+
+    # ### Plot the fields
+    #
+    # Lets look at the physics!
+
+    # log-scale the colorbar
+    from matplotlib.colors import LogNorm
+
+    fig, ax = plt.subplots(1, 2, figsize=(12, 6))
+
+    def plotMe(field, ax):
+        plt.colorbar(mesh.plotImage(
+            field, vType='F', view='vec',
+            range_x=[-100., 100.], range_y=[-180., 60.],
+            pcolorOpts={
+                    'norm': LogNorm(), 'cmap': plt.get_cmap('viridis')
+                },
+            streamOpts={'color': 'k'},
+            ax=ax, mirror=True
+        )[0], ax=ax)
+
+    plotMe(fields[srcList[0], 'bSecondary'].real, ax[0])
+    ax[0].set_title('Real B-Secondary, {}Hz'.format(freqs[0]))
+
+    plotMe(fields[srcList[1], 'bSecondary'].real, ax[1])
+    ax[1].set_title('Real B-Secondary, {}Hz'.format(freqs[1]))
+
+    plt.tight_layout()
+
+    if plotIt:
+        plt.show()
+
+if __name__ == '__main__':
+    run(plotIt=True)
+
+

--- a/SimPEG/Examples/__init__.py
+++ b/SimPEG/Examples/__init__.py
@@ -30,6 +30,7 @@ from SimPEG.Examples import Mesh_QuadTree_Creation
 from SimPEG.Examples import Mesh_QuadTree_FaceDiv
 from SimPEG.Examples import Mesh_QuadTree_HangingNodes
 from SimPEG.Examples import Mesh_Tensor_Creation
+from SimPEG.Examples import Mesh_View
 from SimPEG.Examples import PF_Gravity_Inversion_Linear
 from SimPEG.Examples import PF_Gravity_Laguna_del_Maule_Inversion
 from SimPEG.Examples import PF_Magnetics_Analytics
@@ -37,7 +38,7 @@ from SimPEG.Examples import PF_Magnetics_Inversion_Linear
 from SimPEG.Examples import Utils_plot2Ddata
 from SimPEG.Examples import Utils_surface2ind_topo
 
-__examples__ = ["DC_Analytic_Dipole", "DC_Forward_PseudoSection", "EM_FDEM_1D_Inversion", "EM_FDEM_Analytic_MagDipoleWholespace", "EM_FDEM_Mu_Inversion", "EM_Heagyetal2016_Casing", "EM_Heagyetal2016_CylInversions", "EM_NSEM_1D_ForwardAndInversion", "EM_NSEM_3D_Foward", "EM_Schenkel_Morrison_Casing", "EM_TDEM_1D_Inversion", "EM_TDEM_1D_Inversion_RawWaveform", "FLOW_Richards_1D_Celia1990", "Inversion_Linear", "Inversion_Linear_IRLS", "Maps_ComboMaps", "Maps_Mesh2Mesh", "Maps_ParametrizedBlockInLayer", "Maps_ParametrizedLayer", "Mesh_Basic_ForwardDC", "Mesh_Basic_PlotImage", "Mesh_Basic_Types", "Mesh_Operators_CahnHilliard", "Mesh_Plot_Cyl", "Mesh_QuadTree_Creation", "Mesh_QuadTree_FaceDiv", "Mesh_QuadTree_HangingNodes", "Mesh_Tensor_Creation", "PF_Gravity_Inversion_Linear", "PF_Gravity_Laguna_del_Maule_Inversion", "PF_Magnetics_Analytics", "PF_Magnetics_Inversion_Linear", "Utils_plot2Ddata", "Utils_surface2ind_topo"]
+__examples__ = ["DC_Analytic_Dipole", "DC_Forward_PseudoSection", "EM_FDEM_1D_Inversion", "EM_FDEM_Analytic_MagDipoleWholespace", "EM_FDEM_Mu_Inversion", "EM_Heagyetal2016_Casing", "EM_Heagyetal2016_CylInversions", "EM_NSEM_1D_ForwardAndInversion", "EM_NSEM_3D_Foward", "EM_Schenkel_Morrison_Casing", "EM_TDEM_1D_Inversion", "EM_TDEM_1D_Inversion_RawWaveform", "FLOW_Richards_1D_Celia1990", "Inversion_Linear", "Inversion_Linear_IRLS", "Maps_ComboMaps", "Maps_Mesh2Mesh", "Maps_ParametrizedBlockInLayer", "Maps_ParametrizedLayer", "Mesh_Basic_ForwardDC", "Mesh_Basic_PlotImage", "Mesh_Basic_Types", "Mesh_Operators_CahnHilliard", "Mesh_Plot_Cyl", "Mesh_QuadTree_Creation", "Mesh_QuadTree_FaceDiv", "Mesh_QuadTree_HangingNodes", "Mesh_Tensor_Creation", "Mesh_View", "PF_Gravity_Inversion_Linear", "PF_Gravity_Laguna_del_Maule_Inversion", "PF_Magnetics_Analytics", "PF_Magnetics_Inversion_Linear", "Utils_plot2Ddata", "Utils_surface2ind_topo"]
 
 ##### AUTOIMPORTS #####
 

--- a/SimPEG/Mesh/View.py
+++ b/SimPEG/Mesh/View.py
@@ -42,13 +42,15 @@ class TensorView(object):
     #         pltNum +=1
     #     if showIt: plt.show()
 
-    def plotImage(self, v, vType='CC', grid=False, view='real',
-                  ax=None, clim=None, showIt=False,
-                  pcolorOpts=None,
-                  streamOpts=None,
-                  gridOpts=None,
-                  numbering=True, annotationColor='w'
-                  ):
+    def plotImage(
+        self, v, vType='CC', grid=False, view='real',
+        ax=None, clim=None, showIt=False,
+        pcolorOpts=None,
+        streamOpts=None,
+        gridOpts=None,
+        numbering=True, annotationColor='w',
+        range_x=None, range_y=None
+    ):
         """
         Mesh.plotImage(v)
 
@@ -89,15 +91,15 @@ class TensorView(object):
         if pcolorOpts is None:
             pcolorOpts = {}
         if streamOpts is None:
-            streamOpts = {'color':'k'}
+            streamOpts = {'color': 'k'}
         if gridOpts is None:
-            gridOpts = {'color':'k'}
+            gridOpts = {'color': 'k'}
 
         if ax is None:
             fig = plt.figure()
             ax = plt.subplot(111)
         else:
-            assert isinstance(ax,matplotlib.axes.Axes), "ax must be an Axes!"
+            assert isinstance(ax, matplotlib.axes.Axes), "ax must be an Axes!"
             fig = ax.figure
 
         if self.dim == 1:
@@ -108,10 +110,12 @@ class TensorView(object):
             ax.set_xlabel("x")
             ax.axis('tight')
         elif self.dim == 2:
-            return self._plotImage2D(v, vType=vType, grid=grid, view=view,
-                                     ax=ax, clim=clim, showIt=showIt,
-                                     pcolorOpts=pcolorOpts, streamOpts=streamOpts,
-                                     gridOpts=gridOpts)
+            return self._plotImage2D(
+                v, vType=vType, grid=grid, view=view,
+                ax=ax, clim=clim, showIt=showIt,
+                pcolorOpts=pcolorOpts, streamOpts=streamOpts,
+                gridOpts=gridOpts, range_x=range_x, range_y=range_y
+            )
         elif self.dim == 3:
             # get copy of image and average to cell-centers is necessary
             if vType == 'CC':
@@ -124,8 +128,8 @@ class TensorView(object):
                 # if 'x' in vType: v = np.r_[v,np.zeros(n[1]),np.zeros(n[2])]
                 # if 'y' in vType: v = np.r_[np.zeros(n[0]),v,np.zeros(n[2])]
                 # if 'z' in vType: v = np.r_[np.zeros(n[0]),np.zeros(n[1]),v]
-                v = getattr(self,aveOp)*v # average to cell centers
-                ind_xyz = {'x':0,'y':1,'z':2}[vType[1]]
+                v = getattr(self, aveOp)*v # average to cell centers
+                ind_xyz = {'x': 0, 'y': 1,'z':2}[vType[1]]
                 vc = self.r(v.reshape((self.nC,-1),order='F'), 'CC','CC','M')[ind_xyz]
 
             # determine number oE slices in x and y dimension
@@ -184,7 +188,8 @@ class TensorView(object):
                   ax=None, clim=None, showIt=False,
                   pcolorOpts=None,
                   streamOpts=None,
-                  gridOpts=None
+                  gridOpts=None,
+                  range_x=None, range_y=None
                   ):
 
         """
@@ -300,20 +305,22 @@ class TensorView(object):
         ax.set_title('Slice {0:.0f}'.format(ind))
         return out
 
-
-    def _plotImage2D(self, v, vType='CC', grid=False, view='real',
-              ax=None, clim=None, showIt=False,
-              pcolorOpts=None,
-              streamOpts=None,
-              gridOpts=None
-              ):
+    def _plotImage2D(
+        self, v, vType='CC', grid=False, view='real',
+        ax=None, clim=None, showIt=False,
+        pcolorOpts=None,
+        streamOpts=None,
+        gridOpts=None,
+        range_x=None,
+        range_y=None
+    ):
 
         if pcolorOpts is None:
             pcolorOpts = {}
         if streamOpts is None:
-            streamOpts = {'color':'k'}
+            streamOpts = {'color': 'k'}
         if gridOpts is None:
-            gridOpts = {'color':'k'}
+            gridOpts = {'color': 'k'}
         vTypeOptsCC = ['N','CC','Fx','Fy','Ex','Ey']
         vTypeOptsV = ['CCv','F','E']
         vTypeOpts = vTypeOptsCC + vTypeOptsV
@@ -358,22 +365,55 @@ class TensorView(object):
             U, V = self.r(v.reshape((self.nC,-1), order='F'), 'CC', 'CC', 'M')
             if clim is None:
                 uv = np.sqrt(U**2 + V**2)
-                clim = [uv.min(),uv.max()]
+                clim = [uv.min(), uv.max()]
 
             # Matplotlib seems to not support irregular
             # spaced vectors at the moment. So we will
             # Interpolate down to a regular mesh at the
             # smallest mesh size in this 2D slice.
-            nxi = int(self.hx.sum()/self.hx.min())
-            nyi = int(self.hy.sum()/self.hy.min())
-            tMi = self.__class__([np.ones(nxi)*self.hx.sum()/nxi,
-                                  np.ones(nyi)*self.hy.sum()/nyi], self.x0)
-            P = self.getInterpolationMat(tMi.gridCC,'CC',zerosOutside=True)
+            if range_x is not None:
+                dx = (range_x[1] - range_x[0])
+                nxi = int(dx/self.hx.min())
+                hx = np.ones(nxi)*dx/nxi
+                x0_x = range_x[0]
+            else:
+                nxi = int(self.hx.sum()/self.hx.min())
+                hx = np.ones(nxi)*self.hx.sum()/nxi
+                x0_x = self.x0[0]
+
+            if range_y is not None:
+                dy = (range_y[1] - range_y[0])
+                nyi = int(dy/self.hy.min())
+                hy = np.ones(nyi)*dy/nyi
+                x0_y = range_y[0]
+            else:
+                nyi = int(self.hy.sum()/self.hy.min())
+                hy = np.ones(nyi)*self.hy.sum()/nyi
+                x0_y = self.x0[1]
+
+            tMi = self.__class__([hx, hy], np.r_[x0_x, x0_y])
+            P = self.getInterpolationMat(tMi.gridCC, 'CC', zerosOutside=True)
+
             Ui = tMi.r(P*mkvc(U), 'CC', 'CC', 'M')
             Vi = tMi.r(P*mkvc(V), 'CC', 'CC', 'M')
             # End Interpolation
 
-            out += (ax.pcolormesh(self.vectorNx, self.vectorNy, np.sqrt(U**2+V**2).T, vmin=clim[0], vmax=clim[1], **pcolorOpts),)
+            x = self.vectorNx
+            y = self.vectorNy
+
+            ind_CCx = np.ones(self.vnC, dtype=bool)
+            ind_CCy = np.ones(self.vnC, dtype=bool)
+            if range_x is not None:
+                x = tMi.vectorNx
+
+            if range_y is not None:
+                y = tMi.vectorNy
+
+            if range_x is not None or range_y is not None:  # use interpolated values
+                U = Ui
+                V = Vi
+
+            out += (ax.pcolormesh(x, y, np.sqrt(U**2+V**2).T, vmin=clim[0], vmax=clim[1], **pcolorOpts),)
             out += (ax.streamplot(tMi.vectorCCx, tMi.vectorCCy, Ui.T, Vi.T, **streamOpts),)
 
         if grid:
@@ -383,17 +423,28 @@ class TensorView(object):
             yYGrid = np.c_[self.vectorNy,self.vectorNy,np.nan*np.ones(self.nNy)].flatten()
             out += (ax.plot(np.r_[xXGrid,yXGrid],np.r_[xYGrid,yYGrid],**gridOpts)[0],)
 
-
         ax.set_xlabel('x')
         ax.set_ylabel('y')
-        ax.set_xlim(*self.vectorNx[[0,-1]])
-        ax.set_ylim(*self.vectorNy[[0,-1]])
 
-        if showIt: plt.show()
+        if range_x is not None:
+            ax.set_xlim(*range_x)
+        else:
+            ax.set_xlim(*self.vectorNx[[0, -1]])
+
+        if range_y is not None:
+            ax.set_ylim(*range_y)
+        else:
+            ax.set_ylim(*self.vectorNy[[0, -1]])
+
+        if showIt:
+            plt.show()
         return out
 
 
-    def plotGrid(self, ax=None, nodes=False, faces=False, centers=False, edges=False, lines=True, showIt=False):
+    def plotGrid(
+        self, ax=None, nodes=False, faces=False, centers=False, edges=False,
+        lines=True, showIt=False
+    ):
         """Plot the nodal, cell-centered and staggered grids for 1,2 and 3 dimensions.
 
         :param bool nodes: plot nodes
@@ -514,15 +565,18 @@ class CylView(object):
         # Just create a TM and use its view.
         from SimPEG.Mesh import TensorMesh
 
+        vType = kwargs.pop('vType', None)
+        if vType is not None:
+            if vType.upper() != 'CCV':
+                if vType.upper() == 'F':
+                    val = mkvc(self.aveF2CCV * args[0])
+                    kwargs['vType'] = 'CCv'  # now the vector is cell centered
+                if vType.upper() == 'E':
+                    val = mkvc(self.aveE2CCV * args[0])
+                args = (val,) + args[1:]
+
         mirror = kwargs.pop('mirror', None)
         if mirror is True:
-            if kwargs.get('vType', None) is not None:
-                if kwargs.get('vType', None) != 'CC':
-                    raise NotImplementedError(
-                        'Mirroring has not yet been implemented for non-cell '
-                        'centered values'
-                    )
-
             # create a mirrored mesh
             hx = np.hstack([np.flipud(self.hx), self.hx])
             x00 = self.x0[0] - self.hx.sum()
@@ -530,9 +584,25 @@ class CylView(object):
 
             # mirror the data
             if len(args) > 0:
-                tmp = args[0].reshape(self.vnC[0], self.vnC[2], order='F')
-                tmp = mkvc(np.vstack([np.flipud(tmp), tmp]))
-                args = (tmp,) + args[1:]
+                val = args[0]
+
+            if len(val) == self.nC:  # only a single value at cell centers
+                val = val.reshape(self.vnC[0], self.vnC[2], order='F')
+                val = mkvc(np.vstack([np.flipud(val), val]))
+
+            elif len(val) == 2*self.nC:
+                val_x = val[:self.nC]
+                val_z = val[self.nC:]
+
+                val_x = val_x.reshape(self.vnC[0], self.vnC[2], order='F')
+                val_x = mkvc(np.vstack([-1.*np.flipud(val_x), val_x])) # by symmetry
+
+                val_z = val_z.reshape(self.vnC[0], self.vnC[2], order='F')
+                val_z = mkvc(np.vstack([np.flipud(val_z), val_z]))
+
+                val = np.hstack([val_x, val_z])
+
+            args = (val,) + args[1:]
         else:
             M = TensorMesh([self.hx, self.hz], x0=[self.x0[0], self.x0[2]])
 
@@ -559,12 +629,12 @@ class CylView(object):
 
         return out
 
-
     def plotGrid(self, *args, **kwargs):
         return self._plotCylTensorMesh('plotGrid', *args, **kwargs)
 
     def plotImage(self, *args, **kwargs):
         return self._plotCylTensorMesh('plotImage', *args, **kwargs)
+
 
 class CurvView(object):
     """
@@ -668,7 +738,9 @@ class CurvView(object):
         if showIt:
             plt.show()
 
-    def plotImage(self, I, ax=None, showIt=False, grid=False, clim=None):
+    def plotImage(
+        self, I, ax=None, showIt=False, grid=False, clim=None
+    ):
         if self.dim == 3:
             raise NotImplementedError('This is not yet done!')
 

--- a/docs/content/examples/Mesh_View.rst
+++ b/docs/content/examples/Mesh_View.rst
@@ -1,0 +1,29 @@
+.. _examples_Mesh_View:
+
+.. --------------------------------- ..
+..                                   ..
+..    THIS FILE IS AUTO GENEREATED   ..
+..                                   ..
+..    SimPEG/Examples/__init__.py    ..
+..                                   ..
+.. --------------------------------- ..
+
+
+Mesh: Plotting with defining range
+==================================
+
+When using a large Mesh with the cylindrical code, it is advantageous
+to define a :code:`range_x` and :code:`range_y` when plotting with
+vectors. In this case, only the region inside of the range is
+interpolated. In particular, you often want to ignore padding cells.
+
+
+
+.. plot::
+
+    from SimPEG import Examples
+    Examples.Mesh_View.run()
+
+.. literalinclude:: ../../../SimPEG/Examples/Mesh_View.py
+    :language: python
+    :linenos:


### PR DESCRIPTION
Add `range_x` and `range_y` kwargs to `Mesh.plotImage` that creates a smaller mesh and samples your data only in that region. 

This is essential for working with large meshes and plotting vector plots as the `view='vec'` previously interpolated the entire domain onto a mesh with cell widths equal to that of the minimum cell width ... big problem if you have lots of padding cells. 

Added an example demonstrating its use (with a fine core cyl mesh and a load of padding b/c we want to look at 4 decades of frequency)s
![figure_2](https://cloud.githubusercontent.com/assets/6361812/21897592/f1885cce-d89e-11e6-9115-2f4258c5348b.png)
using a sphere model
![figure_3](https://cloud.githubusercontent.com/assets/6361812/21897651/1fffd154-d89f-11e6-981c-af2c093dd381.png)
and we can look at the fields! (if you try without the range - it will run into a memory error)
![figure_4](https://cloud.githubusercontent.com/assets/6361812/21897697/3d66ed36-d89f-11e6-88ea-8ecd40c853e6.png)

(I will add this to discretize in a separate pr, but I need it working with SimPEG dev soon for some of the em-examples)