### PR TITLE
Em/patch/zero util

### DIFF
--- a/SimPEG/EM/Base.py
+++ b/SimPEG/EM/Base.py
@@ -140,7 +140,7 @@ class BaseEMProblem(Problem.BaseProblem):
         Derivative of :code:`MfMui` with respect to the model.
         """
         if self.muiMap is None:
-            return Utils.Zero()
+            return Utils.spzeros(self.mesh.nF, len(self.model))
 
         return (
             self.mesh.getFaceInnerProductDeriv(self.mui)(u) * self.muiDeriv
@@ -162,7 +162,7 @@ class BaseEMProblem(Problem.BaseProblem):
         """
 
         if self.muiMap is None:
-            return Utils.Zero()
+            return Utils.spzeros(self.mesh.nF, len(self.model))
 
         if len(self.mui.shape) > 1:
             if self.mui.shape[1] > self.mesh.dim:
@@ -173,7 +173,6 @@ class BaseEMProblem(Problem.BaseProblem):
         dMfMuiI_dI = -self.MfMuiI**2
         dMf_dmui = self.mesh.getEdgeInnerProductDeriv(self.mui)(u)
         return dMfMuiI_dI * (dMf_dmui * self.muiDeriv)
-
 
     @property
     def MeMu(self):
@@ -190,7 +189,7 @@ class BaseEMProblem(Problem.BaseProblem):
         Derivative of :code:`MeMu` with respect to the model.
         """
         if self.muMap is None:
-            return Utils.Zero()
+            return Utils.spzeros(self.mesh.nE, len(self.model))
 
         return (
             self.mesh.getEdgeInnerProductDeriv(self.mu)(u) * self.muDeriv
@@ -212,7 +211,7 @@ class BaseEMProblem(Problem.BaseProblem):
         """
 
         if self.muMap is None:
-            return Utils.Zero()
+            return Utils.spzeros(self.mesh.nE, len(self.model))
 
         if len(self.mu.shape) > 1:
             if self.mu.shape[1] > self.mesh.dim:
@@ -243,13 +242,12 @@ class BaseEMProblem(Problem.BaseProblem):
         Derivative of MeSigma with respect to the model
         """
         if self.sigmaMap is None:
-            return Utils.Zero()
+            return Utils.spzeros(self.mesh.nE, len(self.model))
 
         return (
             self.mesh.getEdgeInnerProductDeriv(self.sigma)(u) *
             self.sigmaDeriv
         )
-
 
     @property
     def MeSigmaI(self):
@@ -268,7 +266,7 @@ class BaseEMProblem(Problem.BaseProblem):
         Derivative of :code:`MeSigmaI` with respect to the model
         """
         if self.sigmaMap is None:
-            return Utils.Zero()
+            return Utils.spzeros(self.mesh.nE, len(self.model))
 
         if len(self.sigma.shape) > 1:
             if self.sigma.shape[1] > self.mesh.dim:
@@ -296,7 +294,7 @@ class BaseEMProblem(Problem.BaseProblem):
         Derivative of :code:`MfRho` with respect to the model.
         """
         if self.rhoMap is None:
-            return Utils.Zero()
+            return Utils.spzeros(self.mesh.nF, len(self.model))
 
         return (
             self.mesh.getFaceInnerProductDeriv(self.rho)(u) * self.rhoDeriv
@@ -317,7 +315,7 @@ class BaseEMProblem(Problem.BaseProblem):
             Derivative of :code:`MfRhoI` with respect to the model.
         """
         if self.rhoMap is None:
-            return Utils.Zero()
+            return Utils.spzeros(self.mesh.nF, len(self.model))
 
         if len(self.rho.shape) > 1:
             if self.rho.shape[1] > self.mesh.dim:

--- a/SimPEG/EM/Base.py
+++ b/SimPEG/EM/Base.py
@@ -3,15 +3,16 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import numpy as np
 import properties
 from scipy.constants import mu_0
 
-from SimPEG import Survey
-from SimPEG import Problem
-from SimPEG import Utils
-from SimPEG import Maps
-from SimPEG import Props
-from SimPEG import Solver as SimpegSolver
+from .. import Survey
+from .. import Problem
+from .. import Utils
+from .. import Maps
+from .. import Props
+from .. import Solver as SimpegSolver
 
 
 __all__ = ['BaseEMProblem', 'BaseEMSurvey', 'BaseEMSrc']
@@ -415,7 +416,10 @@ class BaseEMSrc(Survey.BaseSrc):
         :rtype: numpy.ndarray
         :return: magnetic source term on mesh
         """
-        return Utils.Zero()
+        if prob._formulation == 'EB':
+            return np.zeros(prob.mesh.nF)
+        elif prob._formulation == 'HJ':
+            return np.zeros(prob.mesh.nE)
 
     def s_e(self, prob):
         """
@@ -425,7 +429,10 @@ class BaseEMSrc(Survey.BaseSrc):
         :rtype: numpy.ndarray
         :return: electric source term on mesh
         """
-        return Utils.Zero()
+        if prob._formulation == 'EB':
+            return np.zeros(prob.mesh.nE)
+        elif prob._formulation == 'HJ':
+            return np.zeros(prob.mesh.nF)
 
     def s_mDeriv(self, prob, v, adjoint=False):
         """
@@ -437,8 +444,13 @@ class BaseEMSrc(Survey.BaseSrc):
         :rtype: numpy.ndarray
         :return: product of magnetic source term derivative with a vector
         """
+        if adjoint is True:
+            return np.zeros_like(prob.model)
 
-        return Utils.Zero()
+        if prob._formulation == 'EB':
+            return np.zeros(prob.mesh.nF)
+        elif prob._formulation == 'HJ':
+            return np.zeros(prob.mesh.nE)
 
     def s_eDeriv(self, prob, v, adjoint=False):
         """
@@ -450,4 +462,10 @@ class BaseEMSrc(Survey.BaseSrc):
         :rtype: numpy.ndarray
         :return: product of electric source term derivative with a vector
         """
-        return Utils.Zero()
+        if adjoint is True:
+            return np.zeros_like(prob.model)
+
+        if prob._formulation == 'EB':
+            return np.zeros(prob.mesh.nE)
+        elif prob._formulation == 'HJ':
+            return np.zeros(prob.mesh.nF)

--- a/SimPEG/EM/Base.py
+++ b/SimPEG/EM/Base.py
@@ -441,7 +441,7 @@ class BaseEMSrc(Survey.BaseSrc):
         :return: product of magnetic source term derivative with a vector
         """
         if adjoint is True:
-            return np.zeros_like(prob.model)
+            return np.zeros(len(prob.model))
 
         if prob._formulation == "EB":
             return np.zeros(prob.mesh.nF)
@@ -459,7 +459,7 @@ class BaseEMSrc(Survey.BaseSrc):
         :return: product of electric source term derivative with a vector
         """
         if adjoint is True:
-            return np.zeros_like(prob.model)
+            return np.zeros(len(prob.model))
 
         if prob._formulation == "EB":
             return np.zeros(prob.mesh.nE)

--- a/SimPEG/EM/Base.py
+++ b/SimPEG/EM/Base.py
@@ -377,9 +377,7 @@ class BaseEMSrc(Survey.BaseSrc):
         :rtype: tuple
         :return: tuple with magnetic source term and electric source term
         """
-        s_m = self.s_m(prob)
-        s_e = self.s_e(prob)
-        return s_m, s_e
+        return self.s_m(prob), self.s_e(prob)
 
     def evalDeriv(self, prob, v=None, adjoint=False):
         """
@@ -414,9 +412,9 @@ class BaseEMSrc(Survey.BaseSrc):
         :rtype: numpy.ndarray
         :return: magnetic source term on mesh
         """
-        if prob._formulation == 'EB':
+        if prob._formulation == "EB":
             return np.zeros(prob.mesh.nF)
-        elif prob._formulation == 'HJ':
+        elif prob._formulation == "HJ":
             return np.zeros(prob.mesh.nE)
 
     def s_e(self, prob):
