### PR TITLE
fix std in DataMisfit and possible bug in PlotUtils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,6 @@ install:
     else
       conda install --quiet --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib cython ipython h5py;
     fi
-  - travis_wait 30 mvn install
 
   - pip install -r requirements_dev.txt
   - python setup.py install
@@ -79,7 +78,6 @@ install:
 # Run test
 script:
   # - nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s
-  #- travis_wait 30 sleep 1800 &
   - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then
       cd docs; travis_wait 30 make html-noplot ; cd ../ ;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ install:
 # Run test
 script:
   # - nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s
+  - travis_wait 30 sleep 1800 &
   - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then
       cd docs; travis_wait 30 make html-noplot ; cd ../ ;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,11 +81,7 @@ script:
   - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then
       cd docs; travis_wait 30 make html-noplot ; cd ../ ;
     else
-      if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
-        travis_wait 30 nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
-      else
-        nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
-      fi;
+      nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - DEPLOY_DIR=tests/docs
     - MASTER_BRANCH=master
     - GAE_PROJECT=simpegdocs
-    - DOCS_PY=2.7  # deploy docs from 2.7
+    - DOCS_PY=3.6  # deploy docs from 3.6
     - PYPI_PY=3.6 # deploy to pypi from python 3.6
 
   matrix:
@@ -60,7 +60,7 @@ install:
 
   - pip install -r requirements_dev.txt
   - python setup.py install
-  - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
+  - if [ "$TEST_DIR" = "$DEPLOY_DIR" ]; then
       if [ ! -d ${HOME}/google-cloud-sdk ]; then curl https://sdk.cloud.google.com | bash; fi ;
       pip install google-compute-engine;
       openssl aes-256-cbc -K $encrypted_7e0a8632ac3f_key -iv $encrypted_7e0a8632ac3f_iv -in credentials.tar.gz.enc -out credentials.tar.gz -d ;
@@ -78,7 +78,7 @@ install:
 # Run test
 script:
   # - nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s
-  - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then
+  - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
       cd docs; travis_wait 30 make html-noplot ; cd ../ ;
     else
       nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ install:
     else
       conda install --quiet --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib cython ipython h5py;
     fi
+  - travis_wait 30 mvn install
 
   - pip install -r requirements_dev.txt
   - python setup.py install
@@ -78,7 +79,7 @@ install:
 # Run test
 script:
   # - nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s
-  - travis_wait 30 sleep 1800 &
+  #- travis_wait 30 sleep 1800 &
   - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then
       cd docs; travis_wait 30 make html-noplot ; cd ../ ;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,11 +80,12 @@ script:
   # - nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s
   - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then
       cd docs; travis_wait 30 make html-noplot ; cd ../ ;
-    fi
-  - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
-      travis_wait 30 nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
     else
-      nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
+      if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
+        travis_wait 30 nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
+      else
+        nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
+      fi;
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - MASTER_BRANCH=master
     - GAE_PROJECT=simpegdocs
     - DOCS_PY=3.6  # deploy docs from 3.6
-    - PYPI_PY=3.6 # deploy to pypi from python 3.6
+    - PYPI_PY=3.6  # deploy to pypi from python 3.6
 
   matrix:
     - TEST_DIR=tests/em/fdem/inverse/derivs

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,9 @@ script:
   # - nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s
   - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "3" ]; then
       cd docs; travis_wait 30 make html-noplot ; cd ../ ;
+    fi
+  - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
+      travis_wait 30 nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
     else
       nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
     fi

