### PR TITLE
Ref/remote download

### DIFF
--- a/SimPEG/EM/Base.py
+++ b/SimPEG/EM/Base.py
@@ -256,7 +256,9 @@ class BaseEMProblem(Problem.BaseProblem):
         Inverse of the edge inner product matrix for \\(\\sigma\\).
         """
         if getattr(self, '_MeSigmaI', None) is None:
-            self._MeSigmaI = self.mesh.getEdgeInnerProduct(self.sigma, invMat=True)
+            self._MeSigmaI = self.mesh.getEdgeInnerProduct(
+                self.sigma, invMat=True
+            )
         return self._MeSigmaI
 
     # TODO: This should take a vector
@@ -425,7 +427,7 @@ class BaseEMSrc(Survey.BaseSrc):
         """
         return Utils.Zero()
 
-    def s_mDeriv(self, prob, v, adjoint = False):
+    def s_mDeriv(self, prob, v, adjoint=False):
         """
         Derivative of magnetic source term with respect to the inversion model
 
@@ -438,7 +440,7 @@ class BaseEMSrc(Survey.BaseSrc):
 
         return Utils.Zero()
 
-    def s_eDeriv(self, prob, v, adjoint = False):
+    def s_eDeriv(self, prob, v, adjoint=False):
         """
         Derivative of electric source term with respect to the inversion model
 

--- a/SimPEG/PF/MagneticsDriver.py
+++ b/SimPEG/PF/MagneticsDriver.py
@@ -11,8 +11,9 @@ class MagneticsDriver_Inv(object):
 
     def __init__(self, input_file=None):
         if input_file is not None:
-            self.basePath = os.path.sep.join(input_file.split(
-                                             os.path.sep)[:-1])
+            self.basePath = os.path.sep.join(
+                input_file.split(os.path.sep)[:-1]
+            )
             if len(self.basePath) > 0:
                 self.basePath += os.path.sep
             self.readDriverFile(input_file.split(os.path.sep)[-1])

--- a/SimPEG/Utils/__init__.py
+++ b/SimPEG/Utils/__init__.py
@@ -23,3 +23,4 @@ from . import SolverUtils
 from .coordutils import rotatePointsFromNormals, rotationMatrixFromNormals
 from .modelutils import surface2ind_topo
 from .PlotUtils import plot2Ddata, plotLayer
+from .io_utils import download

--- a/SimPEG/Utils/io_utils.py
+++ b/SimPEG/Utils/io_utils.py
@@ -227,7 +227,7 @@ def download(
     # download files
     urllist = url if isinstance(url, list) else [url]
     for u, f in zip(urllist, downloadpath):
-        print("Downloading {}...".format(u))
+        print("Downloading {}".format(u))
         urlretrieve(u, f)
         print("   saved to: " + f)
 

--- a/SimPEG/Utils/io_utils.py
+++ b/SimPEG/Utils/io_utils.py
@@ -147,13 +147,13 @@ def surface2inds(vrtx, trgl, mesh, boundaries=True, internal=True):
 
 
 def download(
-    url, path='.', overwrite=False, verbose=True
+    url, folder='.', overwrite=False, verbose=True
 ):
     """
     Function to download all files stored in a cloud directory
 
     :param str url: url or list of urls for the file(s) to be downloaded ("https://...")
-    :param str path: path to where the directory is created and files downloaded (default is the current directory)
+    :param str folder: folder to where the directory is created and files downloaded (default is the current directory)
     :param bool overwrite: overwrite if a file with the specified name already exists
     :param bool verbose: print out progress
     """
@@ -193,18 +193,18 @@ def download(
         urlretrieve = urllib.request.urlretrieve
 
     # ensure we are working with absolute paths and home directories dealt with
-    path = os.path.abspath(os.path.expanduser(path))
+    folder = os.path.abspath(os.path.expanduser(folder))
 
     # make the directory if it doesn't currently exist
-    if not os.path.exists(path):
-        os.makedirs(path)
+    if not os.path.exists(folder):
+        os.makedirs(folder)
 
     if isinstance(url, str):
         filenames = [url.split('/')[-1]]
     elif isinstance(url, list):
         filenames = [u.split('/')[-1] for u in url]
 
-    downloadpath = [os.path.sep.join([path, f]) for f in filenames]
+    downloadpath = [os.path.sep.join([folder, f]) for f in filenames]
 
     # check if the directory already exists
     for i, download in enumerate(downloadpath):

--- a/examples/04-grav/plot_laguna_del_maule_inversion.py
+++ b/examples/04-grav/plot_laguna_del_maule_inversion.py
@@ -31,11 +31,8 @@ def run(plotIt=True, cleanAfterRun=True):
     ]
 
     # Download to Downloads/SimPEGtemp
-    basePath = download(
-        [url+f for f in cloudfiles],
-        path='~/Downloads/simpegtemp',
-        overwrite=True
-    )
+    basePath = os.path.expanduser('~/Downloads/simpegtemp')
+    download([url+f for f in cloudfiles], path=basePath, overwrite=True)
 
     input_file = basePath + os.path.sep + 'LdM_input_file.inp'
     # %% User input
@@ -74,8 +71,9 @@ def run(plotIt=True, cleanAfterRun=True):
     static = driver.staticCells
     dynamic = driver.dynamicCells
 
-    staticCells = Maps.InjectActiveCells(None,
-                                         dynamic, driver.m0[static], nC=nC)
+    staticCells = Maps.InjectActiveCells(
+        None, dynamic, driver.m0[static], nC=nC
+    )
     mstart = driver.m0[dynamic]
 
     # Get index of the center

--- a/examples/04-grav/plot_laguna_del_maule_inversion.py
+++ b/examples/04-grav/plot_laguna_del_maule_inversion.py
@@ -16,7 +16,7 @@ import shutil
 import SimPEG.PF as PF
 from SimPEG import Maps, Regularization, Optimization, DataMisfit,\
                    InvProblem, Directives, Inversion
-from SimPEG.Utils.io_utils import remoteDownload
+from SimPEG.Utils.io_utils import download
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -31,10 +31,10 @@ def run(plotIt=True, cleanAfterRun=True):
     ]
 
     # Download to Downloads/SimPEGtemp
