### PR TITLE
Feat/combo directives

### DIFF
--- a/SimPEG/DataMisfit.py
+++ b/SimPEG/DataMisfit.py
@@ -40,7 +40,12 @@ class BaseDataMisfit(ObjectiveFunction.L2ObjectiveFunction):
             return '*'
 
     @property
+    def nD(self):
+        return self.survey.nD
+
+    @property
     def Wd(self):
+        # TODO: add a version number prior to merging.
         raise AttributeError(
             'The `Wd` property been depreciated, please use: `W` instead'
         )

--- a/SimPEG/Directives.py
+++ b/SimPEG/Directives.py
@@ -587,7 +587,6 @@ class Update_IRLS(InversionDirective):
                 self.reg.norms = self.norms
                 print("L[p qx qy qz]-norm : " + str(self.reg.norms))
 
-
             if self.ComboObjFun:
                     for reg in self.reg.objfcts:
                         reg.model = self.invProb.model
@@ -595,6 +594,7 @@ class Update_IRLS(InversionDirective):
             else:
                 self.reg.model = self.invProb.model
 
+            self.model = self.invProb.model.copy()
             self.l2model = self.invProb.model.copy()
 
             # Re-assign the norms
@@ -624,13 +624,15 @@ class Update_IRLS(InversionDirective):
 
             else:
                 # Update the model used in the regularization
-                if self.ComboObjFun:
-                    for reg in self.reg.objfcts:
-                        reg.model = self.invProb.model
+                # if self.ComboObjFun:
+                #     for reg in self.reg.objfcts:
+                #         reg.model = self.invProb.model
 
-                else:
-                    self.reg.model = self.invProb.model
+                # else:
+                #     self.reg.model = self.invProb.model
 
+                self.reg.model = self.invProb.model
+                self.model = self.invProb.model.copy()
                 self.IRLSiter += 1
 
             # Reset the regularization matrices so that it is

--- a/SimPEG/Directives.py
+++ b/SimPEG/Directives.py
@@ -510,6 +510,9 @@ class Update_IRLS(InversionDirective):
             # It is a Combo objective, so will have to loop
             self.ComboObjFun = True
 
+            # expose model (should be the same for all cases)
+            self.reg.expose('model')
+
         if self.mode == 1:
 
             if self.ComboObjFun:

--- a/SimPEG/Directives.py
+++ b/SimPEG/Directives.py
@@ -18,7 +18,9 @@ class InversionDirective(properties.HasProperties):
 
     debug = properties.Bool("Print debugging information", default=False)
 
-    def __init__(self, **kwargs):
+    def __init__(self, dmisfit=None, reg=None, **kwargs):
+        self._dmisfit = dmisfit
+        self._reg = reg
         Utils.setKwargs(self, **kwargs)
 
     @property
@@ -43,21 +45,25 @@ class InversionDirective(properties.HasProperties):
     def opt(self):
         return self.invProb.opt
 
-    # @property
-    # def reg(self):
-    #     return self.invProb.reg
+    @property
+    def reg(self):
+        if getattr(self, '_reg', None) is None:
+            self._reg = self.invProb.reg
+        return self._reg
 
-    # @property
-    # def dmisfit(self):
-    #     return self.invProb.dmisfit
+    @property
+    def dmisfit(self):
+        if getattr(self, '_dmisfit', None) is None:
+            self._dmisfit = self.invProb.dmisfit
+        return self._dmisfit
 
-    # @property
-    # def survey(self):
-    #     return self.dmisfit.survey
+    @property
+    def survey(self):
+        return self.dmisfit.survey
 
-    # @property
-    # def prob(self):
-    #     return self.dmisfit.prob
+    @property
+    def prob(self):
+        return self.dmisfit.prob
 
     @property
     def stopping_criteria_satisfied(self):
@@ -160,22 +166,7 @@ class BetaEstimate_ByEig(InversionDirective):
     )
 
     def __init__(self, dmisfit=None, reg=None, **kwargs):
