### PR TITLE
Patch/zero mref

### DIFF
--- a/SimPEG/InvProblem.py
+++ b/SimPEG/InvProblem.py
@@ -77,6 +77,15 @@ class BaseInvProblem(Props.BaseSimPEG):
             print('SimPEG.InvProblem will set Regularization.mref to m0.')
             self.reg.mref = m0
 
+        if (
+            isinstance(self.reg, ObjectiveFunction.ComboObjectiveFunction) and
+            not isinstance(self.reg, Regularization.BaseComboRegularization)
+        ):
+            for fct in self.reg.objfcts:
+                if hasattr(fct, 'mref') and getattr(fct, 'mref', None) is None:
+                    print('SimPEG.InvProblem will set Regularization.mref to m0.')
+                    fct.mref = m0
+
         self.phi_d = np.nan
         self.phi_m = np.nan
 

--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -145,7 +145,7 @@ class BaseObjectiveFunction(Props.BaseSimPEG):
         v = x + 0.1*np.random.rand(len(x))
         return checkDerivative(
             lambda m: [self.deriv(m).dot(v), self.deriv2(m, v=v)],
-            x, num=num, expectedOrder=1, plotIt=plotIt, eps=1e-9, **kwargs
+            x, num=num, expectedOrder=1, plotIt=plotIt, **kwargs
         )
 
     def test(self, x=None, num=4, plotIt=False, **kwargs):

--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -242,10 +242,10 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
 
         self._nP = '*'
 
-        assert(len(objfcts)==len(multipliers)),(
+        assert(len(objfcts)==len(multipliers)), (
             "Must have the same number of Objective Functions and Multipliers "
-            "not {} and {}".format(len(objfcts),len(multipliers))
-            )
+            "not {} and {}".format(len(objfcts), len(multipliers))
+        )
 
         def validate_list(objfctlist, multipliers):
             """

--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -233,6 +233,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
 
     """
     _multiplier_types = (float, None, Utils.Zero, np.float64) + integer_types # Directive
+    _multipliers = None
 
     def __init__(self, objfcts=[], multipliers=None, **kwargs):
 

--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -142,11 +142,10 @@ class BaseObjectiveFunction(Props.BaseSimPEG):
             else:
                 x = np.random.randn(self.nP)
 
-        v = x + 0.01*np.random.rand(len(x))
+        v = x + 0.1*np.random.rand(len(x))
         return checkDerivative(
             lambda m: [self.deriv(m).dot(v), self.deriv2(m, v=v)],
-                x, num=num, expectedOrder=1,
-                plotIt=plotIt, **kwargs
+            x, num=num, expectedOrder=1, plotIt=plotIt, **kwargs
         )
 
     def test(self, x=None, num=4, plotIt=False, **kwargs):

--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -145,7 +145,7 @@ class BaseObjectiveFunction(Props.BaseSimPEG):
         v = x + 0.1*np.random.rand(len(x))
         return checkDerivative(
             lambda m: [self.deriv(m).dot(v), self.deriv2(m, v=v)],
-            x, num=num, expectedOrder=1, plotIt=plotIt, **kwargs
+            x, num=num, expectedOrder=1, plotIt=plotIt, eps=1e-9, **kwargs
         )
 
     def test(self, x=None, num=4, plotIt=False, **kwargs):

--- a/SimPEG/Regularization.py
+++ b/SimPEG/Regularization.py
@@ -524,6 +524,9 @@ class BaseRegularization(ObjectiveFunction.BaseObjectiveFunction):
             value._assertMatchesPair(self.mapPair)
         self._mapping = value
 
+    def _delta_m(self, m):
+        return (-self.mref + m)  # in case self.mref is Zero, returns type m
+
     @Utils.timeIt
     def __call__(self, m):
         """
@@ -533,7 +536,7 @@ class BaseRegularization(ObjectiveFunction.BaseObjectiveFunction):
 
             r(m) = \\frac{1}{2}
         """
-        r = self.W * (self.mapping * (m - self.mref))
+        r = self.W * (self.mapping * (self._delta_m(m)))
         return 0.5 * r.dot(r)
 
     @Utils.timeIt
@@ -555,8 +558,8 @@ class BaseRegularization(ObjectiveFunction.BaseObjectiveFunction):
 
         """
 
-        mD = self.mapping.deriv(m - self.mref)
-        r = self.W * (self.mapping * (m - self.mref))
+        mD = self.mapping.deriv(self._delta_m(m))
+        r = self.W * (self.mapping * (self._delta_m(m)))
         return mD.T * (self.W.T * r)
 
     @Utils.timeIt
@@ -583,7 +586,7 @@ class BaseRegularization(ObjectiveFunction.BaseObjectiveFunction):
             R(m) = \mathbf{W^\\top W}
 
         """
-        mD = self.mapping.deriv(m - self.mref)
+        mD = self.mapping.deriv(self._delta_m(m))
         if v is None:
             return mD.T * self.W.T * self.W * mD
 