-    basePath = remoteDownload(
-        url, cloudfiles,
-        path=os.path.sep.join([os.getenv('HOME'), 'Downloads']),
-        rm_previous=True
+    basePath = download(
+        [url+f for f in cloudfiles],
+        path='~/Downloads/simpegtemp',
+        overwrite=True
     )
 
     input_file = basePath + os.path.sep + 'LdM_input_file.inp'

--- a/examples/04-grav/plot_laguna_del_maule_inversion.py
+++ b/examples/04-grav/plot_laguna_del_maule_inversion.py
@@ -32,7 +32,7 @@ def run(plotIt=True, cleanAfterRun=True):
 
     # Download to Downloads/SimPEGtemp
     basePath = os.path.expanduser('~/Downloads/simpegtemp')
-    download([url+f for f in cloudfiles], path=basePath, overwrite=True)
+    download([url+f for f in cloudfiles], folder=basePath, overwrite=True)
 
     input_file = basePath + os.path.sep + 'LdM_input_file.inp'
     # %% User input

--- a/examples/04-grav/plot_laguna_del_maule_inversion.py
+++ b/examples/04-grav/plot_laguna_del_maule_inversion.py
@@ -25,14 +25,18 @@ def run(plotIt=True, cleanAfterRun=True):
 
     # Start by downloading files from the remote repository
     url = "https://storage.googleapis.com/simpeg/Chile_GRAV_4_Miller/"
-    cloudfiles = ['LdM_grav_obs.grv', 'LdM_mesh.mesh',
-                  'LdM_topo.topo', 'LdM_input_file.inp']
+    cloudfiles = [
+        'LdM_grav_obs.grv', 'LdM_mesh.mesh',
+        'LdM_topo.topo', 'LdM_input_file.inp'
+    ]
 
-    basePath = os.path.sep.join(os.path.abspath(os.getenv('HOME')).split
-                                (os.path.sep)+['Downloads']+['SimPEGtemp'])
-    basePath = os.path.abspath(remoteDownload(url,
-                                              cloudfiles,
-                                              basePath=basePath+os.path.sep))
+    # Download to Downloads/SimPEGtemp
+    basePath = remoteDownload(
+        url, cloudfiles,
+        path=os.path.sep.join([os.getenv('HOME'), 'Downloads']),
+        rm_previous=True
+    )
+
     input_file = basePath + os.path.sep + 'LdM_input_file.inp'
     # %% User input
     # Plotting parameters, max and min densities in g/cc

--- a/examples/07-fdem/plot_heagyetal2016_casing.py
+++ b/examples/07-fdem/plot_heagyetal2016_casing.py
@@ -7,7 +7,7 @@ This example is used in the paper Heagy et al 2016 (in prep)
 from SimPEG import Mesh, Utils, Maps, Tests
 from SimPEG.EM import mu_0, FDEM, Analytics
 from SimPEG.EM.Utils import omega
-from SimPEG.Utils.io_utils import remoteDownload
+from SimPEG.Utils.io_utils import download
 # try:
 #     from pymatsolver import MumpsSolver as Solver
 #     print('using MumpsSolver')
@@ -1243,23 +1243,6 @@ class PrimSecCasingStoredResults(PrimSecCasingExample):
         'J_PrimSec_5e6Casing_50Mu_05Hz_LargeCondBody',
     ]
 
