### PR TITLE
Add SumMap and HomogeneousMap

### DIFF
--- a/SimPEG/Directives.py
+++ b/SimPEG/Directives.py
@@ -753,10 +753,10 @@ class Update_lin_PreCond(InversionDirective):
                 for reg in self.reg.objfcts:
                     reg_diag.append(self.invProb.beta*(reg.W.T*reg.W).diagonal())
 
-                diagA = np.sum(self.prob.G**2., axis=0) + np.hstack(reg_diag)
+                diagA = self.prob.getJtJdiag(self.invProb.model) + np.hstack(reg_diag)
 
             else:
-                diagA = (np.sum(self.prob.G**2., axis=0) +
+                diagA = (self.prob.getJtJdiag(self.invProb.model) +
                          self.invProb.beta*(self.reg.W.T*self.reg.W).diagonal())
 
             PC = Utils.sdiag((self.mapping.deriv(None).T * diagA)**-1.)
@@ -776,10 +776,10 @@ class Update_lin_PreCond(InversionDirective):
                 for reg in self.reg.objfcts:
                     reg_diag.append(self.invProb.beta*(reg.W.T*reg.W).diagonal())
 
-                diagA = np.sum(self.prob.G**2., axis=0) + np.hstack(reg_diag)
+                diagA = self.prob.getJtJdiag(self.invProb.model) + np.hstack(reg_diag)
 
             else:
-                diagA = (np.sum(self.prob.G**2., axis=0) +
+                diagA = (self.prob.getJtJdiag(self.invProb.model) +
                          self.invProb.beta*(self.reg.W.T*self.reg.W).diagonal())
 
             PC = Utils.sdiag((self.mapping.deriv(None).T * diagA)**-1.)

--- a/SimPEG/Maps.py
+++ b/SimPEG/Maps.py
@@ -254,10 +254,15 @@ class ComboMap(IdentityMap):
                     )
                 )
 
-            if isinstance(m, ComboMap):
-                self.maps += m.maps
-            elif isinstance(m, IdentityMap):
+            if np.any([isinstance(m, SumMap), isinstance(m, IdentityMap)]):
                 self.maps += [m]
+            elif isinstance(m, ComboMap):
+                self.maps += m.maps
+            else:
+                raise ValueError(
+                    'Map[{0!s}] not supported',
+                    m.__class__.__name__
+                )
 
     @property
     def shape(self):
@@ -328,6 +333,155 @@ class Projection(IdentityMap):
 
     def _transform(self, m):
         return m[self.index]