--- a/SimPEG/DataMisfit.py
+++ b/SimPEG/DataMisfit.py
@@ -58,7 +58,7 @@ class l2_DataMisfit(BaseDataMisfit):
 
     """
 
-    std = 0.05  #: default standard deviation if not provided by survey
+    std = None  #: default standard deviation if not provided by survey
     eps = None  #: default floor
     eps_factor = 1e-5  #: factor to multiply by the norm of the data to create floor
 
@@ -66,11 +66,12 @@ class l2_DataMisfit(BaseDataMisfit):
         BaseDataMisfit.__init__(self, survey, **kwargs)
 
         if self.std is None:
-            if getattr(self.survey, 'std', None) is not None:
+            if getattr(self.survey, 'std', None) is None:
                 print(
                     'SimPEG.DataMisfit.l2_DataMisfit assigning default std '
                     'of 5%'
                 )
+                self.std = 0.05
             else:
                 self.std = self.survey.std
 

--- a/SimPEG/Directives.py
+++ b/SimPEG/Directives.py
@@ -427,7 +427,13 @@ class SaveOutputEveryIteration(SaveEveryIteration):
                 i_target += 1
             self.i_target = i_target
 
-    def plot_misfit_curves(self, fname=None, plot_small_smooth=False):
+    def plot_misfit_curves(
+        self, fname=None, dpi=300,
+        plot_small_smooth=False,
+        plot_phi_m=True,
+        plot_small=False,
+        plot_smooth=False
+    ):
 
         self.target_misfit = self.invProb.dmisfit.prob.survey.nD / 2.
         self.i_target = None
@@ -441,22 +447,55 @@ class SaveOutputEveryIteration(SaveEveryIteration):
         fig = plt.figure(figsize=(5, 2))
         ax = plt.subplot(111)
         ax_1 = ax.twinx()
-        ax.semilogy(np.arange(len(self.phi_d)), self.phi_d, 'k-', lw=2)
-        ax_1.semilogy(np.arange(len(self.phi_d)), self.phi_m, 'r', lw=2)
-        if plot_small_smooth:
-            ax_1.semilogy(np.arange(len(self.phi_d)), self.phi_m_small, 'ro')
-            ax_1.semilogy(np.arange(len(self.phi_d)), self.phi_m_smooth, 'rx')
-            ax_1.legend(
-                ("$\phi_m$", "small", "smooth"), bbox_to_anchor=(1.5, 1.)
-                )
+        ax.semilogy(
+            np.arange(len(self.phi_d)),
+            self.phi_d, 'k-', lw=2,
+            label="$\phi_d$"
+        )
 
-        ax.plot(np.r_[ax.get_xlim()[0], ax.get_xlim()[1]], np.ones(2)*self.target_misfit, 'k:')
+        if plot_phi_m:
+            ax_1.semilogy(
+                np.arange(len(self.phi_d)),
+                self.phi_m, 'r', lw=2,
+                label="$\phi_m$"
+            )
+
+        if plot_small_smooth or plot_small:
+            ax_1.semilogy(np.arange(
+                len(self.phi_d)),
+                self.phi_m_small, 'ro',
+                label="small"
+            )
+        if plot_small_smooth or plot_smooth:
+            ax_1.semilogy(np.arange(
+                len(self.phi_d)),
+                self.phi_m_smooth_x, 'rx',
+                label="smooth_x"
+            )
+            ax_1.semilogy(np.arange(
+                len(self.phi_d)),
+                self.phi_m_smooth_y, 'rx',
+                label="smooth_y"
+            )
+            ax_1.semilogy(np.arange(
+                len(self.phi_d)),
+                self.phi_m_smooth_z, 'rx',
+                label="smooth_z"
+            )
+
+        ax.legend(loc=1)
+        ax_1.legend(loc=2)
+
+        ax.plot(np.r_[ax.get_xlim()[0], ax.get_xlim()[1]],
+                np.ones(2) * self.target_misfit, 'k:')
         ax.set_xlabel("Iteration")
         ax.set_ylabel("$\phi_d$")
         ax_1.set_ylabel("$\phi_m$", color='r')
-        for tl in ax_1.get_yticklabels():
-            tl.set_color('r')
+        ax_1.tick_params(axis='y', which='both', colors='red')
+
         plt.show()
+        if fname is not None:
+            fig.savefig(fname, dpi=dpi)
 
     def plot_tikhonov_curves(self, fname=None, dpi=200):
 

--- a/SimPEG/Survey.py
+++ b/SimPEG/Survey.py
@@ -465,7 +465,7 @@ class BaseSurvey(object):
         "Check if the data is synthetic."
         return self.mtrue is not None
 
-    def makeSyntheticData(self, m, std=0.05, f=None, force=False):
+    def makeSyntheticData(self, m, std=None, f=None, force=False):
         """
             Make synthetic data given a model, and a standard deviation.
 
@@ -482,9 +482,23 @@ class BaseSurvey(object):
             )
         self.mtrue = m
         self.dtrue = self.dpred(m, f=f)
-        noise = std*abs(self.dtrue)*np.random.randn(*self.dtrue.shape)
+        if std is None and self.std is None:
+            stddev = 0.05
+            print(
+                    'SimPEG.Survey assigned default std '
+                    'of 5%'
+                )
+        elif std is None:
+            stddev = self.std
+            print(
+                    'SimPEG.Survey assigned new std '
+                    'of {:.2f}%'.format(100.*stddev)
+                )
+        else:
+            stddev = std
+        noise = stddev*abs(self.dtrue)*np.random.randn(*self.dtrue.shape)
         self.dobs = self.dtrue+noise
-        self.std = self.dobs*0 + std
+        self.std = self.dobs*0 + stddev
         return self.dobs
 
 

--- a/SimPEG/Survey.py
+++ b/SimPEG/Survey.py
@@ -482,6 +482,7 @@ class BaseSurvey(object):
             )
         self.mtrue = m
         self.dtrue = self.dpred(m, f=f)
+
         if std is None and self.std is None:
             stddev = 0.05
             print(
@@ -490,12 +491,13 @@ class BaseSurvey(object):
                 )
         elif std is None:
             stddev = self.std
+        else:
+            stddev = std
             print(
                     'SimPEG.Survey assigned new std '
                     'of {:.2f}%'.format(100.*stddev)
                 )
