### PR TITLE
Update Regularization.py

### DIFF
--- a/SimPEG/Regularization.py
+++ b/SimPEG/Regularization.py
@@ -1145,7 +1145,7 @@ class Tikhonov(BaseComboRegularization):
     def __init__(
         self, mesh,
         alpha_s=1e-6, alpha_x=1.0, alpha_y=1.0, alpha_z=1.0,
-        alpha_xx=1., alpha_yy=1., alpha_zz=1.,
+        alpha_xx=0., alpha_yy=0., alpha_zz=0.,
         **kwargs
     ):
 

--- a/SimPEG/Regularization.py
+++ b/SimPEG/Regularization.py
@@ -1145,7 +1145,7 @@ class Tikhonov(BaseComboRegularization):
     def __init__(
         self, mesh,
         alpha_s=1e-6, alpha_x=1.0, alpha_y=1.0, alpha_z=1.0,
-        alpha_xx=Utils.Zero(), alpha_yy=Utils.Zero(), alpha_zz=Utils.Zero(),
+        alpha_xx=1., alpha_yy=1., alpha_zz=1.,
         **kwargs
     ):
 


### PR DESCRIPTION
remove Zero class for alpha_xx, alpha_yy, alpha_zz
this makes a problem 
Objectivefunction.py Line 387 when sqrt is used.
`curW = np.sqrt(mult) * fct.W`