### PR TITLE
distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - MASTER_BRANCH=master
     - DEV_BRANCH=dev
     - DOCS_PY=2.7  # deploy docs from 2.7
-    - PYPI_PY=3.6  # deploy to pypi from python 3.6
+    - PYPI_PY=3.6 # deploy to pypi from python 3.6
   matrix:
     - TEST_DIR=tests/em/fdem/inverse/derivs
     - TEST_DIR="tests/em/tdem tests/base"
@@ -72,7 +72,7 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
   # early exit if not on a deplotment branch
-  - if ! [ "$TRAVIS_BRANCH" = "$MASTER_BRANCH" -o "$TRAVIS_BRANCH" = "$DEV_BRANCH" ]; then
+  - if ! [ "$TRAVIS_BRANCH" = "$MASTER_BRANCH" -o "$TRAVIS_BRANCH" = "$DEV_BRANCH" -o "$TRAVIS_TAG" = "true" ]; then
       echo "Not deploying (because this is not a deployment branch)" ;
       exit 0 ;
     fi
@@ -104,10 +104,10 @@ after_success:
     fi;
 
   #deploy to pypi
-  - if [ "$TRAVIS_BRANCH" = "$MASTER_BRANCH" -a $TRAVIS_PYTHON_VERSION == $PYPI_PY ]; then
+  - if [ $TRAVIS_PYTHON_VERSION == $PYPI_PY" -a $TRAVIS_TAG" = "true" ]; then
       mv credentials/.pypirc ~/.pypirc ;
-      python setup.py register -r pypi ;
-      travis_wait 20 python setup.py sdist upload -r pypi ;
+      python setup.py bdist_wheel --universal ;
+      travis_wait 20 twine upload -r pypi --skip-existing dist/* ;
     fi
 
 notifications:


### PR DESCRIPTION
- build universal wheel for SimPEG on travis whenever a tag is submitted
- similar to simpeg/discretize#44, however since SimPEG is now pure python, a universal wheel can instead be used. https://packaging.python.org/distributing/#universal-wheels