@@ -427,9 +425,9 @@ class BaseEMSrc(Survey.BaseSrc):
         :rtype: numpy.ndarray
         :return: electric source term on mesh
         """
-        if prob._formulation == 'EB':
+        if prob._formulation == "EB":
             return np.zeros(prob.mesh.nE)
-        elif prob._formulation == 'HJ':
+        elif prob._formulation == "HJ":
             return np.zeros(prob.mesh.nF)
 
     def s_mDeriv(self, prob, v, adjoint=False):
@@ -445,9 +443,9 @@ class BaseEMSrc(Survey.BaseSrc):
         if adjoint is True:
             return np.zeros_like(prob.model)
 
-        if prob._formulation == 'EB':
+        if prob._formulation == "EB":
             return np.zeros(prob.mesh.nF)
-        elif prob._formulation == 'HJ':
+        elif prob._formulation == "HJ":
             return np.zeros(prob.mesh.nE)
 
     def s_eDeriv(self, prob, v, adjoint=False):
@@ -463,7 +461,7 @@ class BaseEMSrc(Survey.BaseSrc):
         if adjoint is True:
             return np.zeros_like(prob.model)
 
-        if prob._formulation == 'EB':
+        if prob._formulation == "EB":
             return np.zeros(prob.mesh.nE)
-        elif prob._formulation == 'HJ':
+        elif prob._formulation == "HJ":
             return np.zeros(prob.mesh.nF)

--- a/SimPEG/EM/FDEM/FieldsFDEM.py
+++ b/SimPEG/EM/FDEM/FieldsFDEM.py
@@ -3,7 +3,7 @@ import scipy.sparse as sp
 import SimPEG
 from SimPEG import Utils
 from SimPEG.EM.Utils import omega
-from SimPEG.Utils import sdiag #, Zero, Identity
+from SimPEG.Utils import sdiag
 
 
 class FieldsFDEM(SimPEG.Problem.Fields):
@@ -403,7 +403,7 @@ class Fields3D_e(FieldsFDEM):
         :param SimPEG.EM.FDEM.SrcFDEM.BaseFDEMSrc src: source
         :param numpy.ndarray v: vector to take product with
         :param bool adjoint: adjoint?
-        :rtype: SimPEG.Utils.Zero
+        :rtype: numpy.ndarray
         :return: product of the electric field derivative with respect to the
             inversion model with a vector
         """
@@ -741,7 +741,7 @@ class Fields3D_b(FieldsFDEM):
         :param SimPEG.EM.FDEM.SrcFDEM.BaseFDEMSrc src: source
         :param numpy.ndarray v: vector to take product with
         :param bool adjoint: adjoint?
-        :rtype: SimPEG.Utils.Zero
+        :rtype: numpy.ndarray
         :return: product of the magnetic flux density derivative with respect
             to the inversion model with a vector
         """
@@ -852,7 +852,6 @@ class Fields3D_b(FieldsFDEM):
 
         n = int(self._aveE2CCV.shape[0] / self._nC)  # number of components
         VI = sdiag(np.kron(np.ones(n), 1./self.prob.mesh.vol))
-
 
         j = (self._edgeCurl.T * (self._MfMui * bSolution))
         for i, src in enumerate(srcList):
@@ -1090,7 +1089,7 @@ class Fields3D_j(FieldsFDEM):
         :param SimPEG.EM.FDEM.SrcFDEM.BaseFDEMSrc src: source
         :param numpy.ndarray v: vector to take product with
         :param bool adjoint: adjoint?
-        :rtype: SimPEG.Utils.Zero
+        :rtype: numpy.ndarray
         :return: product of the current density derivative with respect to the
             inversion model with a vector
         """
@@ -1432,7 +1431,7 @@ class Fields3D_h(FieldsFDEM):
         :param SimPEG.EM.FDEM.SrcFDEM.BaseFDEMSrc src: source
         :param numpy.ndarray v: vector to take product with
         :param bool adjoint: adjoint?
-        :rtype: SimPEG.Utils.Zero
+        :rtype: numpy.ndarray
         :return: product of the magnetic field derivative with respect to the
             inversion model with a vector
         """

--- a/SimPEG/EM/FDEM/FieldsFDEM.py
+++ b/SimPEG/EM/FDEM/FieldsFDEM.py
@@ -3,7 +3,7 @@ import scipy.sparse as sp
 import SimPEG
 from SimPEG import Utils
 from SimPEG.EM.Utils import omega
-from SimPEG.Utils import Zero, Identity, sdiag
+from SimPEG.Utils import sdiag #, Zero, Identity
 
 
 class FieldsFDEM(SimPEG.Problem.Fields):
@@ -351,16 +351,6 @@ class Fields3D_e(FieldsFDEM):
         self._MfMui = self.survey.prob.MfMui
         self._MfMuiDeriv = self.survey.prob.MfMuiDeriv
 
-    def _GLoc(self, fieldType):
-        if fieldType in ['e', 'eSecondary', 'ePrimary']:
-            return 'E'
-        elif fieldType in ['b', 'bSecondary', 'bPrimary']:
-            return 'F'
-        elif (fieldType == 'h') or (fieldType == 'j'):
-            return 'CCV'
-        else:
-            raise Exception('Field type must be e, b, h, j')
-
     def _ePrimary(self, eSolution, srcList):
         """
         Primary electric field from source
@@ -401,7 +391,7 @@ class Fields3D_e(FieldsFDEM):
             to the field we solved for with a vector
         """
 
-        return Identity()*v
+        return v
 
     def _eDeriv_m(self, src, v, adjoint=False):
         """
@@ -698,16 +688,6 @@ class Fields3D_b(FieldsFDEM):
         self._mui = self.survey.prob.mui
         self._nC = self.survey.prob.mesh.nC
 
-    def _GLoc(self, fieldType):
-        if fieldType in ['e', 'eSecondary', 'ePrimary']:
-            return 'E'
-        elif fieldType in ['b', 'bSecondary', 'bPrimary']:
-            return 'F'
-        elif (fieldType == 'h') or (fieldType == 'j'):
-            return'CCV'
-        else:
-            raise Exception('Field type must be e, b, h, j')
-
     def _bPrimary(self, bSolution, srcList):
         """
         Primary magnetic flux density from source
@@ -749,7 +729,7 @@ class Fields3D_b(FieldsFDEM):
             respect to the field we solved for with a vector
         """
 
-        return Identity()*du_dm_v
+        return du_dm_v
 
     def _bDeriv_m(self, src, v, adjoint=False):
         """
@@ -767,7 +747,7 @@ class Fields3D_b(FieldsFDEM):
         """
 
         # assuming primary does not depend on the model
-        return Zero()
+        return np.zeros(self.prob.mesh.nF)
 
     def _ePrimary(self, bSolution, srcList):
         """
@@ -1042,16 +1022,6 @@ class Fields3D_j(FieldsFDEM):
         self._aveE2CCV = self.survey.prob.mesh.aveE2CCV
         self._nC = self.survey.prob.mesh.nC
 
-    def _GLoc(self, fieldType):
-        if fieldType in ['h', 'hSecondary', 'hPrimary']:
-            return 'E'
-        elif fieldType in ['j', 'jSecondary', 'jPrimary']:
-            return 'F'
-        elif (fieldType == 'e') or (fieldType == 'b'):
-            return 'CCV'
-        else:
-            raise Exception('Field type must be e, b, h, j')
-
     def _jPrimary(self, jSolution, srcList):
         """
         Primary current density from source
@@ -1108,7 +1078,7 @@ class Fields3D_j(FieldsFDEM):
             to the field we solved for with a vector
         """
 
-        return Identity()*du_dm_v
+        return du_dm_v
 
     def _jDeriv_m(self, src, v, adjoint=False):
         """
@@ -1409,16 +1379,6 @@ class Fields3D_h(FieldsFDEM):
         self._aveE2CCV = self.survey.prob.mesh.aveE2CCV
         self._nC = self.survey.prob.mesh.nC
 
-    def _GLoc(self, fieldType):
-        if fieldType in ['h', 'hSecondary', 'hPrimary']:
-            return 'E'
-        elif fieldType in ['j', 'jSecondary', 'jPrimary']:
-            return 'F'
-        elif (fieldType == 'e') or (fieldType == 'b'):
-            return 'CCV'
-        else:
-            raise Exception('Field type must be e, b, h, j')
-
     def _hPrimary(self, hSolution, srcList):
         """
         Primary magnetic field from source
@@ -1460,7 +1420,7 @@ class Fields3D_h(FieldsFDEM):
             to the field we solved for with a vector
         """
 
-        return Identity()*du_dm_v
+        return du_dm_v
 
     def _hDeriv_m(self, src, v, adjoint=False):
         """

--- a/SimPEG/EM/FDEM/FieldsFDEM.py
+++ b/SimPEG/EM/FDEM/FieldsFDEM.py
@@ -747,7 +747,9 @@ class Fields3D_b(FieldsFDEM):
         """
 
         # assuming primary does not depend on the model
