### PR TITLE
remove testing on python 2.7 from SimPEG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - 3.6
-  - 2.7
 
 sudo: false
 
@@ -52,12 +51,7 @@ before_install:
   - conda update --yes conda
 
 install:
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
-      conda install --quiet --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib cython ipython h5py vtk;
-    else
-      conda install --quiet --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib cython ipython h5py;
-    fi
-
+  - conda install --quiet --yes pip python=$TRAVIS_PYTHON_VERSION numpy scipy matplotlib cython ipython h5py;
   - pip install -r requirements_dev.txt
   - python setup.py install
   - if [ "$TEST_DIR" = "$DEPLOY_DIR" ]; then
@@ -104,25 +98,21 @@ after_success:
     fi
 
   # deploy docs
-  - if [ $TRAVIS_PYTHON_VERSION == $DOCS_PY ]; then
-      if [ "$TRAVIS_BRANCH" = "$MASTER_BRANCH" ]; then
-        cd docs; tar -cvzf _build.tar.gz _build ;
-        cd content; tar -cvzf examples.tar.gz examples ; cd ../../ ;
-        gsutil cp docs/_build.tar.gz gs://simpeg ;
-        gsutil cp docs/content/examples.tar.gz gs://simpeg ;
-        gcloud auth activate-service-account --key-file credentials/client-secret.json ;
-        export GAE_PROJECT=$GAE_PROJECT ;
-      fi ;
+  - if [ "$TRAVIS_BRANCH" = "$MASTER_BRANCH" ]; then
+      cd docs; tar -cvzf _build.tar.gz _build ;
+      cd content; tar -cvzf examples.tar.gz examples ; cd ../../ ;
+      gsutil cp docs/_build.tar.gz gs://simpeg ;
+      gsutil cp docs/content/examples.tar.gz gs://simpeg ;
+      gcloud auth activate-service-account --key-file credentials/client-secret.json ;
+      export GAE_PROJECT=$GAE_PROJECT ;
       gcloud config set project $GAE_PROJECT;
       gcloud app deploy ./docs/app.yaml --version ${TRAVIS_COMMIT} --promote;
     fi;
 
   #deploy to pypi
-  - if [ $TRAVIS_PYTHON_VERSION == $PYPI_PY ]; then
-      if [ "$TRAVIS_TAG" = "true" ]; then
-        mv credentials/.pypirc ~/.pypirc ;
-        python setup.py sdist bdist_wheel --universal upload;
-      fi
+  - if [ "$TRAVIS_TAG" = "true" ]; then
+      mv credentials/.pypirc ~/.pypirc ;
+      python setup.py sdist bdist_wheel --universal upload;
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,7 @@ env:
 # Setup anaconda
 before_install:
 # Install packages
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
-      wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p $HOME/miniconda
   - export PATH=/home/travis/anaconda/bin:/home/travis/miniconda/bin:$PATH
@@ -72,11 +68,7 @@ install:
 # Run test
 script:
   # - nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s
-  - if [ "$TEST_DIR" = "$DEPLOY_DIR" -a ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then
-      cd docs; travis_wait 30 make html-noplot ; cd ../ ;
-    else
-      nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
-    fi
+  - nosetests $TEST_DIR --with-cov --cov SimPEG --cov-config .coveragerc -v -s;
 
 
 # Calculate coverage

--- a/docs/content/basic/installing.rst
+++ b/docs/content/basic/installing.rst
@@ -15,7 +15,9 @@ It installs `python <https://www.python.org/>`_,
 `Jupyter <http://jupyter.org/>`_ and other core
 python libraries for scientific computing.
 
-We also recommend installing the latest version of Python 3.
+As of version 0.11.0, we will no longer ensure compatibility with Python 2.7. Please use
+the latest version of Python 3 with SimPEG. For more ingormation on the transition of the
+Python ecosystem to Python 3, please see the `Python 3 Statement <https://python3statement.org/>`_.
 
 
 .. _installing_simpeg:


### PR DESCRIPTION
- soft removal of python 2.7: we don't explicitly break compatibility as in #731, but it is no longer tested on Python 2.7
- added a note in the docs saying we will not be working to ensure compatibility with python 2.7 anymore 