-    @property
-    def filepath(self):
-        return os.path.sep.join(
-            [os.path.abspath(os.getenv('HOME')), 'Downloads', 'SimPEGtemp']
-        )
-
-    def downloadStoredResults(self):
-        # download the results from where they are stored on google app engine
-
-        return os.path.abspath(
-            remoteDownload(
-                self.url, [self.cloudfile], path=os.path.sep.join(
-                    [os.path.abspath(os.getenv('HOME')), 'Downloads']
-                ), rm_previous=True
-            )
-        )
-
     def removeStoredResults(self):
         import shutil
         print('Removing {}'.format(self.filepath))
@@ -1267,19 +1250,18 @@ class PrimSecCasingStoredResults(PrimSecCasingExample):
 
     def run(self, plotIt=False, runTests=False, saveFig=False):
 
-        self.downloadStoredResults()
+        filepath = download(
+            self.url + self.cloudfile, path='~/Downloads/simpegtemp',
+            overwrite=True
+        )
+        self.filepath = os.path.sep.join(filepath.split(os.path.sep)[:-1])
 
         # resultsFiles = ['{filepath}{slash}{file}'.format(
         #     filepath=self.filepath, slash=os.path.sep, file=file)
         #     for file in self.cloudfiles]
         # results = [np.load(file, encoding='bytes') for file in resultsFiles]
 
-        h5f = h5py.File(
-            '{filepath}{slash}{file}'.format(
-                filepath=self.filepath, slash=os.path.sep, file=self.cloudfile
-                ), 'r'
-            )
-
+        h5f = h5py.File(filepath, 'r')
         results = [h5f[entry_name][:] for entry_name in self.entry_names]
         results = dict(zip(['primfields', 'dpredback', 'dpred', 'J'], results))
 

--- a/examples/07-fdem/plot_heagyetal2016_casing.py
+++ b/examples/07-fdem/plot_heagyetal2016_casing.py
@@ -1255,7 +1255,7 @@ class PrimSecCasingStoredResults(PrimSecCasingExample):
 
         return os.path.abspath(
             remoteDownload(
-                self.url, [self.cloudfile], basePath=self.filepath+os.path.sep
+                self.url, [self.cloudfile], path=self.filepath
             )
         )
 

--- a/examples/07-fdem/plot_heagyetal2016_casing.py
+++ b/examples/07-fdem/plot_heagyetal2016_casing.py
@@ -1251,7 +1251,7 @@ class PrimSecCasingStoredResults(PrimSecCasingExample):
     def run(self, plotIt=False, runTests=False, saveFig=False):
 
         filepath = download(
-            self.url + self.cloudfile, path='~/Downloads/simpegtemp',
+            self.url + self.cloudfile, folder='~/Downloads/simpegtemp',
             overwrite=True
         )
         self.filepath = os.path.sep.join(filepath.split(os.path.sep)[:-1])

--- a/examples/07-fdem/plot_heagyetal2016_casing.py
+++ b/examples/07-fdem/plot_heagyetal2016_casing.py
@@ -1246,8 +1246,7 @@ class PrimSecCasingStoredResults(PrimSecCasingExample):
     @property
     def filepath(self):
         return os.path.sep.join(
-            os.path.abspath(os.getenv('HOME')).split(os.path.sep) +
-            ['Downloads'] + ['SimPEGtemp']
+            [os.path.abspath(os.getenv('HOME')), 'Downloads', 'SimPEGtemp']
         )
 
     def downloadStoredResults(self):
@@ -1255,7 +1254,9 @@ class PrimSecCasingStoredResults(PrimSecCasingExample):
 
         return os.path.abspath(
             remoteDownload(
-                self.url, [self.cloudfile], path=self.filepath
+                self.url, [self.cloudfile], path=os.path.sep.join(
+                    [os.path.abspath(os.getenv('HOME')), 'Downloads']
+                ), rm_previous=True
             )
         )
 

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -319,10 +319,10 @@ class TestDownload(unittest.TestCase):
         url2 = url + cloudfiles[1]
 
         file_names = download(
-            [url1, url2], path='./test_urls', overwrite=True
+            [url1, url2], folder='./test_urls', overwrite=True
         )
         # or