-        return np.zeros(self.prob.mesh.nF)
+        if adjoint is True:
+            return np.zeros_like(self.prob.model, dtype=complex)
+        return np.zeros(self.prob.mesh.nF, dtype=complex)
 
     def _ePrimary(self, bSolution, srcList):
         """

--- a/SimPEG/EM/FDEM/ProblemFDEM.py
+++ b/SimPEG/EM/FDEM/ProblemFDEM.py
@@ -190,10 +190,10 @@ class BaseFDEMProblem(BaseEMProblem):
         :return: (s_m, s_e) (nE or nF, nSrc)
         """
         Srcs = self.survey.getSrcByFreq(freq)
-        if self._formulation is 'EB':
+        if self._formulation == "EB":
             s_m = np.zeros((self.mesh.nF, len(Srcs)), dtype=complex)
             s_e = np.zeros((self.mesh.nE, len(Srcs)), dtype=complex)
-        elif self._formulation is 'HJ':
+        elif self._formulation == "HJ":
             s_m = np.zeros((self.mesh.nE, len(Srcs)), dtype=complex)
             s_e = np.zeros((self.mesh.nF, len(Srcs)), dtype=complex)
 

--- a/SimPEG/EM/FDEM/ProblemFDEM.py
+++ b/SimPEG/EM/FDEM/ProblemFDEM.py
@@ -849,16 +849,18 @@ class Problem3D_h(BaseFDEMProblem):
         :return: product of rhs deriv with a vector
         """
 
-        _, s_e = src.eval(self)
+        s_e = src.s_e(self)
         C = self.mesh.edgeCurl
         MfRho = self.MfRho
 
         MfRhoDeriv = self.MfRhoDeriv(s_e)
         if not adjoint:
             RHSDeriv = C.T * (MfRhoDeriv * v)
+            s_eDeriv = C.T * (MfRho * src.s_eDeriv(self, v))
         elif adjoint:
             RHSDeriv = MfRhoDeriv.T * (C * v)
+            s_eDeriv = src.s_eDeriv(self, MfRho.T * (C * v), adjoint)
 
-        s_mDeriv, s_eDeriv = src.evalDeriv(self, adjoint=adjoint)
-
-        return RHSDeriv + s_mDeriv(v) + C.T * (MfRho * s_eDeriv(v))
+        return (
+            RHSDeriv + src.s_mDeriv(self, v, adjoint) + s_eDeriv
+        )

--- a/SimPEG/EM/FDEM/RxFDEM.py
+++ b/SimPEG/EM/FDEM/RxFDEM.py
@@ -1,7 +1,6 @@
 import SimPEG
 
 
-
 class BaseRx(SimPEG.Survey.BaseRx):
     """
     Frequency domain receiver base class