-        else:
-            stddev = std
+
         noise = stddev*abs(self.dtrue)*np.random.randn(*self.dtrue.shape)
         self.dobs = self.dtrue+noise
         self.std = self.dobs*0 + stddev

--- a/SimPEG/Utils/PlotUtils.py
+++ b/SimPEG/Utils/PlotUtils.py
@@ -58,9 +58,9 @@ def plot2Ddata(
             ~np.isnan(DATA),
             np.abs(DATA) != np.inf
             )
-        if clim is None:
-            vmin = DATA[dataselection].min()
-            vmax = DATA[dataselection].max()
+        if clim is not None:
+            vmin = np.min(clim)
+            vmax = np.max(clim)
         elif np.logical_and(
             'vmin' in contourOpts.keys(),
             'vmax' in contourOpts.keys()
@@ -68,8 +68,8 @@ def plot2Ddata(
             vmin = contourOpts['vmin']
             vmax = contourOpts['vmax']
         else:
-            vmin = np.min(clim)
-            vmax = np.max(clim)
+            vmin = DATA[dataselection].min()
+            vmax = DATA[dataselection].max()
             if scale == "log":
                 vmin = np.log10(vmin)
                 vmax = np.log10(vmax)

--- a/examples/07-fdem/plot_loop_loop_2Dinversion.py
+++ b/examples/07-fdem/plot_loop_loop_2Dinversion.py
@@ -244,10 +244,10 @@ ax = plot_data(dclean)
 # Set up data for inversion
 # -------------------------
 #
-# We will invert the clean data, and assign a standard deviation of 0.03, and
+# We will invert the clean data, and assign a standard deviation of 0.05, and
 # a floor of 1e-11.
 
-survey.std = 0.03
+survey.std = 0.05
 survey.eps = 1e-11
 survey.dobs = dclean
 

--- a/tests/base/test_DataMisfit.py
+++ b/tests/base/test_DataMisfit.py
@@ -44,8 +44,7 @@ class DataMisfitTest(unittest.TestCase):
         self.prob = prob
         self.dobs = dobs
         self.dmis = dmis
-        import SimPEG
-        print(SimPEG.__path__)
+
 
     def test_Wd_depreciation(self):
         with self.assertRaises(Exception):

--- a/tests/base/test_DataMisfit.py
+++ b/tests/base/test_DataMisfit.py
@@ -31,8 +31,11 @@ class DataMisfitTest(unittest.TestCase):
 
         prob.pair(survey)
 
+        self.std = 0.01
+        survey.std = self.std
         dobs = survey.makeSyntheticData(model)
-
+        self.eps = 1e-8 * np.min(np.abs(dobs))
+        survey.eps = self.eps
         dmis = DataMisfit.l2_DataMisfit(survey)
 
         self.model = model
@@ -41,6 +44,8 @@ class DataMisfitTest(unittest.TestCase):
         self.prob = prob
         self.dobs = dobs
         self.dmis = dmis
+        import SimPEG
+        print(SimPEG.__path__)
 
     def test_Wd_depreciation(self):
         with self.assertRaises(Exception):
@@ -68,6 +73,18 @@ class DataMisfitTest(unittest.TestCase):
     def test_DataMisfitOrder(self):
         self.dmis.test(x=self.model)
 
+    def test_std_eps(self):
+        stdtest = np.all(self.survey.std == self.dmis.std)
+        epstest = (self.survey.eps == self.dmis.eps)
+        Wtest = np.allclose(
+            np.abs(np.dot(self.dmis.W.todense(), self.dobs)),
+            1./self.std,
+            atol=self.eps
+        )
+
+        self.assertTrue(stdtest)
+        self.assertTrue(epstest)
+        self.assertTrue(Wtest)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/base/test_DataMisfit.py
+++ b/tests/base/test_DataMisfit.py
@@ -45,7 +45,6 @@ class DataMisfitTest(unittest.TestCase):
         self.dobs = dobs
         self.dmis = dmis
 
-
     def test_Wd_depreciation(self):
         with self.assertRaises(Exception):
             print(self.dmis.Wd)


### PR DESCRIPTION
Fix for Issue #746

- fixed `DataMisfit.std` that now take into consideration `survey.std`. So you are not forced to set `DataMisfit.W` manually anymore

-  Fixed: `Survey.MakeSyntheticData`, if not given a `std`, was overwriting `survey.std` even if already set.  Now it will use `survey.std` if not given a `std` argument.

Explanation:
`DataMisfit.std` was set to 5% by default, but to change it to `survey.std`, it expected a `None` value, thus it never gets updated...

- bonus: light improvement again of `Plot2DData` (reordering of `if` statement so specifying `contourOpts['vmin','vmax']`  without a `clim` works.

- bonus: Somehow PR #725 did not make it to improve `plot_misfit_curves` so I put it back here. Mainly, more option to plot $\phi_m$ or $\phi_small$  and $\phi_smooth$ independently, plus more options to save the figure.