-        self._dmisfit = dmisfit
-        self._reg = reg
-
-        super(BetaEstimate_ByEig, self).__init__(**kwargs)
-
-    @property
-    def dmisfit(self):
-        if self._dmisfit is None:
-            self._dmisfit = self.invProb.dmisfit
-        return self._dmisfit
-
-    @property
-    def reg(self):
-        if self._reg is None:
-            self._reg = self.invProb.reg
-        return self._reg
+        super(BetaEstimate_ByEig, self).__init__(dmisfit, reg, **kwargs)
 
     def initialize(self):
         """
@@ -263,7 +254,7 @@ class TargetMisfit(InversionDirective):
         self._dmisfit = dmisfit
         self._phi_d_star = phi_d_star
 
-        super(TargetMisfit, self).__init__(**kwargs)
+        super(TargetMisfit, self).__init__(dmisfit=dmisfit, **kwargs)
 
     @property
     def dmisfit(self):
@@ -477,9 +468,10 @@ class Update_IRLS(InversionDirective):
     iterStart = 0
 
     # Beta schedule
+    # comment: I think this should be included as a separate directive
     coolingFactor = 2.
     coolingRate = 1
-    ComboObjFun = False
+    # ComboObjFun = False
 
     updateBeta = True
 
@@ -505,17 +497,17 @@ class Update_IRLS(InversionDirective):
 
         if self.mode == 1:
 
-            if self.ComboObjFun:
+            # if self.ComboObjFun:
 
-                self.norms = []
-                for reg in self.reg.objfcts:
-                    self.norms.append(reg.norms)
-                    reg.norms = [2., 2., 2., 2.]
+            #     self.norms = []
+            #     for reg in self.reg.objfcts:
+            #         self.norms.append(reg.norms)
+            #         reg.norms = [2., 2., 2., 2.]
 
-            else:
-                # Store assigned norms for later use - start with l2
-                self.norms = self.reg.norms
-                self.reg.norms = [2., 2., 2., 2.]
+            # else:
+            # Store assigned norms for later use - start with l2
+            self.norms = self.reg.norms
+            self.reg.norms = [2., 2., 2., 2.]
 
     def endIter(self):
 

--- a/SimPEG/Directives.py
+++ b/SimPEG/Directives.py
@@ -92,9 +92,10 @@ class InversionDirective(properties.HasProperties):
 
 class DirectiveList(object):
 
-    dList = []   #: The list of Directives
+    dList = None   #: The list of Directives
 
     def __init__(self, *directives, **kwargs):
+        self.dList = []
         for d in directives:
             assert isinstance(d, InversionDirective), (
                 'All directives must be InversionDirectives not {}'
@@ -603,6 +604,7 @@ class Update_IRLS(InversionDirective):
 
             # else:
             self.reg.model = self.invProb.model
+            self.model = self.invProb.model.copy()
             self.l2model = self.invProb.model.copy()
 
             # Re-assign the norms
@@ -638,7 +640,7 @@ class Update_IRLS(InversionDirective):
 
                 # else:
                 self.reg.model = self.invProb.model
-
+                self.model = self.invProb.model.copy()
                 self.IRLSiter += 1
 
             # Reset the regularization matrices so that it is

--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -429,7 +429,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
             properties = dict(zip(properties, len(properties)*[None]))
 
         # go through the properties list and expose them
-        for prop, val in properties.iteritems(): # skip if already in self._exposed
+        for prop, val in properties.items(): # skip if already in self._exposed
             # if prop not in self._exposed:
             if getattr(type(self), prop, None) is not None:
                 raise Exception(

--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -220,9 +220,9 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
 
         self._nP = '*'
 
-        assert(len(objfcts)==len(multipliers)),(
+        assert(len(objfcts)==len(multipliers)), (
             "Must have the same number of Objective Functions and Multipliers "
-            "not {} and {}".format(len(objfcts),len(multipliers))
+            "not {} and {}".format(len(objfcts), len(multipliers))
             )
 
         def validate_list(objfctlist, multipliers):
@@ -354,23 +354,22 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
     _exposed = {}
 
     def expose(self, properties):
-
         # if 'all', exposes all top level properties in the objective function
         # list
-        if isinstance(properties, str) and properties.lower() == 'all':
+        if isinstance(properties, string_types) and properties.lower() == 'all':
             prop_set = []
             for objfct in self.objfcts:
                 prop_set += [
                     prop for prop in dir(objfct)
                     if prop[0] != '_' and  # only expose top level properties
                     isinstance(
-                        getattr(type(objfct), prop), property
-                    ) and not
+                        getattr(type(objfct), prop, None), property
+                    ) and
                     (
                         # don't try and over-write things like nP
                         # which are properties on this class
-                        getattr(self, prop, None) is not None and
-                        prop not in self._exposed.keys()
+                        getattr(type(self), prop, None) is None or
+                        prop in self._exposed.keys()
                     )
                 ]
             properties = list(set(prop_set))
@@ -386,7 +385,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
         # go through the properties list and expose them
         for prop, val in properties.iteritems(): # skip if already in self._exposed
             # if prop not in self._exposed:
-            if getattr(self, prop, None) is not None and prop not in self._exposed.keys():
+            if getattr(type(self), prop, None) is not None:
                 raise Exception(
                     "can't expose {} as it is a property on the combo "
                     "objective function".format(prop)

--- a/SimPEG/Optimization.py
+++ b/SimPEG/Optimization.py
@@ -4,8 +4,8 @@ import numpy as np
 import scipy.sparse as sp
 from six import string_types
 from .Utils.SolverUtils import *
-norm = np.linalg.norm
 from SimPEG import Regularization
+
 
 __all__ = [
     'Minimize', 'Remember', 'SteepestDescent', 'BFGS', 'GaussNewton',
@@ -13,6 +13,7 @@ __all__ = [
     'StoppingCriteria', 'IterationPrinters'
 ]
 
+norm = np.linalg.norm
 SolverICG = SolverWrapI(sp.linalg.cg, checkAccuracy=False)
 
 

--- a/SimPEG/PF/BaseGrav.py
+++ b/SimPEG/PF/BaseGrav.py
@@ -1,7 +1,7 @@
 from SimPEG import Survey, Maps
 
 
-class LinearSurvey(Survey.BaseSurvey):
+class LinearSurvey(Survey.LinearSurvey):
     """Base Magnetics Survey"""
 
     rxLoc = None  #: receiver locations
@@ -9,10 +9,10 @@ class LinearSurvey(Survey.BaseSurvey):
 
     def __init__(self, srcField, **kwargs):
         self.srcField = srcField
-        Survey.BaseSurvey.__init__(self, **kwargs)
+        Survey.LinearSurvey.__init__(self, **kwargs)
 
-    def eval(self, u):
-        return u
+    # def eval(self, u):
+    #     return u
 
     @property
     def nD(self):

--- a/SimPEG/PF/BaseMag.py
+++ b/SimPEG/PF/BaseMag.py
@@ -4,14 +4,14 @@ import scipy.sparse as sp
 from scipy.constants import mu_0
 
 
-class BaseMagSurvey(Survey.BaseSurvey):
+class BaseMagSurvey(Survey.LinearSurvey):
     """Base Magnetics Survey"""
 
     rxLoc = None   #: receiver locations
     rxType = None   #: receiver type
 
     def __init__(self, **kwargs):
-        Survey.BaseSurvey.__init__(self, **kwargs)
+        super(BaseMagSurvey, self).__init__(**kwargs)
 
     def setBackgroundField(self, Inc, Dec, Btot):
 
@@ -106,7 +106,7 @@ class BaseMagSurvey(Survey.BaseSurvey):
         return np.r_[bfx, bfy, bfz]
 
 
-class LinearSurvey(Survey.BaseSurvey):
+class LinearSurvey(Survey.LinearSurvey):
     """Base Magnetics Survey"""
 
     rxLoc = None  #: receiver locations
@@ -114,10 +114,10 @@ class LinearSurvey(Survey.BaseSurvey):
 
     def __init__(self, srcField, **kwargs):
         self.srcField = srcField
-        Survey.BaseSurvey.__init__(self, **kwargs)
+        super(LinearSurvey, self).__init__(**kwargs)
 
-    def eval(self, u):
-        return u
+    # def eval(self, u):
+    #     return u
 
     @property
     def nD(self):

--- a/SimPEG/PF/Magnetics.py
+++ b/SimPEG/PF/Magnetics.py
@@ -14,6 +14,7 @@ import gc
 from . import BaseMag as MAG
 from .MagAnalytics import spheremodel, CongruousMagBC
 
+
 class MagneticIntegral(Problem.LinearProblem):
 
     chi, chiMap, chiDeriv = Props.Invertible(
@@ -30,7 +31,7 @@ class MagneticIntegral(Problem.LinearProblem):
     silent = False  # Don't display progress on screen
 
     def __init__(self, mesh, **kwargs):
-        Problem.BaseProblem.__init__(self, mesh, **kwargs)
+        super(Problem.LinearProblem, self).__init__(mesh, **kwargs)
 
     def fwr_ind(self, m):
 
@@ -88,8 +89,6 @@ class MagneticIntegral(Problem.LinearProblem):
                               np.sin(np.deg2rad(I))], 2).T
 
         return self._ProjTMI
-
-
 
     def Intrgl_Fwr_Op(self, m=None, magType="H0", recType='tmi'):
 

--- a/SimPEG/Problem.py
+++ b/SimPEG/Problem.py
@@ -108,6 +108,11 @@ class BaseProblem(Props.HasModel):
                 "The survey object is already paired to a problem. "
                 "Use survey.unpair()"
             )
+        elif self.ispaired:
+            raise Exception(
+                "The problem is already paired to a survey. "
+                "Use problem.unpair()"
+            )
         self._survey = d
         d._prob = self
 
@@ -260,7 +265,7 @@ class BaseTimeProblem(BaseProblem):
 
 class LinearProblem(BaseProblem):
 
-    # surveyPair = Survey.LinearSurvey
+    surveyPair = Survey.LinearSurvey
 
     F = None
 

--- a/SimPEG/Regularization.py
+++ b/SimPEG/Regularization.py
@@ -658,6 +658,11 @@ class BaseComboRegularization(ObjectiveFunction.ComboObjectiveFunction):
             objfcts=objfcts, multipliers=None
         )
 
+        # self.expose([
+        #     'mref', 'mrefInSmooth', 'indActive', 'cell_weights', 'scale',
+        #     'mesh', 'regmesh', 'mapping'
+
+        # ])
         Utils.setKwargs(self, **kwargs)
 
     # Properties
@@ -687,9 +692,12 @@ class BaseComboRegularization(ObjectiveFunction.ComboObjectiveFunction):
 
     @property
     def nP(self):
-        if getattr(self.mapping, 'nP') != '*':
+        if (
+            getattr(self.mapping, 'nP', None) is not None and
+            getattr(self.mapping, 'nP', None) != '*'
+        ):
             return self.mapping.nP
-        elif getattr(self.regmesh, 'nC') != '*':
+        elif getattr(self.regmesh, 'nC', None) != '*':
             return self.regmesh.nC
         else:
             return '*'

--- a/SimPEG/Regularization.py
+++ b/SimPEG/Regularization.py
@@ -388,6 +388,7 @@ class BaseRegularization(ObjectiveFunction.BaseObjectiveFunction):
     """
 
     counter = None