--- a/SimPEG/EM/FDEM/SrcFDEM.py
+++ b/SimPEG/EM/FDEM/SrcFDEM.py
@@ -344,7 +344,7 @@ class MagDipole(BaseFDEMSrc):
         "frequency of the source (Hz)", required=True
     )
     loc = properties.Vector3(
-        "location of the source", default=np.r_[0.,0.,0.]
+        "location of the source", default=np.r_[0., 0., 0.]
     )
 
     def __init__(
@@ -363,7 +363,9 @@ class MagDipole(BaseFDEMSrc):
     def _warn_non_axis_aligned_sources(self, change):
         value = change['value']
         axaligned = [
-            True for vec in [np.r_[1.,0.,0.], np.r_[0.,1.,0.], np.r_[0.,0.,1.]]
+            True for vec in [
+                np.r_[1., 0., 0.], np.r_[0., 1., 0.], np.r_[0., 0., 1.]
+            ]
             if np.all(value == vec)
         ]
         if len(axaligned) != 1:
@@ -471,7 +473,8 @@ class MagDipole(BaseFDEMSrc):
             return -C.T * (MMui_s * self.bPrimary(prob))
 
     def s_eDeriv(self, prob, v, adjoint=False):
-        if not hasattr(prob, 'muMap') or not hasattr(prob, 'muiMap'):
+        # if not hasattr(prob, 'muMap') or not hasattr(prob, 'muiMap'):
+        if prob.muMap is None or prob.muiMap is None:
             if adjoint is True:
                 return np.zeros_like(prob.model)
 

--- a/SimPEG/EM/FDEM/SrcFDEM.py
+++ b/SimPEG/EM/FDEM/SrcFDEM.py
@@ -51,12 +51,15 @@ class BaseFDEMSrc(BaseEMSrc):
         :rtype: numpy.ndarray
         :return: primary magnetic flux density
         """
-        if prob._formulation == 'EB':
-            return np.zeros(prob.mesh.nF)
-        elif prob._formulation == 'HJ':
-            return np.zeros(
-                np.count_nonzero(prob.mesh.vnE) * prob.mesh.nC
-            )
+        if adjoint is True:
+            return np.zeros_like(prob.model)
+        else:
+            if prob._formulation == 'EB':
+                return np.zeros(prob.mesh.nF)
+            elif prob._formulation == 'HJ':
+                return np.zeros(
+                    np.count_nonzero(prob.mesh.vnE) * prob.mesh.nC
+                )
 
     def hPrimary(self, prob):
         """
@@ -85,6 +88,9 @@ class BaseFDEMSrc(BaseEMSrc):
         :rtype: numpy.ndarray
         :return: primary magnetic flux density
         """
+        if adjoint is True:
+            return np.zeros_like(prob.model)
+
         if prob._formulation == 'EB':
             return np.zeros(
                 np.count_nonzero(prob.mesh.vnF) * prob.mesh.nC
@@ -100,6 +106,7 @@ class BaseFDEMSrc(BaseEMSrc):
         :rtype: numpy.ndarray
         :return: primary electric field
         """
+
         if self._ePrimary is None:
             if prob._formulation == 'EB':
                 self._ePrimary = np.zeros(prob.mesh.nE)
@@ -119,6 +126,9 @@ class BaseFDEMSrc(BaseEMSrc):
         :rtype: numpy.ndarray
         :return: primary magnetic flux density
         """
+        if adjoint is True:
+            return np.zeros_like(prob.model)
+
         if prob._formulation == 'EB':
             return np.zeros(prob.mesh.nE)
         elif prob._formulation == 'HJ':
@@ -153,6 +163,9 @@ class BaseFDEMSrc(BaseEMSrc):
         :rtype: numpy.ndarray
         :return: primary magnetic flux density
         """
+        if adjoint is True:
+            return np.zeros_like(prob.model)
+
         if prob._formulation == 'EB':
             return np.zeros(
                 np.count_nonzero(prob.mesh.vnF) * prob.mesh.nC

--- a/SimPEG/EM/FDEM/SrcFDEM.py
+++ b/SimPEG/EM/FDEM/SrcFDEM.py
@@ -472,14 +472,16 @@ class MagDipole(BaseFDEMSrc):
 
     def s_eDeriv(self, prob, v, adjoint=False):
         if not hasattr(prob, 'muMap') or not hasattr(prob, 'muiMap'):
+            if adjoint is True:
+                return np.zeros_like(prob.model)
+
             if prob._formulation == 'EB':
                 return np.zeros(prob.mesh.nE)
             elif prob._formulation == 'HJ':
                 return np.zeros(prob.mesh.nF)
         else:
-            formulation = prob._formulation
 
-            if formulation == 'EB':
+            if prob._formulation == 'EB':
                 mui_s = prob.mui - 1./self.mu
                 MMui_sDeriv = prob.mesh.getFaceInnerProductDeriv(mui_s)(
                     self.bPrimary(prob)
@@ -491,14 +493,16 @@ class MagDipole(BaseFDEMSrc):
 
                 return -C.T * (MMui_sDeriv * v)
 
-            elif formulation == 'HJ':
+            elif prob._formulation == 'HJ':
+                if adjoint is True:
+                    return np.zeros_like(prob.model)
                 return np.zeros(prob.mesh.nF)
                 # raise NotImplementedError
-                mu_s = prob.mu - self.mu
-                MMui_s = prob.mesh.getEdgeInnerProduct(mu_s, invMat=True)
-                C = prob.mesh.edgeCurl.T
+                # mu_s = prob.mu - self.mu
+                # MMui_s = prob.mesh.getEdgeInnerProduct(mu_s, invMat=True)
+                # C = prob.mesh.edgeCurl.T
 
-                return -C.T * (MMui_s * self.bPrimary(prob))
+                # return -C.T * (MMui_s * self.bPrimary(prob))
 
 
 class MagDipole_Bfield(MagDipole):
@@ -615,7 +619,7 @@ class PrimSecSigma(BaseFDEMSrc):
 
     def s_e(self, prob):
         return (
-            prob.MeSigma -  prob.mesh.getEdgeInnerProduct(self.sigBack)
+            prob.MeSigma - prob.mesh.getEdgeInnerProduct(self.sigBack)
         ) * self.ePrimary(prob)
 
     def s_eDeriv(self, prob, v, adjoint=False):

--- a/SimPEG/EM/FDEM/SrcFDEM.py
+++ b/SimPEG/EM/FDEM/SrcFDEM.py
@@ -64,11 +64,11 @@ class BaseFDEMSrc(BaseEMSrc):
         :return: primary magnetic field
         """
         if prob._formulation == 'EB':
-            return = np.zeros(
+            return np.zeros(
                 np.count_nonzero(prob.mesh.vnF) * prob.mesh.nC
             )
         elif prob._formulation == 'HJ':
-            return = np.zeros(prob.mesh.nE)
+            return np.zeros(prob.mesh.nE)
 
     def hPrimaryDeriv(self, prob, v, adjoint=False):
         """

--- a/SimPEG/EM/FDEM/SrcFDEM.py
+++ b/SimPEG/EM/FDEM/SrcFDEM.py
@@ -335,8 +335,6 @@ class MagDipole(BaseFDEMSrc):
         "location of the source", default=np.r_[0., 0., 0.]
     )
 
-    _bPrimary = None
-
     def __init__(
         self, rxList, freq, loc, **kwargs
     ):

--- a/SimPEG/EM/FDEM/SurveyFDEM.py
+++ b/SimPEG/EM/FDEM/SurveyFDEM.py
@@ -2,7 +2,6 @@ import SimPEG
 from SimPEG.EM.Utils import omega
 from SimPEG.EM.Base import BaseEMSurvey
 from scipy.constants import mu_0
-from SimPEG.Utils import Zero, Identity
 from . import SrcFDEM as Src
 from . import RxFDEM as Rx
 

--- a/SimPEG/EM/NSEM/SrcNSEM.py
+++ b/SimPEG/EM/NSEM/SrcNSEM.py
@@ -24,7 +24,8 @@ class BaseNSEMSrc(FDEMBaseSrc):
     '''
 
     freq = None #: Frequency (float)
-
+    _ePrimary = None  #: Primary electric field
+    _bPrimary = None  #: Primary magnetic field
 
     def __init__(self, rxList, freq):
 

--- a/SimPEG/EM/TDEM/FieldsTDEM.py
+++ b/SimPEG/EM/TDEM/FieldsTDEM.py
@@ -4,7 +4,7 @@ import scipy.sparse as sp
 import SimPEG
 from SimPEG import Utils
 from SimPEG.EM.Utils import omega
-from SimPEG.Utils import Zero, Identity
+# from SimPEG.Utils import Zero, Identity
 
 
 class FieldsTDEM(SimPEG.Problem.TimeFields):

--- a/SimPEG/EM/TDEM/ProblemTDEM.py
+++ b/SimPEG/EM/TDEM/ProblemTDEM.py
@@ -321,7 +321,7 @@ class BaseTDEMProblem(Problem.BaseTimeProblem, BaseEMProblem):
                         tInd, f[src, ftype, tInd], ATinv_df_duT_v[isrc, :],
                         adjoint=True)
                 else:
-                    dAsubdiagT_dm_v = Utils.spzeros(len(m), len(u))
+                    dAsubdiagT_dm_v = Utils.mkvc(np.zeros_like(m))
 
                 dRHST_dm_v = self.getRHSDeriv(
                         tInd+1, src, ATinv_df_duT_v[isrc, :], adjoint=True
@@ -401,6 +401,7 @@ class BaseTDEMProblem(Problem.BaseTimeProblem, BaseEMProblem):
                     None)(self, v, adjoint, f)) + ifieldsDeriv
             )
         return ifieldsDeriv
+
 
 ###############################################################################
 #                                                                             #

--- a/SimPEG/EM/TDEM/ProblemTDEM.py
+++ b/SimPEG/EM/TDEM/ProblemTDEM.py
@@ -321,7 +321,7 @@ class BaseTDEMProblem(Problem.BaseTimeProblem, BaseEMProblem):
                         tInd, f[src, ftype, tInd], ATinv_df_duT_v[isrc, :],
                         adjoint=True)
                 else:
-                    dAsubdiagT_dm_v = Utils.Zero()
+                    dAsubdiagT_dm_v = Utils.spzeros(len(m), len(u))
 
                 dRHST_dm_v = self.getRHSDeriv(
                         tInd+1, src, ATinv_df_duT_v[isrc, :], adjoint=True
@@ -542,7 +542,9 @@ class Problem3D_b(BaseTDEMProblem):
         return Asubdiag
 
     def getAsubdiagDeriv(self, tInd, u, v, adjoint=False):
-        return Utils.Zero() * v
+        if adjoint is True:
+            return Utils.mkvc(np.zeros_like(self.model))
+        return Utils.mkvc(np.zeros_like(u))
 
     def getRHS(self, tInd):
         """
@@ -580,10 +582,10 @@ class Problem3D_b(BaseTDEMProblem):
         if adjoint:
             if self._makeASymmetric is True:
                 v = self.MfMui * v
-            if isinstance(s_e, Utils.Zero):
-                MeSigmaIDerivT_v = Utils.Zero()
-            else:
-                MeSigmaIDerivT_v = MeSigmaIDeriv(s_e).T * C.T * v
+            # if isinstance(s_e, Utils.Zero):
+            #     MeSigmaIDerivT_v = Utils.Zero()
+            # else:
+            MeSigmaIDerivT_v = MeSigmaIDeriv(s_e).T * C.T * v
 
             RHSDeriv = (
                 MeSigmaIDerivT_v + s_eDeriv( MeSigmaI.T * (C.T * v)) +
@@ -592,10 +594,10 @@ class Problem3D_b(BaseTDEMProblem):
 
             return RHSDeriv
 
-        if isinstance(s_e, Utils.Zero):
-            MeSigmaIDeriv_v = Utils.Zero()
-        else:
-            MeSigmaIDeriv_v = MeSigmaIDeriv(s_e) * v
+        # if isinstance(s_e, Utils.Zero):
+        #     MeSigmaIDeriv_v = Utils.Zero()
+        # else:
+        MeSigmaIDeriv_v = MeSigmaIDeriv(s_e) * v
 
         RHSDeriv = (
             C * MeSigmaIDeriv_v + C * MeSigmaI * s_eDeriv(v) + s_mDeriv(v)
@@ -876,7 +878,7 @@ class Problem3D_e(BaseTDEMProblem):
 
     def getRHSDeriv(self, tInd, src, v, adjoint=False):
         # right now, we are assuming that s_e, s_m do not depend on the model.
-        return Utils.Zero()
+        return Utils.mkvc(np.zeros(self.mesh.nE))
 
     def getInitialFields(self):
         """
@@ -1014,7 +1016,9 @@ class Problem3D_h(BaseTDEMProblem):
         return - 1./dt * self.MeMu
 
     def getAsubdiagDeriv(self, tInd, u, v, adjoint=False):
-        return Utils.Zero()
+        if adjoint is True:
+            return Utils.mkvc(np.zeros_like(self.model))
+        return Utils.mkvc(np.zeros_like(u))
 
     def getRHS(self, tInd):
 
@@ -1105,7 +1109,9 @@ class Problem3D_j(BaseTDEMProblem):
         return -1./dt * eye
 
     def getAsubdiagDeriv(self, tInd, u, v, adjoint=False):
-        return Utils.Zero()
+        if adjoint is True:
+            return Utils.mkvc(np.zeros_like(self.model))
+        return Utils.mkvc(np.zeros_like(u))
 
     def getRHS(self, tInd):
 
@@ -1124,5 +1130,5 @@ class Problem3D_j(BaseTDEMProblem):
         return rhs
 
     def getRHSDeriv(self, tInd, src, v, adjoint=False):
-        return Utils.Zero()  # assumes no derivs on sources
+        return Utils.mkvc(np.zeros(self.mesh.nF))  # assumes no derivs on sources
 

--- a/SimPEG/EM/TDEM/ProblemTDEM.py
+++ b/SimPEG/EM/TDEM/ProblemTDEM.py
@@ -583,9 +583,6 @@ class Problem3D_b(BaseTDEMProblem):
         if adjoint:
             if self._makeASymmetric is True:
                 v = self.MfMui * v
-            # if isinstance(s_e, Utils.Zero):
-            #     MeSigmaIDerivT_v = Utils.Zero()
-            # else:
             MeSigmaIDerivT_v = MeSigmaIDeriv(s_e).T * C.T * v
 
             RHSDeriv = (
@@ -595,9 +592,6 @@ class Problem3D_b(BaseTDEMProblem):
 
             return RHSDeriv
 
-        # if isinstance(s_e, Utils.Zero):
-        #     MeSigmaIDeriv_v = Utils.Zero()
-        # else:
         MeSigmaIDeriv_v = MeSigmaIDeriv(s_e) * v
 
         RHSDeriv = (

--- a/SimPEG/EM/TDEM/ProblemTDEM.py
+++ b/SimPEG/EM/TDEM/ProblemTDEM.py
@@ -719,7 +719,7 @@ class Problem3D_e(BaseTDEMProblem):
                     df_duT_v[src, '{}Deriv'.format(self._fieldType), tInd] = (
                         df_duT_v[src, '{}Deriv'.format(self._fieldType), tInd]
                         + Utils.mkvc(cur[0], 2)
-                        )
+                    )
                     JTv = cur[1] + JTv
 
         # no longer need this
@@ -764,11 +764,12 @@ class Problem3D_e(BaseTDEMProblem):
 
                 dAsubdiagT_dm_v = self.getAsubdiagDeriv(
                     tInd, f[src, ftype, tInd], ATinv_df_duT_v[isrc, :],
-                    adjoint=True)
+                    adjoint=True
+                )
 
                 dRHST_dm_v = self.getRHSDeriv(
-                        tInd+1, src, ATinv_df_duT_v[isrc, :], adjoint=True
-                        )  # on nodes of time mesh
+                    tInd+1, src, ATinv_df_duT_v[isrc, :], adjoint=True
+                )  # on nodes of time mesh
 
                 un_src = f[src, ftype, tInd+1]
                 # cell centered on time mesh
@@ -795,14 +796,14 @@ class Problem3D_e(BaseTDEMProblem):
                 ))
 
                 dRHST_dm_v = self.getRHSDeriv(
-                        tInd+1, src, ATinv_df_duT_v[isrc, :], adjoint=True
-                        )  # on nodes of time mesh
+                    tInd+1, src, ATinv_df_duT_v[isrc, :], adjoint=True
+                )  # on nodes of time mesh
 
                 un_src = f[src, ftype, tInd+1]
                 # cell centered on time mesh
                 dAT_dm_v = (
                     self.MeSigmaDeriv(un_src).T * ATinv_df_duT_v[isrc, :]
-                    )
+                )
 
                 JTv = JTv + Utils.mkvc(
                     -dAT_dm_v + dRHST_dm_v
@@ -879,6 +880,8 @@ class Problem3D_e(BaseTDEMProblem):
 
     def getRHSDeriv(self, tInd, src, v, adjoint=False):
         # right now, we are assuming that s_e, s_m do not depend on the model.
+        if adjoint is True:
+            return Utils.mkvc(np.zeros_like(self.model))
         return Utils.mkvc(np.zeros(self.mesh.nE))
 
     def getInitialFields(self):
@@ -937,6 +940,7 @@ class Problem3D_e(BaseTDEMProblem):
         """
         if self.Adcinv is not None:
             self.Adcinv.clean()
+
 
 ###############################################################################
 #                                                                             #
@@ -1131,5 +1135,7 @@ class Problem3D_j(BaseTDEMProblem):
         return rhs
 
     def getRHSDeriv(self, tInd, src, v, adjoint=False):
+        if adjoint is True:
+            return Utils.mkvc(np.zeros_like(self.model))
         return Utils.mkvc(np.zeros(self.mesh.nF))  # assumes no derivs on sources
 

--- a/SimPEG/EM/TDEM/SrcTDEM.py
+++ b/SimPEG/EM/TDEM/SrcTDEM.py
@@ -321,8 +321,6 @@ class MagDipole(BaseTDEMSrc):
                 return np.zeros(
                     np.count_nonzero(prob.mesh.vnE) * prob.mesh.nC
                 )
-            # return super(MagDipole, self).bInitial(prob)
-
         return self._bSrc(prob)
 
     def hInitial(self, prob):
@@ -335,7 +333,6 @@ class MagDipole(BaseTDEMSrc):
                 )
             elif prob._formulation == 'HJ':
                 self._hInitial = np.zeros(prob.mesh.nE)
-            # return super(MagDipole, self).hInitial(prob)
 
         return 1./self.mu * self._bSrc(prob)
 

--- a/SimPEG/EM/TDEM/SrcTDEM.py
+++ b/SimPEG/EM/TDEM/SrcTDEM.py
@@ -378,7 +378,6 @@ class CircularLoop(MagDipole):
     radius = properties.Float(
         "radius of the loop source", default=1., min=0.
     )
-    # waveform = None
     # loc = None
     # orientation = 'Z'
     # radius = None

--- a/SimPEG/EM/TDEM/SrcTDEM.py
+++ b/SimPEG/EM/TDEM/SrcTDEM.py
@@ -336,12 +336,6 @@ class MagDipole(BaseTDEMSrc):
 
         return 1./self.mu * self._bSrc(prob)
 
-    # def s_m(self, prob, time):
-    #     if self.waveform.hasInitialFields is False:
-    #         # raise NotImplementedError
-    #         return Zero()
-    #     return Zero()
-
     def s_e(self, prob, time):
         C = prob.mesh.edgeCurl
         b = self._bSrc(prob)
@@ -361,7 +355,6 @@ class MagDipole(BaseTDEMSrc):
             else:
                 # b = self._bfromVectorPotential(prob)
                 return C.T * (MfMui * b) * self.waveform.eval(time)
-        # return Zero()
 
         elif prob._formulation == 'HJ':
 

--- a/SimPEG/EM/TDEM/SrcTDEM.py
+++ b/SimPEG/EM/TDEM/SrcTDEM.py
@@ -18,7 +18,7 @@ from ..Base import BaseEMSrc
 ###############################################################################
 
 
-class BaseWaveform(object):
+class BaseWaveform(properties.HasProperties):
 
     hasInitialFields = properties.Bool(
         "Does the waveform have initial fields?", default=False
@@ -26,6 +26,10 @@ class BaseWaveform(object):
 
     offTime = properties.Float(
         "off-time of the source", default=0.
+    )
+
+    eps = properties.Float(
+        "times before this considered zero", default=1e-9
     )
 
     def __init__(self, **kwargs):
@@ -45,8 +49,6 @@ class BaseWaveform(object):
 
 
 class StepOffWaveform(BaseWaveform):
-
-    eps = 1e-9
 
     def __init__(self, offTime=0.):
         BaseWaveform.__init__(self, offTime=offTime, hasInitialFields=True)
@@ -81,20 +83,24 @@ class TriangularWaveform(BaseWaveform):
 
 class VTEMWaveform(BaseWaveform):
 
-    eps = 1e-9
-    offTime = 4.2e-3
-    peakTime = 2.73e-3
-    a = 3.
-    hasInitialFields = False
+    offTime = properties.Float(
+        "Time at which the transmitter is shuf off", default=4.2e-3
+    )
+    peakTime = properties.Float(
+        "Time at which the VTEM waveform is at its peak", default=2.73e-3
+    )
+    a = properties.Float(
+        "parameter controlling how quickly the waveform ramps on", default=3.
+    )
 
     def __init__(self, **kwargs):
-        BaseWaveform.__init__(self, **kwargs)
+        BaseWaveform.__init__(self, hasInitialFields=False, **kwargs)
 
     def eval(self, time):
         if time <= self.peakTime:
             return (
                 (1. - np.exp(-self.a*time/self.peakTime))/(1.-np.exp(-self.a))
-                )
+            )
         elif (time < self.offTime) and (time > self.peakTime):
             return -1. / (self.offTime-self.peakTime) * (time - self.offTime)
         else:
@@ -111,53 +117,100 @@ class BaseTDEMSrc(BaseEMSrc):
 
     # rxPair = Rx
 
-    waveformPair = BaseWaveform  #: type of waveform to pair with
-    waveform = None  #: source waveform
+    waveform = properties.Instance(
+        "Waveform of the source", BaseWaveform, default=StepOffWaveform()
+    )
+
+    # waveformPair = StepOffWaveform  #: type of waveform to pair with
     srcType = None
 
     def __init__(self, rxList, **kwargs):
-        super(BaseTDEMSrc, self).__init__(rxList, **kwargs)
-
-    @property
-    def waveform(self):
-        "A waveform instance is not None"
-        return getattr(self, '_waveform', None)
-
-    @waveform.setter
-    def waveform(self, val):
-        if self.waveform is None:
-            val._assertMatchesPair(self.waveformPair)
-            self._waveform = val
-        else:
-            self._waveform = self.StepOffWaveform(val)
-
-    def __init__(self, rxList, waveform = StepOffWaveform(), **kwargs):
-        self.waveform = waveform
+        # self.waveform = waveform
         BaseEMSrc.__init__(self, rxList, **kwargs)
 
     def bInitial(self, prob):
-        return Zero()
+        if getattr(self, '_bInitial', None) is None:
+            if prob._formulation == 'EB':
+                self._bInitial = np.zeros(prob.mesh.nF)
+            elif prob._formulation == 'HJ':
+                self._bInitial = np.zeros(
+                    np.count_nonzero(prob.mesh.vnE) * prob.mesh.nC
+                )
+        return self._bInitial
 
     def bInitialDeriv(self, prob, v=None, adjoint=False, f=None):
-        return Zero()
+        if adjoint is True:
+            return np.zeros_like(prob.model)
+
+        if prob._formulation == 'EB':
+            return np.zeros(prob.mesh.nF)
+        elif prob._formulation == 'HJ':
+            return np.zeros(
+                np.count_nonzero(prob.mesh.vnE) * prob.mesh.nC
+            )
 
     def eInitial(self, prob):
-        return Zero()
+        if getattr(self, '_eInitial', None) is None:
+            if prob._formulation == 'EB':
+                self._eInitial = np.zeros(prob.mesh.nE)
+            elif prob._formulation == 'HJ':
+                self._eInitial = np.zeros(
+                    np.count_nonzero(prob.mesh.vnF) * prob.mesh.nC
+                )
+        return self._eInitial
 
     def eInitialDeriv(self, prob, v=None, adjoint=False, f=None):
-        return Zero()
+        if adjoint is True:
+            return np.zeros_like(prob.model)
+
+        if prob._formulation == 'EB':
+            return np.zeros(prob.mesh.nE)
+        elif prob._formulation == 'HJ':
+            return np.zeros(
+                np.count_nonzero(prob.mesh.vnF) * prob.mesh.nC
+            )
 
     def hInitial(self, prob):
-        return Zero()
+        if getattr(self, '_hInitial', None) is None:
+            if prob._formulation == 'EB':
+                self._hInitial = np.zeros(
+                    np.count_nonzero(prob.mesh.vnF) * prob.mesh.nC
+                )
+            elif prob._formulation == 'HJ':
+                self._hInitial = np.zeros(prob.mesh.nE)
+        return self._hInitial
 
     def hInitialDeriv(self, prob, v=None, adjoint=False, f=None):
-        return Zero()
+        if adjoint is True:
+            return np.zeros_like(prob.model)
+
+        if prob._formulation == 'EB':
+            return np.zeros(
+                np.count_nonzero(prob.mesh.vnF) * prob.mesh.nC
+            )
+        elif prob._formulation == 'HJ':
+            return np.zeros(prob.mesh.nE)
 
     def jInitial(self, prob):
-        return Zero()
+        if getattr(self, '_jInitial', None) is None:
+            if prob._formulation == 'EB':
+                self._jInitial = np.zeros(
+                    np.count_nonzero(prob.mesh.vnF) * prob.mesh.nC
+                )
+            elif prob._formulation == 'HJ':
+                self._jInitial = np.zeros(prob.mesh.nF)
+        return self._jInitial
 
     def jInitialDeriv(self, prob, v=None, adjoint=False, f=None):
-        return Zero()
+        if adjoint is True:
+            return np.zeros_like(prob.model)
+
+        if prob._formulation == 'EB':
+            return np.zeros(
+                np.count_nonzero(prob.mesh.vnF) * prob.mesh.nC
+            )
+        elif prob._formulation == 'HJ':
+            return np.zeros(prob.mesh.nF)
 
     def eval(self, prob, time):
         s_m = self.s_m(prob, time)
@@ -177,16 +230,16 @@ class BaseTDEMSrc(BaseEMSrc):
             )
 
     def s_m(self, prob, time):
-        return Zero()
+        return super(BaseTDEMSrc, self).s_m(prob)  # base knows the size
 
     def s_e(self, prob, time):
-        return Zero()
+        return super(BaseTDEMSrc, self).s_e(prob)  # base knows the size
 
     def s_mDeriv(self, prob, time, v=None, adjoint=False):
-        return Zero()
+        return super(BaseTDEMSrc, self).s_mDeriv(prob, v, adjoint)
 
     def s_eDeriv(self, prob, time, v=None, adjoint=False):
-        return Zero()
+        return super(BaseTDEMSrc, self).s_eDeriv(prob, v, adjoint)
 
 
 class MagDipole(BaseTDEMSrc):
@@ -214,7 +267,9 @@ class MagDipole(BaseTDEMSrc):
     def _warn_non_axis_aligned_sources(self, change):
         value = change['value']
         axaligned = [
-            True for vec in [np.r_[1.,0.,0.], np.r_[0.,1.,0.], np.r_[0.,0.,1.]]
+            True for vec in [
+                np.r_[1., 0., 0.], np.r_[0., 1., 0.], np.r_[0., 0., 1.]
+            ]
             if np.all(value == vec)
         ]
         if len(axaligned) != 1:
@@ -260,6 +315,13 @@ class MagDipole(BaseTDEMSrc):
 
         if self.waveform.hasInitialFields is False:
             return Zero()
+            if prob._formulation == 'EB':
+                return np.zeros(prob.mesh.nF)
+            elif prob._formulation == 'HJ':
+                return np.zeros(
+                    np.count_nonzero(prob.mesh.vnE) * prob.mesh.nC
+                )
+            # return super(MagDipole, self).bInitial(prob)
 
         return self._bSrc(prob)
 
@@ -267,14 +329,21 @@ class MagDipole(BaseTDEMSrc):
 
         if self.waveform.hasInitialFields is False:
             return Zero()
+            if prob._formulation == 'EB':
+                self._hInitial = np.zeros(
+                    np.count_nonzero(prob.mesh.vnF) * prob.mesh.nC
+                )
+            elif prob._formulation == 'HJ':
+                self._hInitial = np.zeros(prob.mesh.nE)
+            # return super(MagDipole, self).hInitial(prob)
 
         return 1./self.mu * self._bSrc(prob)
 
-    def s_m(self, prob, time):
-        if self.waveform.hasInitialFields is False:
-            # raise NotImplementedError
-            return Zero()
-        return Zero()
+    # def s_m(self, prob, time):
+    #     if self.waveform.hasInitialFields is False:
+    #         # raise NotImplementedError
+    #         return Zero()
+    #     return Zero()
 
     def s_e(self, prob, time):
         C = prob.mesh.edgeCurl
@@ -288,7 +357,7 @@ class MagDipole(BaseTDEMSrc):
                 # if time > 0.0:
                 #     return Zero()
                 if prob._fieldType == 'b':
-                    return Zero()
+                    return np.zeros(prob.mesh.nE)
                 elif prob._fieldType == 'e':
                     # Compute s_e from vector potential
                     return C.T * (MfMui * b)
@@ -305,7 +374,7 @@ class MagDipole(BaseTDEMSrc):
                 # if time > 0.0:
                 #     return Zero()
                 if prob._fieldType == 'h':
-                    return Zero()
+                    return np.zeros(prob.mesh.nF)
                 elif prob._fieldType == 'j':
                     # Compute s_e from vector potential
                     return C * h
@@ -346,14 +415,14 @@ class LineCurrent(BaseTDEMSrc):
     :param list rxList: receiver list
     :param bool integrate: Integrate the source term (multiply by Me) [False]
     """
-    waveform = None
+    # waveform = None
     loc = None
     mu = mu_0
     srcType = "Galvanic"
 
     def __init__(self, rxList, **kwargs):
         self.integrate = False
-        BaseEMSrc.__init__(self, rxList, **kwargs)
+        BaseTDEMSrc.__init__(self, rxList, **kwargs)
 
     def Mejs(self, prob):
         if getattr(self, '_Mejs', None) is None:
@@ -364,8 +433,9 @@ class LineCurrent(BaseTDEMSrc):
             px = self.loc[:, 0]
             py = self.loc[:, 1]
             pz = self.loc[:, 2]
-            self._Mejs = getSourceTermLineCurrentPolygon(x0, hx, hy, hz,
-                                                         px, py, pz)
+            self._Mejs = getSourceTermLineCurrentPolygon(
+                x0, hx, hy, hz, px, py, pz
+            )
         return self._Mejs
 
     def getRHSdc(self, prob):
@@ -378,7 +448,7 @@ class LineCurrent(BaseTDEMSrc):
         if self.waveform.eval(0) == 1.:
             raise Exception("Not implemetned for computing b!")
         else:
-            return Zero()
+            return super(LineCurrent, self).bInitial(prob)
 
     def eInitial(self, prob):
         if self.waveform.hasInitialFields:
@@ -386,7 +456,7 @@ class LineCurrent(BaseTDEMSrc):
             soldc = prob.Adcinv * RHSdc
             return - prob.mesh.nodalGrad * soldc
         else:
-            return Zero()
+            return super(LineCurrent, self).eInitial(prob)
 
     def eInitialDeriv(self, prob, v=None, adjoint=False, f=None):
         if self.waveform.hasInitialFields:
@@ -401,10 +471,7 @@ class LineCurrent(BaseTDEMSrc):
                 edcDerivT = prob.getAdcDeriv(edc, vec, adjoint=adjoint)
                 return edcDerivT
         else:
-            return Zero()
-
-    def s_m(self, prob, time):
-        return Zero()
+            return super(LineCurrent, self).eInitialDeriv(prob, v, adjoint, f)
 
     def s_e(self, prob, time):
         return self.Mejs(prob) * self.waveform.eval(time)

--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -339,7 +339,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
         :param numpy.ndarray m: model
         :param SimPEG.Fields f: Fields object (if applicable)
         """
-        g = Utils.Zero()
+        g = np.zeros_like(m)
         for i, phi in enumerate(self):
             multiplier, objfct = phi
             if multiplier == 0.: # don't evaluate the fct
@@ -361,7 +361,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
         :param numpy.ndarray v: vector we are multiplying by
         :param SimPEG.Fields f: Fields object (if applicable)
         """
-        H = Utils.Zero()
+        H = Utils.spzeros(len(m), len(m))
         for i, phi in enumerate(self):
             multiplier, objfct = phi
             if multiplier == 0.: # don't evaluate the fct

--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -339,7 +339,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
         :param numpy.ndarray m: model
         :param SimPEG.Fields f: Fields object (if applicable)
         """
-        g = np.zeros_like(m)
+        g = Utils.mkvc(np.zeros_like(m))
         for i, phi in enumerate(self):
             multiplier, objfct = phi
             if multiplier == 0.: # don't evaluate the fct

--- a/SimPEG/ObjectiveFunction.py
+++ b/SimPEG/ObjectiveFunction.py
@@ -339,7 +339,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
         :param numpy.ndarray m: model
         :param SimPEG.Fields f: Fields object (if applicable)
         """
-        g = Utils.mkvc(np.zeros_like(m))
+        g = np.zeros_like(m)
         for i, phi in enumerate(self):
             multiplier, objfct = phi
             if multiplier == 0.: # don't evaluate the fct
@@ -349,7 +349,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
                     g += multiplier * objfct.deriv(m, f=f[i])
                 else:
                     g += multiplier * objfct.deriv(m)
-        return g
+        return Utils.mkvc(g)
 
     def deriv2(self, m, v=None, f=None):
         """
@@ -361,7 +361,10 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
         :param numpy.ndarray v: vector we are multiplying by
         :param SimPEG.Fields f: Fields object (if applicable)
         """
-        H = Utils.spzeros(len(m), len(m))
+        if v is None:
+            H = Utils.spzeros(len(m), len(m))
+        else:
+            H = np.zeros_like(m)
         for i, phi in enumerate(self):
             multiplier, objfct = phi
             if multiplier == 0.: # don't evaluate the fct

--- a/SimPEG/Props.py
+++ b/SimPEG/Props.py
@@ -28,7 +28,7 @@ class Array(SphinxProp, properties.Array):
     class_info = 'a numpy, Zero or Identity array'
 
     def validate(self, instance, value):
-        if isinstance(value, (Utils.Zero, Utils.Identity)):
+        if isinstance(value, (Utils.Zero, Utils.Identity)) or value is None:
             return value
         return super(Array, self).validate(instance, value)
 

--- a/SimPEG/Props.py
+++ b/SimPEG/Props.py
@@ -307,14 +307,14 @@ class Derivative(SphinxProp, properties.GettableProperty):
 
         def fget(self):
             if scope.physical_property is None:
-                return Utils.Zero()
+                return None
             if scope.mapping is None:
-                return Utils.Zero()
+                return None
             mapping = getattr(self, scope.mapping.name)
             if mapping is None:
-                return Utils.Zero()
+                return None
             if self.model is None:
-                return Utils.Zero()
+                return None
 
             return mapping.deriv(self.model)
 

--- a/SimPEG/Regularization.py
+++ b/SimPEG/Regularization.py
@@ -429,7 +429,7 @@ class BaseRegularization(ObjectiveFunction.BaseObjectiveFunction):
 
     @properties.validator('mref')
     def _validate_mref(self, change):
-        if not isinstance(change['value'], Utils.Zero) and self.nP != '*':
+        if change['value'] is not None and self.nP != '*':
             assert len(change['value']) == self.nP, (
                 'mref must be length {}'.format(self.nP)
             )
@@ -667,7 +667,7 @@ class BaseComboRegularization(ObjectiveFunction.ComboObjectiveFunction):
         for fct in self.objfcts:
             if getattr(fct, 'mrefInSmooth', None) is not None:
                 if self.mrefInSmooth is False:
-                    fct.mref = np.zeros((self.nP,))
+                    fct.mref = None
                 else:
                     fct.mref = change['value']
             else:
@@ -1057,7 +1057,7 @@ class SmoothDeriv(BaseRegularization):
         )
 
         if self.mrefInSmooth is False:
-            self.mref = Utils.Zero()
+            self.mref = None
 
     @property
     def _multiplier_pair(self):
@@ -1190,7 +1190,7 @@ class Tikhonov(BaseComboRegularization):
     def __init__(
         self, mesh,
         alpha_s=1e-6, alpha_x=1.0, alpha_y=1.0, alpha_z=1.0,
-        alpha_xx=Utils.Zero(), alpha_yy=Utils.Zero(), alpha_zz=Utils.Zero(),
+        alpha_xx=0., alpha_yy=0., alpha_zz=0.,
         **kwargs
     ):
 

--- a/SimPEG/Regularization.py
+++ b/SimPEG/Regularization.py
@@ -525,7 +525,7 @@ class BaseRegularization(ObjectiveFunction.BaseObjectiveFunction):
     def _delta_m(self, m):
         if self.mref is None:
             return m
-        return (-self.mref + m)  # in case self.mref is Zero, returns type m
+        return (m - self.mref)  # in case self.mref is Zero, returns type m
 
     @Utils.timeIt
     def __call__(self, m):
@@ -667,7 +667,7 @@ class BaseComboRegularization(ObjectiveFunction.ComboObjectiveFunction):
         for fct in self.objfcts:
             if getattr(fct, 'mrefInSmooth', None) is not None:
                 if self.mrefInSmooth is False:
-                    fct.mref = Utils.Zero()
+                    fct.mref = np.zeros((self.nP,))
                 else:
                     fct.mref = change['value']
             else:

--- a/tests/base/test_Props.py
+++ b/tests/base/test_Props.py
@@ -147,7 +147,7 @@ class TestPropMaps(unittest.TestCase):
             assert np.all(PM.sigma == np.r_[1., 2., 3.])
             PM = pickle.loads(pickle.dumps(PM))
             assert PM.sigmaMap is None
-            assert PM.sigmaDeriv == 0
+            assert PM.sigmaDeriv is None
 
             del PM.model
             # sigma is not changed
@@ -167,8 +167,8 @@ class TestPropMaps(unittest.TestCase):
         PM.rho = np.r_[1., 2., 3.]
         assert PM.rhoMap is None
         assert PM.sigmaMap is None
-        assert PM.rhoDeriv == 0
-        assert PM.sigmaDeriv == 0
+        assert PM.rhoDeriv is None
+        assert PM.sigmaDeriv is None
         assert np.all(PM.sigma == 1.0 / np.r_[1., 2., 3.])
 
         PM.sigmaMap = expMap
@@ -198,7 +198,7 @@ class TestPropMaps(unittest.TestCase):
 
         PM.rho = np.r_[1., 2., 3.]
         assert PM.sigmaMap is None
-        assert PM.sigmaDeriv == 0
+        assert PM.sigmaDeriv is None
         assert np.all(PM.sigma == 1.0 / np.r_[1., 2., 3.])
 
         PM.sigmaMap = expMap
@@ -269,7 +269,7 @@ class TestPropMaps(unittest.TestCase):
         PM.model = np.ones(2)
         PM.summary()
         PM.validate()
-        assert PM.KsDeriv == 0
+        assert PM.KsDeriv is None
 
     def test_nested(self):
         PM = NestedModels()

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -304,6 +304,8 @@ class TestSequenceFunctions(unittest.TestCase):
         assert len(np.where(indtopoCC)[0]) == 8729
         assert len(np.where(indtopoN)[0]) == 8212
 
+        os.remove(file2load)
+
 
 class TestDiagEst(unittest.TestCase):
 

--- a/tests/em/fdem/inverse/adjoint/test_FDEM_adjointHJ.py
+++ b/tests/em/fdem/inverse/adjoint/test_FDEM_adjointHJ.py
@@ -17,7 +17,8 @@ MU = mu_0
 freq = 1e-1
 addrandoms = True
 
-SrcList = ['RawVec', 'MagDipole'] #or 'MAgDipole_Bfield', 'CircularLoop', 'RawVec'
+SrcList = ['RawVec', 'MagDipole']  #or 'MagDipole_Bfield', 'CircularLoop', 'RawVec'
+
 
 def adjointTest(fdemType, comp):
     prb = getFDEMProblem(fdemType, comp, SrcList, freq)

--- a/tests/em/tdem/test_TDEM_DerivAdjoint.py
+++ b/tests/em/tdem/test_TDEM_DerivAdjoint.py
@@ -1,21 +1,20 @@
 from __future__ import division, print_function
 import unittest
 import numpy as np
-from SimPEG import Mesh, Maps, SolverLU, Tests
+from SimPEG import Mesh, Maps, Tests
 from SimPEG import EM
 
 try:
-    from pymatsolver import PardisoSolver
-    Solver = PardisoSolver
+    from pymatsolver import PardisoSolver as Solver
 except ImportError:
-    Solver = SolverLU
+    from SimPEG import SolverLU as Solver
 
 plotIt = False
 
 testDeriv = True
 testAdjoint = True
 
-TOL = 1e-4
+TOL_Adjoint = 1e-4
 
 np.random.seed(10)
 
@@ -113,7 +112,7 @@ class TDEM_DerivTests(unittest.TestCase):
         tInd = 2  # not actually used
         V1 = v.dot(prb.getAdiagDeriv(tInd, u, m))
         V2 = m.dot(prb.getAdiagDeriv(tInd, u, v, adjoint=True))
-        passed = np.abs(V1-V2) < TOL * (np.abs(V1) + np.abs(V2))/2.
+        passed = np.abs(V1-V2) < TOL_Adjoint * (np.abs(V1) + np.abs(V2))/2.
         print('AdjointTest {prbtype} {v1} {v2} {passed}'.format(
             prbtype=prbtype, v1=V1, v2=V2, passed=passed))
         self.assertTrue(passed)
@@ -147,7 +146,7 @@ class TDEM_DerivTests(unittest.TestCase):
         e = np.random.randn(prb.mesh.nE)
         V1 = e.dot(f._eDeriv_m(1, prb.survey.srcList[0], m))
         V2 = m.dot(f._eDeriv_m(1, prb.survey.srcList[0], e, adjoint=True))
-        tol = TOL * (np.abs(V1) + np.abs(V2)) / 2.
+        tol = TOL_Adjoint * (np.abs(V1) + np.abs(V2)) / 2.
         passed = np.abs(V1-V2) < tol
 
         print ('    ', V1, V2, np.abs(V1-V2), tol, passed)
@@ -163,7 +162,7 @@ class TDEM_DerivTests(unittest.TestCase):
         e = np.random.randn(prb.mesh.nE)
         V1 = e.dot(f._eDeriv_u(1, prb.survey.srcList[0], b))
         V2 = b.dot(f._eDeriv_u(1, prb.survey.srcList[0], e, adjoint=True))
-        tol = TOL * (np.abs(V1) + np.abs(V2)) / 2.
+        tol = TOL_Adjoint * (np.abs(V1) + np.abs(V2)) / 2.
         passed = np.abs(V1-V2) < tol
 
         print ('    ', V1, V2, np.abs(V1-V2), tol, passed)
@@ -231,7 +230,7 @@ class TDEM_DerivTests(unittest.TestCase):
 
 
 
-# ====== TEST Jtvec ========== #
+# # ====== TEST Jtvec ========== #
 
     if testAdjoint:
 
@@ -248,7 +247,7 @@ class TDEM_DerivTests(unittest.TestCase):
             d = np.random.randn(prb.survey.nD)
             V1 = d.dot(prb.Jvec(m0, m))
             V2 = m.dot(prb.Jtvec(m0, d))
-            tol = TOL * (np.abs(V1) + np.abs(V2)) / 2.
+            tol = TOL_Adjoint * (np.abs(V1) + np.abs(V2)) / 2.
             passed = np.abs(V1-V2) < tol
 
             print('AdjointTest {prbtype} {v1} {v2} {passed}'.format(

--- a/tests/em/utils/test_linecurrents.py
+++ b/tests/em/utils/test_linecurrents.py
@@ -1,16 +1,18 @@
 import numpy as np
+import os
 from SimPEG.EM.Utils.CurrentUtils import (
     getStraightLineCurrentIntegral, getSourceTermLineCurrentPolygon
     )
 import unittest
 from SimPEG.Utils import io_utils
 
+
 class LineCurrentTests(unittest.TestCase):
 
     def setUp(self):
         url = 'https://storage.googleapis.com/simpeg/tests/em_utils/'
-        cloudfiles = ['currents.npy']
-        self.basePath = io_utils.remoteDownload(url, cloudfiles)
+        cloudfile = 'currents.npy'
+        self.basePath = io_utils.download(url + cloudfile)
 
     def test(self):
 
@@ -22,8 +24,9 @@ class LineCurrentTests(unittest.TestCase):
         sy_true = np.r_[0.265625, 0.096875, 0.096875, 0.040625]
         sz_true = np.r_[0.1605, 0.057, 0.057, 0.0255]
 
-        sx, sy, sz = getStraightLineCurrentIntegral(hx, hy, hz,
-                                                    ax, ay, az, bx, by, bz)
+        sx, sy, sz = getStraightLineCurrentIntegral(
+            hx, hy, hz, ax, ay, az, bx, by, bz
+        )
 
         s_true = np.r_[sx_true, sy_true, sz_true]
         s = np.r_[sx, sy, sz]
@@ -49,8 +52,7 @@ class LineCurrentTests(unittest.TestCase):
         xorig = np.r_[0., 0., 0.]
 
         out = getSourceTermLineCurrentPolygon(xorig, hx, hy, hz, px, py, pz)
-        fname = self.basePath + "currents.npy"
-        out_true = np.load(fname)
+        out_true = np.load(self.basePath)
         err = np.linalg.norm(out-out_true)
         print (">> Test getSourceTermLineCurrentPolygon")
 
@@ -61,6 +63,8 @@ class LineCurrentTests(unittest.TestCase):
             print (("Failed, Error = %d") % (err))
 
         self.assertTrue(passed)
+
+        os.remove(self.basePath)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Remove use of Utils.Zero() in EM code and instead be explicit about sizes of Zero vectors that are returned and passed around. 

`Utils.Zero()` is too touchy. order of operations matters `a + Utils.Zero()` does not do the same thing as `Utils.Zero() + a` and it behaves differently on different operating systems (including the most recent travis failures on dev: https://travis-ci.org/simpeg/simpeg/builds/238426219). On my machine, I cannot reproduce those errors. 

This also promotes us being clear about sizes of vectors, matrices, which I think is a good thing anyways.  