### PR TITLE
Printversion revisions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ install:
 script:
   # - nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s
   - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then
-      cd docs; make html-noplot ; cd ../ ;
+      cd docs; travis_wait 30 make html-noplot ; cd ../ ;
     else
       nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   matrix:
     - TEST_DIR=tests/em/fdem/inverse/derivs
     - TEST_DIR=tests/em/tdem
-    - TEST_DIR="tests/em/static tests/seis tests/base"
+    - TEST_DIR="tests/em/static tests/seis tests/base tests/utils"
     - TEST_DIR=tests/flow
     - TEST_DIR="tests/em/nsem/forward tests/em/nsem/inversion"
     - TEST_DIR=tests/em/fdem/inverse/adjoint

--- a/SimPEG/Fields.py
+++ b/SimPEG/Fields.py
@@ -16,12 +16,13 @@ class Fields(object):
 
     """
 
-    #: Known fields,   a dict with locations, e.g. {"e": "E", "phi": "CC"}
+    #: Known fields, a dict with locations, e.g. ``{"e": "E", "phi": "CC"}``
     knownFields = None
-    #: Aliased fields, a dict with [alias, location, function], e.g. {"b":["e","F",lambda(F,e,ind)]}
+    #: Aliased fields, a dict with [alias, location, function], e.g. ``{"b": ["e", "F", lambda(F,e,ind)]}``
     aliasFields = None
     #: dtype is the type of the storage matrix. This can be a dictionary.
     dtype = float
+
 
     def __init__(self, mesh, survey, **kwargs):
         self.survey = survey

--- a/SimPEG/Utils/printinfo.py
+++ b/SimPEG/Utils/printinfo.py
@@ -1,6 +1,6 @@
 """
-:mod:`printinfo` -- Tools to print date, time, and version information
-======================================================================
+`printinfo` -- Tools to print date, time, and version information
+=================================================================
 
 Print or return date, time, and package version information in any environment
 (Jupyter notebook, IPython console, Python console, QT console), either as
@@ -113,11 +113,13 @@ def versions(mode='print', add_pckg=None, ncol=4):
 
 
     **Returns**
+
     Depending on ``mode`` (HTML-instance; plain text; html as plain text; or
     nothing, only printing to stdout).
 
 
     **Examples**
+
     >>> import pytest
     >>> import dateutil
     >>> from SimPEG import versions

--- a/SimPEG/Utils/printinfo.py
+++ b/SimPEG/Utils/printinfo.py
@@ -91,8 +91,8 @@ def versions(mode='print', add_pckg=None, ncol=4):
 
     This is a wrapper for ``versions_html`` and ``versions_text``.
 
-    Parameters
-    ----------
+    **Parameters**
+
     mode : string, optional; {<'print'>, 'HTML', 'Pretty', 'plain', 'html'}
         Defaults to 'print':
             - 'print': Prints text-version to stdout, nothing returned.
@@ -112,14 +112,12 @@ def versions(mode='print', add_pckg=None, ncol=4):
         ``mode='HTML'`` or ``mode='html'``. Defaults to 3.
 
 
-    Returns
-    -------
+    **Returns**
     Depending on ``mode`` (HTML-instance; plain text; html as plain text; or
     nothing, only printing to stdout).
 
 
-    Examples
-    --------
+    **Examples**
     >>> import pytest
     >>> import dateutil
     >>> from SimPEG import versions

