### PR TITLE
Objective function Multipliers

### DIFF
--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -180,7 +180,7 @@ class BaseObjectiveFunction(Props.BaseSimPEG):
             objfct2 = 1 * objfct2
 
         objfctlist = self.objfcts + objfct2.objfcts
-        multipliers = self._multipliers + objfct2._multipliers
+        multipliers = self.multipliers + objfct2.multipliers
 
         return ComboObjectiveFunction(
             objfcts=objfctlist, multipliers=multipliers
@@ -232,7 +232,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
             )
 
     """
-    _multiplier_types = (float, None, Utils.Zero) + integer_types # Directive
+    _multiplier_types = (float, None, Utils.Zero, np.float64) + integer_types # Directive
 
     def __init__(self, objfcts=[], multipliers=None, **kwargs):
 
@@ -280,23 +280,41 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
         validate_list(objfcts, multipliers)
 
         self.objfcts = objfcts
-        self.__multipliers = multipliers
+        self._multipliers = multipliers
 
         super(ComboObjectiveFunction, self).__init__(**kwargs)
 
     def __len__(self):
-        return len(self._multipliers)
+        return len(self.multipliers)
 
     def __getitem__(self, key):
-        return self._multipliers[key], self.objfcts[key]
+        return self.multipliers[key], self.objfcts[key]
 
     @property
     def __len__(self):
         return self.objfcts.__len__
 
     @property
-    def _multipliers(self):
-        return self.__multipliers
+    def multipliers(self):
+        return self._multipliers
+
+    @multipliers.setter
+    def multipliers(self, value):
+        for val in value:
+            assert type(val) in self._multiplier_types, (
+                'Multiplier must be in type {} not {}'.format(
+                    self._multiplier_types, type(val)
+                )
+            )
+
+        assert len(value) == len(self.objfcts), (
+            'the length of multipliers should be the same as the number of'
+            ' objective functions ({}), not {}'.format(
+                len(self.objfcts, len(value))
+            )
+        )
+
+        self._multipliers = value
 
     def __call__(self, m, f=None):
 

--- a/SimPEG/Regularization.py
+++ b/SimPEG/Regularization.py
@@ -694,7 +694,7 @@ class BaseComboRegularization(ObjectiveFunction.ComboObjectiveFunction):
             return '*'
 
     @property
-    def _multipliers(self):
+    def multipliers(self):
         """
         Factors that multiply the objective functions that are summed together
         to build to composite regularization

--- a/tests/base/test_Objectivefct.py
+++ b/tests/base/test_Objectivefct.py
@@ -57,7 +57,7 @@ class TestBaseObjFct(unittest.TestCase):
         self.assertTrue(objfct_c(m) == objfct_a(m) + objfct_b(m))
 
         self.assertTrue(len(objfct_c.objfcts) == 2)
-        self.assertTrue(len(objfct_c._multipliers) == 2)
+        self.assertTrue(len(objfct_c.multipliers) == 2)
         self.assertTrue(len(objfct_c) == 2)
 
     def test_sum(self):
@@ -69,7 +69,7 @@ class TestBaseObjFct(unittest.TestCase):
         )
         self.assertTrue(objfct.test(eps=1e-9))
 
-        self.assertTrue(np.all(objfct._multipliers == np.r_[1., scalar]))
+        self.assertTrue(np.all(objfct.multipliers == np.r_[1., scalar]))
 
     def test_2sum(self):
         nP = 80
@@ -83,8 +83,8 @@ class TestBaseObjFct(unittest.TestCase):
         phi2 = ObjectiveFunction.L2ObjectiveFunction() + alpha2 * phi1
         self.assertTrue(phi2.test(eps=EPS))
 
-        self.assertTrue(len(phi1._multipliers) == 2)
-        self.assertTrue(len(phi2._multipliers) == 2)
+        self.assertTrue(len(phi1.multipliers) == 2)
+        self.assertTrue(len(phi2.multipliers) == 2)
 
         self.assertTrue(len(phi1.objfcts) == 2)
         self.assertTrue(len(phi2.objfcts) == 2)
@@ -93,8 +93,8 @@ class TestBaseObjFct(unittest.TestCase):
         self.assertTrue(len(phi1) == 2)
         self.assertTrue(len(phi2) == 2)
 
-        self.assertTrue(np.all(phi1._multipliers == np.r_[1., alpha1]))
-        self.assertTrue(np.all(phi2._multipliers == np.r_[1., alpha2]))
+        self.assertTrue(np.all(phi1.multipliers == np.r_[1., alpha1]))
+        self.assertTrue(np.all(phi2.multipliers == np.r_[1., alpha2]))
 
 
     def test_3sum(self):