--- a/SimPEG/Regularization.py
+++ b/SimPEG/Regularization.py
@@ -399,7 +399,7 @@ class BaseRegularization(ObjectiveFunction.BaseObjectiveFunction):
 
     # Properties
     mref = Props.Array(
-        "reference model", default=Utils.Zero()
+        "reference model"
     )
     indActive = properties.Array(
         "indices of active cells in the mesh", dtype=(bool, int)
@@ -525,6 +525,8 @@ class BaseRegularization(ObjectiveFunction.BaseObjectiveFunction):
         self._mapping = value
 
     def _delta_m(self, m):
+        if self.mref is None:
+            return m
         return (-self.mref + m)  # in case self.mref is Zero, returns type m
 
     @Utils.timeIt

--- a/tests/base/test_Objectivefct.py
+++ b/tests/base/test_Objectivefct.py
@@ -117,7 +117,7 @@ class TestBaseObjFct(unittest.TestCase):
         )
 
         self.assertTrue(
-            alpha1*phi1(m) + alpha2*phi2(m) + phi3(m)/alpha3inv == phi(m)
+           np.allclose((alpha1*phi1(m) + alpha2*phi2(m) + phi3(m)/alpha3inv), phi(m))
         )
 
         self.assertTrue(len(phi.objfcts) == 3)

--- a/tests/base/test_Objectivefct.py
+++ b/tests/base/test_Objectivefct.py
@@ -96,7 +96,6 @@ class TestBaseObjFct(unittest.TestCase):
         self.assertTrue(np.all(phi1.multipliers == np.r_[1., alpha1]))
         self.assertTrue(np.all(phi2.multipliers == np.r_[1., alpha2]))
 
-
     def test_3sum(self):
         nP = 90
 

--- a/tests/base/test_joint.py
+++ b/tests/base/test_joint.py
@@ -78,6 +78,22 @@ class DataMisfitTest(unittest.TestCase):
 
         mrec = inv.run(m0)
 
+    def test_inv_mref_setting(self):
+        reg1 = Regularization.Tikhonov(self.mesh)
+        reg2 = Regularization.Tikhonov(self.mesh)
+        reg = reg1+reg2
+        opt = Optimization.InexactGaussNewton(maxIter=10)
+        invProb = InvProblem.BaseInvProblem(self.dmiscobmo, reg, opt)
+        directives = [
+            Directives.BetaEstimate_ByEig(beta0_ratio=1e-2),
+        ]
+        inv = Inversion.BaseInversion(invProb, directiveList=directives)
+        m0 = self.model.mean() * np.ones_like(self.model)
+
+        mrec = inv.run(m0)
+
+        self.assertTrue(np.all(reg1.mref == m0))
+        self.assertTrue(np.all(reg2.mref == m0))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -9,7 +9,7 @@ from SimPEG import Mesh, Maps, Regularization, Utils, Tests, ObjectiveFunction
 from scipy.sparse.linalg import dsolve
 import inspect
 
-TOL = 1e-8
+TOL = 1e-7
 testReg = True
 testRegMesh = True
 
@@ -67,7 +67,7 @@ class RegularizationTests(unittest.TestCase):
                     reg.mref = mref
 
                     # test derivs
-                    passed = reg.test(m)
+                    passed = reg.test(m, eps=TOL)
                     self.assertTrue(passed)
 
 
@@ -211,17 +211,17 @@ class RegularizationTests(unittest.TestCase):
         reg_a = reg1 + reg2
         self.assertTrue(len(reg_a)==2)
         self.assertTrue(reg1(m) + reg2(m) == reg_a(m))
-        reg_a.test()
+        reg_a.test(eps=TOL)
 
         reg_b = 2*reg1 + reg2
         self.assertTrue(len(reg_b)==2)
         self.assertTrue(2*reg1(m) + reg2(m) == reg_b(m))
-        reg_b.test()
+        reg_b.test(eps=TOL)
 
         reg_c = reg1 + reg2/2
         self.assertTrue(len(reg_c)==2)
         self.assertTrue(reg1(m) + 0.5*reg2(m) == reg_c(m))
-        reg_c.test()
+        reg_c.test(eps=TOL)
 
     def test_mappings(self):
         mesh = Mesh.TensorMesh([8, 7, 6])
@@ -242,9 +242,9 @@ class RegularizationTests(unittest.TestCase):
             print(reg3(m), reg1(m), reg2(m))
             self.assertTrue(reg3(m) == reg1(m) + reg2(m))
 
-            reg1.test()
-            reg2.test()
-            reg3.test()
+            reg1.test(eps=TOL)
+            reg2.test(eps=TOL)
+            reg3.test(eps=TOL)
 
     def test_mref_is_zero(self):
 

--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -71,7 +71,6 @@ class RegularizationTests(unittest.TestCase):
                     self.assertTrue(passed)
 
 
-
         def test_regularization_ActiveCells(self):
             for R in dir(Regularization):
                 r = getattr(Regularization, R)


### PR DESCRIPTION
A few bug fixes with the new regularization, thanks for finding these @sgkang :)  
- add a `_delta_m(self, m)` method to the base regularization that figures out how to remove mref (if it is a Utils.Zero(), it is touchy)
- have the invprob check if the regularization is a combo and if so check all of the children mrefs (this is a patch, I would like to expose mref on the parent objective function instead) 
- add a test to make sure that mrefs are properly being set in combo regularizations 