### PR TITLE
Fix simple regularization

### DIFF
--- a/SimPEG/regularization/sparse.py
+++ b/SimPEG/regularization/sparse.py
@@ -423,7 +423,7 @@ class SparseDeriv(BaseSparse):
                 self.regmesh.Pac.T*self.regmesh.mesh.h_gridded[:, index]
             )**2.
 
-            self._length_scales = length_scales / length_scales.min()
+            self._length_scales = length_scales.min() / length_scales
 
         return self._length_scales
 

--- a/SimPEG/regularization/tikhonov.py
+++ b/SimPEG/regularization/tikhonov.py
@@ -155,7 +155,7 @@ class SimpleSmoothDeriv(BaseRegularization):
                 self.regmesh.Pac.T*self.regmesh.mesh.h_gridded[:, index]
             )**2.
 
-            self._length_scales = length_scales / length_scales.min()
+            self._length_scales = length_scales.min() / length_scales
 
         return self._length_scales
 


### PR DESCRIPTION
Proposed modification to the model gradient measure for Simple and Sparse regularization.
Normalized length scales are multiplying cell_weights before averaging to cell faces.
- Reduces the dependency of the solution on the change in discretization
- Still allows for IRLS weights to be mesh independent
- Default alpha's remain at 1 (takes care of length scales internally) 

**Before**
![image](https://user-images.githubusercontent.com/2406426/64080554-b08c4480-ccaa-11e9-8eba-59a77cb6d691.png)

**After**
![LengthScalesApplied](https://user-images.githubusercontent.com/2406426/64080547-a79b7300-ccaa-11e9-9206-22c8adbd514b.png)