@@ -113,7 +113,7 @@ class TestBaseObjFct(unittest.TestCase):
         m = np.random.rand(nP)
 
         self.assertTrue(
-            np.all(phi._multipliers == np.r_[alpha1, alpha2, 1./alpha3inv])
+            np.all(phi.multipliers == np.r_[alpha1, alpha2, 1./alpha3inv])
         )
 
         self.assertTrue(
@@ -179,14 +179,14 @@ class TestBaseObjFct(unittest.TestCase):
 
         self.assertTrue(phi(m) == phi1(m) + phi2(m))
 
-        phi._multipliers[0] = Utils.Zero()
+        phi.multipliers[0] = Utils.Zero()
         self.assertTrue(phi(m) == phi2(m))
 
-        phi._multipliers[0] = 1.
-        phi._multipliers[1] = Utils.Zero()
+        phi.multipliers[0] = 1.
+        phi.multipliers[1] = Utils.Zero()
 
         self.assertTrue(len(phi.objfcts) == 2)
-        self.assertTrue(len(phi._multipliers) == 2)
+        self.assertTrue(len(phi.multipliers) == 2)
         self.assertTrue(len(phi) == 2)
 
         self.assertTrue(phi(m) == phi1(m))
@@ -205,15 +205,15 @@ class TestBaseObjFct(unittest.TestCase):
         objfct = phi1 + 0*phi2
 
         self.assertTrue(len(objfct) == 2)
-        self.assertTrue(np.all(objfct._multipliers == np.r_[1, 0]))
+        self.assertTrue(np.all(objfct.multipliers == np.r_[1, 0]))
         self.assertTrue(objfct(m) == phi1(m))
         self.assertTrue(np.all(objfct.deriv(m) == phi1.deriv(m)))
         self.assertTrue(np.all(objfct.deriv2(m, v) == phi1.deriv2(m, v)))
 
-        objfct._multipliers[1] = Utils.Zero()
+        objfct.multipliers[1] = Utils.Zero()
 
         self.assertTrue(len(objfct) == 2)
-        self.assertTrue(np.all(objfct._multipliers == np.r_[1, 0]))
+        self.assertTrue(np.all(objfct.multipliers == np.r_[1, 0]))
         self.assertTrue(objfct(m) == phi1(m))
         self.assertTrue(np.all(objfct.deriv(m) == phi1.deriv(m)))
         self.assertTrue(np.all(objfct.deriv2(m, v) == phi1.deriv2(m, v)))
@@ -287,6 +287,31 @@ class TestBaseObjFct(unittest.TestCase):
         self.assertTrue(phi3(m) == phi4(m))
         self.assertTrue(np.all(phi3.deriv(m) == phi4.deriv(m)))
         self.assertTrue(np.all(phi3.deriv2(m, v) == phi4.deriv2(m, v)))
+
+    def test_updating_multipliers(self):
+        nP = 20
+
+        phi1 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
+        phi2 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
+
+        phi3 = 2*phi1 + 4*phi2
+
+        self.assertTrue(all(phi3.multipliers == np.r_[2, 4]))
+
+        phi3.multipliers[1] = 3
+        self.assertTrue(all(phi3.multipliers == np.r_[2, 3]))
+
+        phi3.multipliers = np.r_[1., 5.]
+        self.assertTrue(all(phi3.multipliers == np.r_[1., 5.]))
+
+        with self.assertRaises(Exception):
+            phi3.multipliers[0] = 'a'
+
+        with self.assertRaises(Exception):
+            phi3.multipliers = np.r_[0., 3., 4.]
+
+        with self.assertRaises(Exception):
+            phi3.multipliers = ['a', 'b']
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- bring multipliers to top level namespace for objective functions (includes the addition of a setter)
- add np.float64 to acceptable multiplier types 

Now you can change multipliers if you would like to update the multipliers of the objective functions, you can do so from the top level namespace cc @fourndo 

```python
phi1 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)
phi2 = ObjectiveFunction.L2ObjectiveFunction(nP=nP)

phi3 = 2*phi1 + 4*phi2

assert(all(phi3.multipliers == np.r_[2, 4]))

multipliers[1] = 3
assert(all(phi3.multipliers == np.r_[2, 3]))

multipliers = np.r_[1., 5.]
assert(all(phi3.multipliers == np.r_[1., 5.]))
```