-        file_name = download(url1, path='./test_url', overwrite=True)
+        file_name = download(url1, folder='./test_url', overwrite=True)
         # where
         assert isinstance(file_names, list)
         assert len(file_names) == 2

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import scipy.sparse as sp
+import os
+import shutil
 from SimPEG.Utils import (
     sdiag, sub2ind, ndgrid, mkvc, inv2X2BlockDiagonal,
     inv3X3BlockDiagonal, invPropertyTensor, makePropertyTensor, indexCube,
@@ -10,6 +12,7 @@ from SimPEG.Utils import (
 )
 from SimPEG import Mesh
 from SimPEG.Tests import checkDerivative
+
 
 TOL = 1e-8
 
@@ -316,14 +319,18 @@ class TestDownload(unittest.TestCase):
         url2 = url + cloudfiles[1]
 
         file_names = download(
-            [url1, url2], path='~/Downloads/mag_stuff', overwrite=True
+            [url1, url2], path='./test_urls', overwrite=True
         )
         # or
-        file_name = download(url1)
+        file_name = download(url1, path='./test_url', overwrite=True)
         # where
         assert isinstance(file_names, list)
         assert len(file_names) == 2
         assert isinstance(file_name, str)
+
+        # clean up
+        shutil.rmtree(os.path.expanduser('./test_urls'))
+        shutil.rmtree(os.path.expanduser('./test_url'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -5,7 +5,8 @@ import scipy.sparse as sp
 from SimPEG.Utils import (
     sdiag, sub2ind, ndgrid, mkvc, inv2X2BlockDiagonal,
     inv3X3BlockDiagonal, invPropertyTensor, makePropertyTensor, indexCube,
-    ind2sub, asArray_N_x_Dim, TensorType, diagEst, count, timeIt, Counter
+    ind2sub, asArray_N_x_Dim, TensorType, diagEst, count, timeIt, Counter,
+    download
 )
 from SimPEG import Mesh
 from SimPEG.Tests import checkDerivative
@@ -302,6 +303,27 @@ class TestDiagEst(unittest.TestCase):
         print('Testing probing. {}'.format(err))
         self.assertTrue(err < TOL)
 
+
+class TestDownload(unittest.TestCase):
+    def test_downloads(self):
+        url = "https://storage.googleapis.com/simpeg/Chile_GRAV_4_Miller/"
+        cloudfiles = [
+            'LdM_grav_obs.grv', 'LdM_mesh.mesh',
+            'LdM_topo.topo', 'LdM_input_file.inp'
+        ]
+
+        url1 = url + cloudfiles[0]
+        url2 = url + cloudfiles[1]
+
+        file_names = download(
+            [url1, url2], path='~/Downloads/mag_stuff', overwrite=True
+        )
+        # or
+        file_name = download(url1)
+        # where
+        assert isinstance(file_names, list)
+        assert len(file_names) == 2
+        assert isinstance(file_name, str)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/em/fdem/forward/test_FDEM_primsec.py
+++ b/tests/em/fdem/forward/test_FDEM_primsec.py
@@ -8,7 +8,6 @@ try:
     from pymatsolver import Pardiso as Solver
 except ImportError:
     from SimPEG import Solver as SolverLU
-from SimPEG.Utils.io_utils import remoteDownload
 
 import time
 import os

--- a/tests/pf/test_gravity_IO.py
+++ b/tests/pf/test_gravity_IO.py
@@ -4,6 +4,7 @@ from SimPEG import Mesh, PF
 from SimPEG.Utils import io_utils
 from scipy.constants import mu_0
 import shutil
+import os
 
 
 class MagSensProblemTests(unittest.TestCase):
@@ -13,11 +14,13 @@ class MagSensProblemTests(unittest.TestCase):
         cloudfiles = ['GravData.obs', 'Gaussian.topo', 'Mesh_10m.msh',
                       'ModelStart.sus', 'SimPEG_Grav_Input.inp']
 
-        self.basePath = io_utils.remoteDownload(url, cloudfiles)
+        self.basePath = io_utils.remoteDownload(
+            url, cloudfiles, rm_previous=True
+        )
 
     def test_magnetics_inversion(self):
 
-        inp_file = self.basePath + 'SimPEG_Grav_Input.inp'
+        inp_file = os.path.sep.join([self.basePath, 'SimPEG_Grav_Input.inp'])
 
         driver = PF.GravityDriver.GravityDriver_Inv(inp_file)
 
@@ -36,8 +39,12 @@ class MagSensProblemTests(unittest.TestCase):
         print(driver.eps)
 
         # Write obs to file
-        PF.Gravity.writeUBCobs(self.basePath + 'FWR_data.dat',
-                               driver.survey, driver.survey.dobs)
+        PF.Gravity.writeUBCobs(
+            os.path.sep.join(
+                [self.basePath, 'FWR_data.dat']
+            ),
+            driver.survey, driver.survey.dobs
+        )
 
         # Clean up the working directory
         shutil.rmtree(self.basePath)

--- a/tests/pf/test_gravity_IO.py
+++ b/tests/pf/test_gravity_IO.py
@@ -17,7 +17,7 @@ class MagSensProblemTests(unittest.TestCase):
         self.basePath = os.path.expanduser('~/Downloads/simpegtemp')
         self.files = io_utils.download(
             [url + f for f in cloudfiles],
-            path=self.basePath,
+            folder=self.basePath,
             overwrite=True
         )
 

--- a/tests/pf/test_gravity_IO.py
+++ b/tests/pf/test_gravity_IO.py
@@ -14,8 +14,11 @@ class MagSensProblemTests(unittest.TestCase):
         cloudfiles = ['GravData.obs', 'Gaussian.topo', 'Mesh_10m.msh',
                       'ModelStart.sus', 'SimPEG_Grav_Input.inp']
 
-        self.basePath = io_utils.remoteDownload(
-            url, cloudfiles, rm_previous=True
+        self.basePath = os.path.expanduser('~/Downloads/simpegtemp')
+        self.files = io_utils.download(
+            [url + f for f in cloudfiles],
+            path=self.basePath,
+            overwrite=True
         )
 
     def test_magnetics_inversion(self):

--- a/tests/pf/test_magnetics_IO.py
+++ b/tests/pf/test_magnetics_IO.py
@@ -16,7 +16,7 @@ class MagSensProblemTests(unittest.TestCase):
 
         self.basePath = os.path.expanduser('~/Downloads/simpegtemp')
         self.files = io_utils.download(
-            [url+f for f in cloudfiles], path=self.basePath, overwrite=True
+            [url+f for f in cloudfiles], folder=self.basePath, overwrite=True
         )
 
     def test_magnetics_inversion(self):

--- a/tests/pf/test_magnetics_IO.py
+++ b/tests/pf/test_magnetics_IO.py
@@ -14,7 +14,10 @@ class MagSensProblemTests(unittest.TestCase):
         cloudfiles = ['MagData.obs', 'Gaussian.topo', 'Mesh_10m.msh',
                       'ModelStart.sus', 'SimPEG_Mag_Input.inp']
 
-        self.basePath = io_utils.remoteDownload(url, cloudfiles)
+        self.basePath = os.path.expanduser('~/Downloads/simpegtemp')
+        self.files = io_utils.download(
+            [url+f for f in cloudfiles], path=self.basePath, overwrite=True
+        )
 
     def test_magnetics_inversion(self):
 

--- a/tests/pf/test_magnetics_IO.py
+++ b/tests/pf/test_magnetics_IO.py
@@ -4,6 +4,7 @@ from SimPEG import Mesh, PF
 from SimPEG.Utils import io_utils
 from scipy.constants import mu_0
 import shutil
+import os
 
 
 class MagSensProblemTests(unittest.TestCase):
@@ -17,7 +18,7 @@ class MagSensProblemTests(unittest.TestCase):
 
     def test_magnetics_inversion(self):
 
-        inp_file = self.basePath + 'SimPEG_Mag_Input.inp'
+        inp_file = os.path.sep.join([self.basePath, 'SimPEG_Mag_Input.inp'])
 
         driver = PF.MagneticsDriver.MagneticsDriver_Inv(inp_file)
 
@@ -36,8 +37,10 @@ class MagSensProblemTests(unittest.TestCase):
         print(driver.eps)
 
         # Write obs to file
-        PF.Magnetics.writeUBCobs(self.basePath + 'FWR_data.dat',
-                                 driver.survey, driver.survey.dobs)
+        PF.Magnetics.writeUBCobs(
+            os.path.sep.join([self.basePath, 'FWR_data.dat']),
+            driver.survey, driver.survey.dobs
+        )
 
         # Clean up the working directory
         shutil.rmtree(self.basePath)


### PR DESCRIPTION
modify the `remoteDownload` utils so that more of the string handling is done by the util as per #596 

Before
```
basePath = os.path.sep.join(os.path.abspath(os.getenv('HOME')).split(os.path.sep)+['Downloads']+['SimPEGtemp'])
basePath = os.path.abspath(remoteDownload(url, cloudfiles, basePath=basePath+os.path.sep))
```

After
```
basePath = remoteDownload(url, path='~/Downloads', overwrite=True)
```

I have also updated the examples and tests that rely on this function