### PR TITLE
Fix Zenodo DOI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ SimPEG
     :target: https://www.codacy.com/app/lindseyheagy/simpeg?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=simpeg/simpeg&amp;utm_campaign=Badge_Grade
     :alt: codacy
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1345805.svg
-   :target: https://doi.org/10.5281/zenodo.1345805
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.596373.svg
+   :target: https://doi.org/10.5281/zenodo.596373
 
 .. image:: https://img.shields.io/badge/Slack-simpeg-4B0082.svg?logo=slack
     :target: http://slack.simpeg.xyz

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ SimPEG
     :target: https://www.codacy.com/app/lindseyheagy/simpeg?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=simpeg/simpeg&amp;utm_campaign=Badge_Grade
     :alt: codacy
 
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1162997.svg
-   :target: https://doi.org/10.5281/zenodo.1162997
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1345805.svg
+   :target: https://doi.org/10.5281/zenodo.1345805
 
 .. image:: https://img.shields.io/badge/Slack-simpeg-4B0082.svg?logo=slack
     :target: http://slack.simpeg.xyz


### PR DESCRIPTION
Just noted that the current Zenodo DOI points to version 0.7.1 from January 2018. Zenodo has a cool feature, a DOI for a project that always links to the newest version, and lists all zenodos ever released for that piece of work. For SimPEG, it is [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.596373.svg)](https://doi.org/10.5281/zenodo.596373)

Edit: Corrected Zenodo