--- a/SimPEG/Utils/printinfo.py
+++ b/SimPEG/Utils/printinfo.py
@@ -23,6 +23,7 @@ All modules provided in ``add_pckg`` are also shown. They have to be imported
 before ``versions`` is called.
 
 """
+from __future__ import print_function
 
 # Mandatory modules
 import sys
@@ -223,7 +224,7 @@ def versions_text(add_pckg=None):
 
     # Width for text-version
     n = 54
-    text = '\n' + n*'-' + '\n'
+    text = u'\n' + ''.join(n*['-']) + '\n'
 
     # Date and time info as title
     text += time.strftime('  %a %b %d %H:%M:%S %Y %Z\n\n')
@@ -248,8 +249,7 @@ def versions_text(add_pckg=None):
             text += '  '+txt+'\n'
 
     # Finish
-    text += n*'-'
-
+    text += ''.join(n*['-'])
     return text
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
+    'sphinxcontrib.napoleon',
     'matplotlib.sphinxext.plot_directive',
     'sphinx_gallery.gen_gallery',
     'edit_on_github',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,8 @@ extensions = [
     'edit_on_github',
 ]
 
+# numpydoc_show_class_members = False
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/content/api_core/api_Utils.rst
+++ b/docs/content/api_core/api_Utils.rst
@@ -5,6 +5,14 @@ Utils
     :members:
     :undoc-members:
 
+Version
+=======
+
+.. automodule:: SimPEG.Utils.printinfo
+    :members:
+    :undoc-members:
+
+
 Matrix Utilities
 ================
 

--- a/examples/06-dc/plot_dc_schlumberger_array.py
+++ b/examples/06-dc/plot_dc_schlumberger_array.py
@@ -22,7 +22,7 @@ inversion example. Note that we have 3D forward modeling mesh.
 
 from SimPEG import (
     Mesh, Maps, DataMisfit, Regularization, Optimization,
-    InvProblem, Directives, Inversion
+    InvProblem, Directives, Inversion, versions
 )
 from SimPEG.Utils import plotLayer
 try:
@@ -266,3 +266,10 @@ ax[1].set_ylim(-500, 0)
 ax[1].set_xlabel('Conductivity (S/m)', fontsize=25)
 ax[1].set_ylabel('Depth (m)', fontsize=25)
 ax[1].set_title('(b)', fontsize=25)
+
+###############################################################################
+# Print the version of SimPEG and dependencies
+# --------------------------------------------
+#
+
+versions()

--- a/examples/07-fdem/plot_loop_loop_2Dinversion.py
+++ b/examples/07-fdem/plot_loop_loop_2Dinversion.py
@@ -20,7 +20,7 @@ from pymatsolver import Pardiso as Solver
 from SimPEG import (
     Mesh, Maps, Optimization,
     DataMisfit, Regularization, InvProblem,
-    Inversion, Directives
+    Inversion, Directives, versions
 )
 from SimPEG.EM import FDEM
 from SimPEG.Utils import mkvc
@@ -335,6 +335,13 @@ cb.set_label("$\log(\sigma)$")
 
 plt.tight_layout()
 plt.show()
+
+###############################################################################
+# Print the version of SimPEG and dependencies
+# --------------------------------------------
+#
+
+versions()
 
 ###############################################################################
 # Moving Forward

--- a/examples/09-tdem/plot_inductive_src_permeable_target.py
+++ b/examples/09-tdem/plot_inductive_src_permeable_target.py
@@ -21,7 +21,7 @@ from pymatsolver import Pardiso
 import time
 
 from SimPEG.EM import TDEM
-from SimPEG import Utils, Maps
+from SimPEG import Utils, Maps, versions
 
 ###############################################################################
 # Model Parameters
@@ -260,3 +260,10 @@ for a, v in zip(ax, ["magnetostatic", "late_ontime", "diff"]):
         max_r=200
     )
 plt.tight_layout()
+
+###############################################################################
+# Print the version of SimPEG and dependencies
+# --------------------------------------------
+#
+
+versions()

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,3 +17,4 @@ vectormath
 wheel
 pytest
 geoana
+sphinxcontrib-napoleon

--- a/tests/utils/test_printinfo.py
+++ b/tests/utils/test_printinfo.py
@@ -1,4 +1,7 @@
 import pip
+import unittest
+import sys
+import io
 
 # Optional imports
 try:
@@ -10,66 +13,83 @@ from SimPEG import versions
 from SimPEG.Utils import printinfo
 
 
-def test_versions(capsys):
+class TestVersion(unittest.TestCase):
 
-    # Check the default
-    versions()
-    out1, _ = capsys.readouterr()
+    def catch_version_stdout(self, *args, **kwargs):
 
-    # Check one of the standard packages
-    assert 'numpy' in out1
+        # Check the default
+        stdout = sys.stdout
+        sys.stdout = io.StringIO()
 
-    # Check the 'auto'-version, providing a package
-    versions(add_pckg=pip)
-    out1b, _ = capsys.readouterr()
+        # print the versions
+        versions(*args, **kwargs)
 
-    # Check the provided package, with number
-    assert pip.__version__ + ' : pip' in out1b
+        # catch the output
+        out1 = sys.stdout.getvalue()
+        sys.stdout = stdout
 
-    # Check the 'text'-version, providing a package as tuple
-    versions('print', add_pckg=(pip, ))
-    out2, _ = capsys.readouterr()
+        return out1
 
-    # They have to be the same, except time (run at slightly different times)
-    assert out1b[75:] == out2[75:]
+    def test_version_defaults(self):
 
-    # Check the 'Pretty'/'plain'-version, providing a package as list
-    out3 = versions('plain', add_pckg=[pip, ])
-    out3b = printinfo.versions_text(add_pckg=[pip, ])
-    out3c = versions('Pretty', add_pckg=[pip, ])
+        # Check the default
+        out1 = self.catch_version_stdout()
 
-    # They have to be the same, except time (run at slightly different times)
-    assert out3[75:] == out3b[75:]
-    if IPython:
-        assert out3[75:] == out3c.data[75:]
-    else:
-        assert out3c is None
+        # Check one of the standard packages
+        assert 'numpy' in out1
 
-    # Check one of the standard packages
-    assert 'numpy' in out3
+        # Check the 'auto'-version, providing a package
+        out1b = self.catch_version_stdout(add_pckg=pip)
 
-    # Check the provided package, with number
-    assert pip.__version__ + ' : pip' in out3
+        # Check the provided package, with number
+        assert pip.__version__ + ' : pip' in out1b
 
-    # Check 'HTML'/'html'-version, providing a package as a list
-    out4 = versions('html', add_pckg=[pip])
-    out4b = printinfo.versions_html(add_pckg=[pip])
-    out4c = versions('HTML', add_pckg=[pip])
+        # Check the 'text'-version, providing a package as tuple
+        out2 = self.catch_version_stdout('print', add_pckg=(pip, ))
 
-    assert 'numpy' in out4
-    assert 'td style=' in out4
+        # They have to be the same, except time (run at slightly different times)
+        assert out1b[75:] == out2[75:]
 
-    # They have to be the same, except time (run at slightly different times)
-    assert out4[50:] == out4b[50:]
-    if IPython:
-        assert out4[50:] == out4c.data[50:]
-    else:
-        assert out4c is None
+        # Check the 'Pretty'/'plain'-version, providing a package as list
+        out3 = versions('plain', add_pckg=[pip, ])
+        out3b = printinfo.versions_text(add_pckg=[pip, ])
+        out3c = versions('Pretty', add_pckg=[pip, ])
 
-    # Check row of provided package, with number
-    teststr = "<td style='text-align: right; background-color: #ccc; "
-    teststr += "border: 2px solid #fff;'>"
-    teststr += pip.__version__
-    teststr += "</td>\n    <td style='"
-    teststr += "text-align: left; border: 2px solid #fff;'>pip</td>"
-    assert teststr in out4
+        # They have to be the same, except time (run at slightly different times)
+        assert out3[75:] == out3b[75:]
+        if IPython:
+            assert out3[75:] == out3c.data[75:]
+        else:
+            assert out3c is None
+
+        # Check one of the standard packages
+        assert 'numpy' in out3
+
+        # Check the provided package, with number
+        assert pip.__version__ + ' : pip' in out3
+
+        # Check 'HTML'/'html'-version, providing a package as a list
+        out4 = versions('html', add_pckg=[pip])
+        out4b = printinfo.versions_html(add_pckg=[pip])
+        out4c = versions('HTML', add_pckg=[pip])
+
+        assert 'numpy' in out4
+        assert 'td style=' in out4
+
+        # They have to be the same, except time (run at slightly different times)
+        assert out4[50:] == out4b[50:]
+        if IPython:
+            assert out4[50:] == out4c.data[50:]
+        else:
+            assert out4c is None
+
+        # Check row of provided package, with number
+        teststr = "<td style='text-align: right; background-color: #ccc; "
+        teststr += "border: 2px solid #fff;'>"
+        teststr += pip.__version__
+        teststr += "</td>\n    <td style='"
+        teststr += "text-align: left; border: 2px solid #fff;'>pip</td>"
+        assert teststr in out4
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## updates
- convert test on printversion from pytest to unittest (see issue #702) 
- updates to docstrings
- add version to a couple of the notebook-styled examples

## todos
- [ ] check into the docs failure on 2.7
- [ ] think about docs: currently, we use the basic, vanilla sphinx formatting (i.e. https://github.com/simpeg/simpeg/blob/master/SimPEG/Utils/codeutils.py#L9) instead of napoleon. @prisae: I haven't done much digging into the napoleon extension - it looks like the end-product is a bit different in terms of style - or should they be identical? Right now, I have enabled the napoleon extension, so we can have both
![image](https://user-images.githubusercontent.com/6361812/41987526-4a9048f8-79ee-11e8-884a-1791824f2b90.png) see issue #703 
 