### PR TITLE
light refactor in DC receivers

### DIFF
--- a/SimPEG/EM/Static/DC/RxDC.py
+++ b/SimPEG/EM/Static/DC/RxDC.py
@@ -7,7 +7,21 @@ import SimPEG
 import numpy as np
 from SimPEG.Utils import closestPoints
 
+# Trapezoidal integration for 2D DC problem
+def IntTrapezoidal(kys, Pf, y=0.):
+    phi = np.zeros(Pf.shape[0])
+    nky = kys.size
+    dky = np.diff(kys)
+    dky = np.r_[dky[0], dky]
+    phi0 = 1./np.pi*Pf[:, 0]
+    for iky in range(nky):
+        phi1 = 1./np.pi*Pf[:, iky]
+        phi += phi1*dky[iky]/2.*np.cos(kys[iky]*y)
+        phi += phi0*dky[iky]/2.*np.cos(kys[iky]*y)
+        phi0 = phi1.copy()
+    return phi
 
+# Receiver classes
 class BaseRx(SimPEG.Survey.BaseRx):
     """
     Base DC receiver
@@ -131,7 +145,7 @@ class Dipole_ky(BaseRx):
     def eval(self, kys, src, mesh, f):
         P = self.getP(mesh, self.projGLoc(f))
         Pf = P*f[src, self.projField, :]
-        return self.IntTrapezoidal(kys, Pf, y=0.)
+        return IntTrapezoidal(kys, Pf, y=0.)
 
     def evalDeriv(self, ky, src, mesh, f, v, adjoint=False):
         P = self.getP(mesh, self.projGLoc(f))
@@ -139,19 +153,6 @@ class Dipole_ky(BaseRx):
             return P*v
         elif adjoint:
             return P.T*v
-
-    def IntTrapezoidal(self, kys, Pf, y=0.):
-        phi = np.zeros(Pf.shape[0])
-        nky = kys.size
-        dky = np.diff(kys)
-        dky = np.r_[dky[0], dky]
-        phi0 = 1./np.pi*Pf[:, 0]
-        for iky in range(nky):
-            phi1 = 1./np.pi*Pf[:, iky]
-            phi += phi1*dky[iky]/2.*np.cos(kys[iky]*y)
-            phi += phi0*dky[iky]/2.*np.cos(kys[iky]*y)
-            phi0 = phi1.copy()
-        return phi
 
 
 class Pole(BaseRx):
@@ -212,7 +213,7 @@ class Pole_ky(BaseRx):
     def eval(self, kys, src, mesh, f):
         P = self.getP(mesh, self.projGLoc(f))
         Pf = P*f[src, self.projField, :]
-        return self.IntTrapezoidal(kys, Pf, y=0.)
+        return IntTrapezoidal(kys, Pf, y=0.)
 
     def evalDeriv(self, ky, src, mesh, f, v, adjoint=False):
         P = self.getP(mesh, self.projGLoc(f))
@@ -220,16 +221,3 @@ class Pole_ky(BaseRx):
             return P*v
         elif adjoint:
             return P.T*v
-
-    def IntTrapezoidal(self, kys, Pf, y=0.):
-        phi = np.zeros(Pf.shape[0])
-        nky = kys.size
-        dky = np.diff(kys)
-        dky = np.r_[dky[0], dky]
-        phi0 = 1./np.pi*Pf[:, 0]
-        for iky in range(nky):
-            phi1 = 1./np.pi*Pf[:, iky]
-            phi += phi1*dky[iky]/2.*np.cos(kys[iky]*y)
-            phi += phi0*dky[iky]/2.*np.cos(kys[iky]*y)
-            phi0 = phi1.copy()
-        return phi


### PR DESCRIPTION
turn IntTrapezoidal into a function that can be reused by both pole and dipole classes rather than duplicating code. 

@micmitch: would you mind taking a quick look at this pr? 

If you take a look at the code 
![image](https://user-images.githubusercontent.com/6361812/58888590-eb043680-86e7-11e9-92e9-6147038bf423.png)

and please leave any comments or questions here
![image](https://user-images.githubusercontent.com/6361812/58888658-0bcc8c00-86e8-11e9-8d77-91a0e07ae637.png)

Thanks! 