### PR TITLE
examples gallery

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -282,7 +282,8 @@ texinfo_documents = [
 sphinx_gallery_conf = {
     # path to your examples scripts
     'examples_dirs' : '../examples',
-    'gallery_dirs'  : 'content/examples'
+    'gallery_dirs'  : 'content/examples',
+    'backreferences_dir' : False
 }
 
 


### PR DESCRIPTION
- update sphinx-gallery to include a backreferences_dir variable as per sphinx-gallery/sphinx-gallery#151
- right now, we are not using `backreferences_dir`. For examples of how we could, see http://sphinx-gallery.readthedocs.io/en/stable/index.html#examples-using-numpy-linspace