+    mapPair = Maps.IdentityMap
 
     def __init__(
         self, mesh=None, **kwargs
@@ -649,13 +650,10 @@ class BaseComboRegularization(ObjectiveFunction.ComboObjectiveFunction):
     mapPair = Maps.IdentityMap
 
     def __init__(
-        self, mesh, objfcts=[],
-        mapping=None, **kwargs
+        self, mesh, objfcts=[], **kwargs
     ):
 
         self._mesh = mesh
-        self._mapping = mapping
-
         super(BaseComboRegularization, self).__init__(
             objfcts=objfcts, multipliers=None
         )
@@ -1298,14 +1296,12 @@ class SparseDeriv(BaseSparse):
             else:
                 W = ((self.gamma)**0.5) * R
 
-
             theta = self.cellDiffStencil * (self.mapping * m)
             dmdx = coterminal(theta)
             r = W * dmdx
 
         else:
             r = self.W * (self.mapping * (m - self.mref))
-
 
         return 0.5 * r.dot(r)
 
@@ -1351,9 +1347,7 @@ class SparseDeriv(BaseSparse):
             theta = self.cellDiffStencil * (self.mapping * m)
             dmdx = coterminal(theta)
 
-
             r = W * dmdx
-
 
         else:
             r = self.W * (self.mapping * (m - self.mref))
@@ -1514,6 +1508,7 @@ class Sparse(BaseComboRegularization):
     def _mirror_space_to_objfcts(self, change):
         for objfct in self.objfcts:
             objfct.space = change['value']
+
 
 def coterminal(theta):
     """ Compute coterminal angle so that [-pi < theta < pi]"""

--- a/SimPEG/Regularization.py
+++ b/SimPEG/Regularization.py
@@ -92,7 +92,6 @@ class RegularizationMesh(Props.BaseSimPEG):
             self._dim = self.mesh.dim
         return self._dim
 
-
     @property
     def Pac(self):
         """

--- a/SimPEG/Survey.py
+++ b/SimPEG/Survey.py
@@ -267,10 +267,25 @@ class BaseSurvey(object):
 
     def pair(self, p):
         """Bind a problem to this survey instance using pointers"""
-        assert hasattr(p, 'surveyPair'), "Problem must have an attribute 'surveyPair'."
-        assert isinstance(self, p.surveyPair), "Problem requires survey object must be an instance of a {0!s} class.".format((p.surveyPair.__name__))
+        assert hasattr(p, 'surveyPair'), (
+            "Problem must have an attribute 'surveyPair'."
+        )
+        assert isinstance(self, p.surveyPair), (
+            "Problem requires survey object must be an instance of a {0!s} "
+            "class, not a {0!s}".format(
+                p.surveyPair.__name__, self.__class__.__name__
+            )
+        )
         if p.ispaired:
-            raise Exception("The problem object is already paired to a survey. Use prob.unpair()")
+            raise Exception(
+                "The problem object is already paired to a survey. "
+                "Use prob.unpair()"
+            )
+        elif self.ispaired:
+            raise Exception(
+                "The survey object is already paired to a problem. "
+                "Use survey.unpair()"
+            )
         self._prob = p
         p._survey = self
 
@@ -382,6 +397,7 @@ class BaseSurvey(object):
         self.dobs = self.dtrue+noise
         self.std = self.dobs*0 + std
         return self.dobs
+
 
 class LinearSurvey(BaseSurvey):
     def eval(self, f):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -354,4 +354,5 @@ nitpick_ignore = [
     ('py:func', 'discretize.utils.meshutils.meshTensor'),
     ('py:class', 'properties.base.HasProperties'),
     ('py:class', 'properties.base.base.HasProperties'),
+    ('py:class', 'SimPEG.Survey.LinearSurvey')
 ]

--- a/examples/04-grav/plot_inversion_linear.py
+++ b/examples/04-grav/plot_inversion_linear.py
@@ -147,7 +147,7 @@ def run(plotIt=True):
         # Here is the recovered denisty model
         ypanel = midx
         zpanel = -7
-        m_l2 = actvMap * reg.l2model
+        m_l2 = actvMap * IRLS.l2model
         m_l2[m_l2 == -100] = np.nan
 
         m_lp = actvMap * mrec

--- a/examples/04-grav/plot_laguna_del_maule_inversion.py
+++ b/examples/04-grav/plot_laguna_del_maule_inversion.py
@@ -157,7 +157,7 @@ def run(plotIt=True, cleanAfterRun=True):
         # Write output model and data files and print misft stats.
 
         # reconstructing l2 model mesh with air cells and active dynamic cells
-        L2out = activeMap * reg.l2model
+        L2out = activeMap * IRLS.l2model
 
         # reconstructing lp model mesh with air cells and active dynamic cells
         Lpout = activeMap*mrec

--- a/examples/05-mag/plot_MVI_Cartesian.py
+++ b/examples/05-mag/plot_MVI_Cartesian.py
@@ -154,6 +154,7 @@ def run(plotIt=True):
 
     reg = reg_p + reg_s + reg_t
 
+    reg.expose('mref')
     reg.mref = np.zeros(3*nC)
 
     # Data misfit function

--- a/examples/05-mag/plot_MVI_Spherical.py
+++ b/examples/05-mag/plot_MVI_Spherical.py
@@ -256,7 +256,7 @@ def run(plotIt=True):
         fig = plt.figure(figsize=(8, 8))
         ax2 = plt.subplot(312)
 
-        mrec_l2 = PF.Magnetics.atp2xyz(reg.l2model)
+        mrec_l2 = PF.Magnetics.atp2xyz(IRLS.l2model)
         scl_vec = np.max(mrec_l2)/np.max(m) * 0.25
         PF.Magnetics.plotModelSections(mesh, mrec_l2, normal='y',
                                        ind=ypanel, axs=ax2,

--- a/examples/05-mag/plot_inversion_linear.py
+++ b/examples/05-mag/plot_inversion_linear.py
@@ -152,7 +152,7 @@ def run(plotIt=True):
         # Here is the recovered susceptibility model
         ypanel = midx
         zpanel = -5
-        m_l2 = actvMap * reg.l2model
+        m_l2 = actvMap * IRLS.l2model
         m_l2[m_l2 == -100] = np.nan
 
         m_lp = actvMap * mrec

--- a/tests/base/test_Objectivefct.py
+++ b/tests/base/test_Objectivefct.py
@@ -435,6 +435,42 @@ class ExposeTest(unittest.TestCase):
         phi3.x = 40.
         self.assertTrue(phi1.x == 40.)
 
+    def test_nested_objfcts(self):
+        nP = 10
+        m = np.random.rand(nP)
+
+        phi1 = Props_ObjFct(nP=nP)
+        phi2 = Props_ObjFct(nP=nP)
+
+        phi1.x = 10.
+
+        phi3 = 2*phi1 + 3*phi2
+        phi3.x=10
+        phi3.expose('all')
+
+        phi4 = phi1 + 2*phi3
+        phi4.expose('all')
+        phi4.x = 20
+        print(phi2.x)
+
+        getattr(phi4, 'x')
+        setattr(phi4, 'x', 10)
+
+    def test_reg(self):
+        from SimPEG import Regularization, Mesh
+
+        mesh = Mesh.TensorMesh([10, 10, 10])
+        reg1 = Regularization.Tikhonov(mesh=mesh)
+        reg2 = Regularization.Tikhonov(mesh=mesh)
+
+        reg3 = reg1 + reg2
+
+        reg3.expose('all')
+        reg3.mapping = Maps.ExpMap(mesh)
+
+        for objfct in reg3.objfcts:
+            assert isinstance(objfct.mapping, Maps.ExpMap)
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/tests/base/test_Objectivefct.py
+++ b/tests/base/test_Objectivefct.py
@@ -20,6 +20,35 @@ class Empty_ObjFct(ObjectiveFunction.BaseObjectiveFunction):
         super(Empty_ObjFct, self).__init__()
 
 
+class Props_ObjFct(ObjectiveFunction.BaseObjectiveFunction):
+
+    def __init__(self, **kwargs):
+        super(Props_ObjFct, self).__init__(**kwargs)
+
+    @property
+    def x(self):
+        return getattr(self, '_x', None)
+
+    @x.setter
+    def x(self, val):
+        self._x = val
+
+    @property
+    def y(self):
+        return getattr(self, '_y', None)
+
+    @y.setter
+    def y(self, val):
+        self._y = val
+
+    @property
+    def z(self):
+        return getattr(self, '_z', None)
+
+    @z.setter
+    def z(self, val):
+        self._z = val
+
 class Error_if_Hit_ObjFct(ObjectiveFunction.BaseObjectiveFunction):
 
     def __init__(self):
@@ -367,6 +396,44 @@ class ExposeTest(unittest.TestCase):
             phi3.objfcts[1].mapping.__class__.__name__ == 'ExpMap'
         )
 
+    def test_not_allowed(self):
+        nP = 10
+        m = np.random.rand(nP)
+
+        phi1 = Props_ObjFct(nP=nP)
+        phi2 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
+
+        phi1.x = 10.
+
+        phi3 = 2*phi1 + 3*phi2
+
+        with self.assertRaises(Exception):
+            phi3.expose('W')
+            phi3.expose('nP')
+
+    def test_expose_all(self):
+        nP = 10
+        m = np.random.rand(nP)
+
+        phi1 = Props_ObjFct(nP=nP)
+        phi2 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
+
+        phi1.x = 10.
+
+        phi3 = 2*phi1 + 3*phi2
+
+        phi3.expose('all')
+        self.assertTrue(
+            len(
+                set(phi3._exposed).difference(
+                    set(['x', 'y', 'z', 'mapping'])
+                )
+            ) == 0
+        )
+
+        # check that it is being propagated
+        phi3.x = 40.
+        self.assertTrue(phi1.x == 40.)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/base/test_Objectivefct.py
+++ b/tests/base/test_Objectivefct.py
@@ -289,6 +289,85 @@ class TestBaseObjFct(unittest.TestCase):
         self.assertTrue(np.all(phi3.deriv2(m, v) == phi4.deriv2(m, v)))
 
 
+class ExposeTest(unittest.TestCase):
+
+    def test_expose_mapping_string(self):
+        nP = 10
+        m = np.random.rand(nP)
+
+        phi1 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
+        phi2 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
+
+        phi3 = 2*phi1 + 3*phi2
+
+        phi3.expose('mapping')
+
+        phi3.mapping = Maps.ExpMap(nP=10)
+
+        # check that it is being propagated
+        self.assertTrue(all([
+            isinstance(objfct.mapping, Maps.ExpMap) for objfct in phi3.objfcts
+        ]))
+
+        phi1.mapping = Maps.IdentityMap(nP=10)
+        self.assertTrue(
+            phi3.objfcts[0].mapping.__class__.__name__ == 'IdentityMap'
+        )
+        self.assertTrue(
+            phi3.objfcts[1].mapping.__class__.__name__ == 'ExpMap'
+        )
+
+    def test_expose_mapping_list(self):
+        nP = 10
+        m = np.random.rand(nP)
+
+        phi1 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
+        phi2 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
+
+        phi3 = 2*phi1 + 3*phi2
+
+        phi3.expose(['mapping'])
+
+        phi3.mapping = Maps.LogMap(nP=10)
+
+        # check that it is being propagated
+        self.assertTrue(all([
+            isinstance(objfct.mapping, Maps.LogMap) for objfct in phi3.objfcts
+        ]))
+
+        phi1.mapping = Maps.IdentityMap(nP=10)
+        self.assertTrue(
+            phi3.objfcts[0].mapping.__class__.__name__ == 'IdentityMap'
+        )
+        self.assertTrue(
+            phi3.objfcts[1].mapping.__class__.__name__ == 'LogMap'
+        )
+
+    def test_expose_mapping_dict(self):
+        nP = 10
+        m = np.random.rand(nP)
+
+        phi1 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
+        phi2 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
+
+        phi3 = 2*phi1 + 3*phi2
+
+        phi3.expose({'mapping': Maps.ExpMap(nP=10)})
+
+        # check that it is being propagated
+        self.assertTrue(all([
+            isinstance(objfct.mapping, Maps.ExpMap) for objfct in phi3.objfcts
+        ]))
+
+        phi1.mapping = Maps.IdentityMap(nP=10)
+        self.assertTrue(
+            phi3.objfcts[0].mapping.__class__.__name__ == 'IdentityMap'
+        )
+        self.assertTrue(
+            phi3.objfcts[1].mapping.__class__.__name__ == 'ExpMap'
+        )
+
+
 if __name__ == '__main__':
     unittest.main()
 

--- a/tests/base/test_directives.py
+++ b/tests/base/test_directives.py
@@ -9,6 +9,56 @@ from SimPEG import (
 )
 from SimPEG import PF
 
+np.random.seed(20)
+
+
+def magInvSetup():
+    mesh = Mesh.TensorMesh([8, 8, 8])
+
+    # Magnetic inducing field parameter (A,I,D)
+    B = [50000, 90, 0]
+
+    # Create a MAGsurvey
+    rx = PF.BaseMag.RxObs(
+        np.vstack([[0.25, 0.25, 0.25], [-0.25, -0.25, 0.25]])
+    )
+    srcField = PF.BaseMag.SrcField([rx], param=(B[0], B[1], B[2]))
+    survey = PF.BaseMag.LinearSurvey(srcField)
+
+    # Create the forward model operator
+    prob = PF.Magnetics.MagneticIntegral(
+        mesh, chiMap=Maps.IdentityMap(mesh), silent=True
+    )
+
+    # Pair the survey and problem
+    survey.pair(prob)
+
+    # Compute forward model some data
+    m = np.random.rand(mesh.nC)
+    survey.makeSyntheticData(m)
+
+    reg = Regularization.Sparse(mesh)
+    reg.mref = np.zeros(mesh.nC)
+
+    wr = np.sum(prob.F**2., axis=0)**0.5
+    reg.cell_weights = wr
+    reg.norms = [0, 1, 1, 1]
+    reg.eps_p, reg.eps_q = 1e-3, 1e-3
+
+    # Data misfit function
+    dmis = DataMisfit.l2_DataMisfit(survey)
+    dmis.W = 1./survey.std
+
+    # Add directives to the inversion
+    opt = Optimization.ProjectedGNCG(
+        maxIter=2, lower=-10., upper=10.,
+        maxIterCG=2
+    )
+
+    invProb = InvProblem.BaseInvProblem(dmis, reg, opt)
+
+    return mesh, invProb
+
 
 class DirectivesValidation(unittest.TestCase):
 
@@ -54,50 +104,7 @@ class DirectivesValidation(unittest.TestCase):
 class ValidationInInversion(unittest.TestCase):
 
     def setUp(self):
-        mesh = Mesh.TensorMesh([4, 4, 4])
-
-        # Magnetic inducing field parameter (A,I,D)
-        B = [50000, 90, 0]
-
-        # Create a MAGsurvey
-        rx = PF.BaseMag.RxObs(
-            np.vstack([[0.25, 0.25, 0.25], [-0.25, -0.25, 0.25]])
-        )
-        srcField = PF.BaseMag.SrcField([rx], param=(B[0], B[1], B[2]))
-        survey = PF.BaseMag.LinearSurvey(srcField)
-
-        # Create the forward model operator
-        prob = PF.Magnetics.MagneticIntegral(
-            mesh, chiMap=Maps.IdentityMap(mesh), silent=True
-        )
-
-        # Pair the survey and problem
-        survey.pair(prob)
-
-        # Compute forward model some data
-        m = np.random.rand(mesh.nC)
-        survey.makeSyntheticData(m)
-
-        reg = Regularization.Sparse(mesh)
-        reg.mref = np.zeros(mesh.nC)
-
-        wr = np.sum(prob.F**2., axis=0)**0.5
-        reg.cell_weights = wr
-        reg.norms = [0, 1, 1, 1]
-        reg.eps_p, reg.eps_q = 1e-3, 1e-3
-
-        # Data misfit function
-        dmis = DataMisfit.l2_DataMisfit(survey)
-        dmis.W = 1./survey.std
-
-        # Add directives to the inversion
-        opt = Optimization.ProjectedGNCG(
-            maxIter=2, lower=-10., upper=10.,
-            maxIterCG=2
-        )
-
-        invProb = InvProblem.BaseInvProblem(dmis, reg, opt)
-
+        mesh, invProb = magInvSetup()
         self.mesh = mesh
         self.invProb = invProb
 
@@ -123,6 +130,110 @@ class ValidationInInversion(unittest.TestCase):
             # (IRLS needs to be before update_Jacobi)
             inv = Inversion.BaseInversion(self.invProb)
             inv.directiveList = [betaest, update_Jacobi, IRLS]
+
+
+class KillInversionAfterIter(Directives.InversionDirective):
+
+    stopping_criteria_satisfied = False
+
+    def endIter(self):
+        self.stopping_criteria_satisfied = True
+
+
+class ErrorOnIter(Directives.InversionDirective):
+
+    def endIter(self):
+        if self.opt.iter > 1:
+            raise Exception
+
+
+class StoppingCriteria(unittest.TestCase):
+
+    def setUp(self):
+        mesh, invProb = magInvSetup()
+        self.mesh = mesh
+        self.invProb = invProb
+
+    def test_directive_stopping_None(self):
+        betaest = Directives.BetaEstimate_ByEig()
+        dList = [betaest]
+        directiveList = Directives.DirectiveList(*dList)
+
+        inv = Inversion.BaseInversion(
+                self.invProb, directiveList=directiveList
+            )
+
+        # directives list shouldn't stop the inversion if the directive
+        # has no stopping criteria
+        self.assertFalse(directiveList.stopping_criteria_satisfied)
+
+    def test_directive_stopping(self):
+        betaest = Directives.BetaEstimate_ByEig()
+        targetMisfit = Directives.TargetMisfit(phi_d_star=10.)
+        dList = [betaest, targetMisfit]
+        directiveList = Directives.DirectiveList(*dList)
+
+        inv = Inversion.BaseInversion(
+                self.invProb, directiveList=directiveList
+            )
+        self.invProb.startup(np.zeros(self.mesh.nC))
+
+        # should be false to start
+        self.assertFalse(directiveList.stopping_criteria_satisfied)
+
+        # if we set the inv prob phi_d below phi_d_star, the stopping
+        # criteria should be true
+        self.invProb.phi_d = 3.
+        self.assertTrue(directiveList.stopping_criteria_satisfied)
+
+    def test_directive_stopping_multiple(self):
+        betaest = Directives.BetaEstimate_ByEig()
+        targetMisfit = Directives.TargetMisfit(phi_d_star=10.)
+        targetMisfit2 = Directives.TargetMisfit(phi_d_star=2.)
+
+        dList = [betaest, targetMisfit, targetMisfit2]
+        directiveList = Directives.DirectiveList(*dList)
+
+        inv = Inversion.BaseInversion(
+                self.invProb, directiveList=directiveList
+            )
+        self.invProb.startup(np.zeros(self.mesh.nC))
+
+        # should be false to start
+        self.assertFalse(directiveList.stopping_criteria_satisfied)
+
+        # if we set the inv prob phi_d below phi_d_star for target 1
+        # stopping criteria should still be false
+        self.invProb.phi_d = 3.
+        self.assertFalse(directiveList.stopping_criteria_satisfied)
+
+        # if we set the inv prob phi_d below phi_d_star for both targets
+        # stopping criteria should still be true
+        self.invProb.phi_d = 1.
+        print(directiveList.stopping_criteria_satisfied)
+        self.assertTrue(directiveList.stopping_criteria_satisfied)
+
+    def test_stopping_executed(self):
+        inv = Inversion.BaseInversion(
+            self.invProb, directiveList=[
+                Directives.BetaEstimate_ByEig(), ErrorOnIter()
+            ]
+        )
+
+        # make sure we do run enough iterations by default to trigger exception
+        with self.assertRaises(Exception):
+            inv.run(np.zeros(self.mesh.nC))
+
+        _, invProb2 = magInvSetup()
+        inv = Inversion.BaseInversion(
+                invProb2,
+                directiveList=[
+                    Directives.BetaEstimate_ByEig(), ErrorOnIter(),
+                    KillInversionAfterIter()
+                ]
+            )
+        inv.run(np.zeros(self.mesh.nC))
+
 
 
 if __name__ == '__main__':

--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -70,8 +70,6 @@ class RegularizationTests(unittest.TestCase):
                     passed = reg.test(m)
                     self.assertTrue(passed)
 
-
-
         def test_regularization_ActiveCells(self):
             for R in dir(Regularization):
                 r = getattr(Regularization, R)

--- a/tests/pf/test_forward_Grav_Linear.py
+++ b/tests/pf/test_forward_Grav_Linear.py
@@ -62,9 +62,11 @@ class GravFwdProblemTests(unittest.TestCase):
         self.survey.pair(self.prob_x)
         dgx = self.prob_x.fields(self.model)
 
+        self.survey.unpair()
         self.survey.pair(self.prob_y)
         dgy = self.prob_y.fields(self.model)
 
+        self.survey.unpair()
         self.survey.pair(self.prob_z)
         dgz = self.prob_z.fields(self.model)
 


### PR DESCRIPTION
## Directives and Combo Objective Functions for Joint inversions 

- first pass adding an `expose()` method on a combo objective function that gives you hooks to properties of the objective functions lower in the list (as per issues #577, #559)
- update directives to work with `expose` where appropriate
- allow `dmisfit` and `reg` to be set in the init of directives (so that for example we can have two target misfits) 
- give directives a `stopping_criteria_satisfied` property. If all of the directives in the directives list that have a stopping criteria are satisfied, the inversion will stop

This is a first pass, and definitely needs a bit of cleanup, but I would appreciate feedback before going any further. 