+
+    @property
+    def shape(self):
+        """
+        Shape of the matrix operation (number of indices x nP)
+        """
+        return self._shape
+
+    def deriv(self, m, v=None):
+        """
+            :param numpy.array m: model
+            :rtype: scipy.sparse.csr_matrix
+            :return: derivative of transformed model
+        """
+
+        if v is not None:
+            return self.P * v
+        return self.P
+
+
+class SumMap(ComboMap):
+    """
+        A map to add model parameters contributing to the
+        forward operation e.g. F(m) = F(g(x) + h(y))
+
+        Assumes that the model vectors defined by g(x) and h(y)
+        are equal in length.
+        Allows to assume different things about the model m:
+        i.e. parametric + voxel models
+    """
+    def __init__(self, maps, **kwargs):
+        IdentityMap.__init__(self, None, **kwargs)
+
+        self.maps = []
+        for ii, m in enumerate(maps):
+            assert isinstance(m, IdentityMap), "Unrecognized data type, "
+            "inherit from an IdentityMap or ComboMap!"
+
+            if (
+                ii > 0 and not (self.shape == '*' or m.shape == '*') and
+                not self.shape == m.shape
+               ):
+
+                raise ValueError(
+                    'Dimension mismatch in map[{0!s}] ({1!s}, {2!s}) '
+                    'and map[{3!s}] ({4!s}, {5!s}).'.format(
+                        self.maps[0].__class__.__name__,
+                        self.maps[0].shape[0],
+                        self.maps[0].shape[1],
+                        m.__class__.__name__,
+                        m.shape[0],
+                        m.shape[1]
+                    )
+                )
+
+            self.maps += [m]
+
+    @property
+    def shape(self):
+
+        return (self.maps[0].shape[0], self.maps[0].shape[1])
+
+    @property
+    def nP(self):
+        """Number of model properties.
+
+           The number of cells in the
+           last dimension of the mesh."""
+        return self.maps[0][-1].nP
+
+    def _transform(self, m):
+
+        for ii, map_i in enumerate(self.maps):
+
+            m0 = m.copy()
+
+            m0 = map_i * m0
+
+            if ii == 0:
+                mout = m0
+            else:
+                mout += m0
+        return mout
+
+    def deriv(self, m, v=None):
+
+        for ii, map_i in enumerate(self.maps):
+
+            m0 = m.copy()
+
+            if v is not None:
+                deriv = v
+            else:
+                deriv = 1
+
+            deriv = map_i.deriv(m0, v=deriv)
+
+            if ii == 0:
+                sumDeriv = deriv
+            else:
+                sumDeriv += deriv
+
+        return sumDeriv
+
+
+class HomogeneousMap(IdentityMap):
+    """
+        A map to group model cells into an homogeneous unit
+
+        :param list index: list of bool for each homogeneous unit
+
+    """
+    nBlock = 1  # Variable allowing to stack same Map over multiple sets
+
+    def __init__(self, index, **kwargs):
+        assert isinstance(index, (list)), (
+            'index must be a list, not {}'.format(type(index)))
+
+        super(HomogeneousMap, self).__init__(**kwargs)
+
+        self.index = index
+
+    @property
+    def P(self):
+
+        if getattr(self, '_P', None) is None:
+            nP = len(self.index[0])
+            # sparse projection matrix
+            row = []
+            col = []
+            val = []
+            for ii, ind in enumerate(self.index):
+
+                row += [ii]*ind.sum()
+                col += np.where(ind)[0].tolist()
+                val += [1]*ind.sum()
+
+            P = sp.csr_matrix(
+                (val, (row, col)), shape=(len(self.index), nP)
+            ).T
+
+            self._P = sp.block_diag([P for ii in range(self.nBlock)])
+
+            self._shape = self.nBlock*nP, self.nBlock*len(self.index),
+
+        return self._P
+
+    def _transform(self, m):
+        return self.P * m
 
     @property
     def shape(self):

--- a/SimPEG/Maps.py
+++ b/SimPEG/Maps.py
@@ -401,7 +401,7 @@ class SumMap(ComboMap):
 
            The number of cells in the
            last dimension of the mesh."""
-        return self.maps[0][-1].nP
+        return self.maps[-1].shape[1]
 
     def _transform(self, m):
 
@@ -426,10 +426,9 @@ class SumMap(ComboMap):
             if v is not None:
                 deriv = v
             else:
-                deriv = 1
+                deriv = sp.eye(self.nP)
 
             deriv = map_i.deriv(m0, v=deriv)
-
             if ii == 0:
                 sumDeriv = deriv
             else:
@@ -454,6 +453,7 @@ class HomogeneousMap(IdentityMap):
         super(HomogeneousMap, self).__init__(**kwargs)
 
         self.index = index
+        self._shape = self.P.shape
 
     @property
     def P(self):

--- a/SimPEG/PF/Magnetics.py
+++ b/SimPEG/PF/Magnetics.py
@@ -39,11 +39,11 @@ class MagneticIntegral(Problem.LinearProblem):
 
         else:
 
-            return self.G.dot(m)
+            return self.G.dot(self.chiMap * m)
 
-    def fwr_rem(self):
-        # TODO check if we are inverting for M
-        return self.G.dot(self.chiMap(m))
+    # def fwr_rem(self):
+    #     # TODO check if we are inverting for M
+    #     return self.G.dot(self.chiMap * self.model)
 
     def fields(self, m, **kwargs):
         self.model = m
@@ -78,6 +78,11 @@ class MagneticIntegral(Problem.LinearProblem):
             self._G = self.Intrgl_Fwr_Op()
 
         return self._G
+
+    @property
+    def modelMap(self):
+
+        return self.chiMap
 
     def Intrgl_Fwr_Op(self, m=None, Magnetization="ind"):
 
@@ -205,12 +210,12 @@ class MagneticIntegral(Problem.LinearProblem):
             if self.forwardOnly:
 
                 if self.rtype == 'tmi':
-                    fwr_out[ii] = (Ptmi.dot(np.vstack((tx, ty, tz)))*Mxyz).dot(m)
+                    fwr_out[ii] = (Ptmi.dot(np.vstack((tx, ty, tz)))*Mxyz).dot(self.chiMap * m)
 
                 elif self.rtype == 'xyz':
-                    fwr_out[ii] = (tx*Mxyz).dot(m)
-                    fwr_out[ii+ndata] = (ty*Mxyz).dot(m)
-                    fwr_out[ii+2*ndata] = (tz*Mxyz).dot(m)
+                    fwr_out[ii] = (tx*Mxyz).dot(self.chiMap * m)
+                    fwr_out[ii+ndata] = (ty*Mxyz).dot(self.chiMap * m)
+                    fwr_out[ii+2*ndata] = (tz*Mxyz).dot(self.chiMap * m)
 
             else:
 
@@ -266,7 +271,7 @@ class MagneticVector(MagneticIntegral):
 
             # m = np.hstack([m, mii])
 
-            return self.G.dot(m)
+            return self.G.dot(self.chiMap * m)
 
     @property
     def G(self):
@@ -302,9 +307,9 @@ class MagneticAmplitude(MagneticIntegral):
 
         else:
             if m is None:
-                m = self.chiMap*self.model
+                m = self.model
 
-            Bxyz = self.G.dot(m)
+            Bxyz = self.G.dot(self.chiMap * m)
 
             return self.calcAmpData(Bxyz)
 
@@ -351,10 +356,7 @@ class MagneticAmplitude(MagneticIntegral):
 
             ndata = self.survey.srcField.rxList[0].locs.shape[0]
 
-            # Get field data
-            m = self.chiMap*self.model
-
-            Bxyz = self.G.dot(m)
+            Bxyz = self.G.dot(self.chiMap * self.model)
 
             Bamp = self.calcAmpData(Bxyz)
 

--- a/SimPEG/Problem.py
+++ b/SimPEG/Problem.py
@@ -288,10 +288,16 @@ class LinearProblem(BaseProblem):
         self._modelMap = val
 
     def fields(self, m):
-        return self.G.dot(m)
+        return self.G.dot(self.modelMap * m)
+
+    def getJ(self, m):
+        return self.G * self.modelMap.deriv(m)
 
     def Jvec(self, m, v, f=None):
-        return self.G.dot(v)
+        return self.G.dot(self.modelMap.deriv(m) * v)
 
     def Jtvec(self, m, v, f=None):
-        return self.G.T.dot(v)
+        return self.modelMap.deriv(m).T*self.G.T.dot(v)
+
+    def getJtJdiag(self, m):
+        return np.sum(self.getJ(m)**2., axis=0)


### PR DESCRIPTION
Two new maps added to the framework.

**HomogeneousMap**: Allows to invert for groups of model cells under the assumption to have homogeneous physical properties. Useful to invert for best-fitting value of geological model. 

**SumMap**: Allow to decompose the physical property model into components, such that the forward model F(m) = F(g(x) + h(y)), 
where g(x) and h(y) are different parameter spaces. For example:
g(x): HomogeneousMap * WireMap
h(y): WireMap
Each model space can be regularized on a different mesh and with different assumptions.

- [ ] Test maps
- [ ] Write example
