### PR TITLE
Add a .mailmap file to help organize author statistics.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,47 @@
+# For more info on this file, a good reference is: 
+# https://github.com/sympy/sympy/wiki/Using-.mailmap
+
+# The format for each line can be:
+#
+# Proper Name <Proper@email> commit name <commit@email>
+# \-----------+------------/ \----------+-------------/
+#             |                         |
+#          replace                     find
+#
+# Though the "find" part can be omitted to declare a canonical name if only
+# email variations exist, and the "commit name" can be omitted in most cases.
+
+Lindsey Heagy <lindseyheagy@gmail.com>
+Lindsey Heagy <lindseyheagy@gmail.com> <lheagy@eos.ubc.ca>
+
+Rowan Cockett <rowan@visiblegeology.com>
+Rowan Cockett <rowan@visiblegeology.com> <rowanc1@gmail.com>
+Rowan Cockett <rowan@visiblegeology.com> <rowan@3ptscience.com>
+
+Seogi Kang <sgkang09@gmail.com>
+Seogi Kang <sgkang09@gmail.com> <sgkang09@github.com>
+Seogi Kang <sgkang09@gmail.com> <skang@eos.ubc.ca>
+
+Dom Fournier <fourndo@gmail.com>
+
+Gudni Karl Rosenkjaer <gkrosen@gmail.com>
+Gudni Karl Rosenkjaer <gkrosen@gmail.com> <grosenkj@eos.ubc.ca>
+Gudni Karl Rosenkjaer <gkrosen@gmail.com> <grosenkj@users.noreply.github.com>
+
+Thibaut Astic <thast@eos.ubc.ca>
+Thibaut Astic <thast@eos.ubc.ca> <thast@users.noreply.github.com>
+
+Devin Cowan <devinccowan@gmail.com>
+
+Dave Marchant <dwfmarchant@gmail.com>
+
+Michael Mitchell <micmitch44@gmail.com> <mmitchel@eos.ubc.ca>
+
+Lars Ruthotto <lruthotto@eos.ubc.ca> <lruthott@eos.ubc.ca>
+
+Dieter Werthmüller <mail@werthmuller.org>
+Dieter Werthmüller <mail@werthmuller.org> <prisae@users.noreply.github.com>
+
+Eldad Haber <ehaber99@gmail.com>
+
+Brendan Smithyman <smithyman@gmail.com> <brendan@bitsmithy.net>


### PR DESCRIPTION
This `.mailmap` takes the output of `git shortlog -sne` from the one on the left to the one on the right:

![image](https://user-images.githubusercontent.com/57394/69474747-726a6280-0d79-11ea-8cd5-14fe241310b3.png)

It makes it easier to get clean author info from the various git log commands.  If anyone in the team prefers a different canonical name or email, it's easy to fix that now by updating this file. 

The [sympy wiki entry](https://github.com/sympy/sympy/wiki/Using-.mailmap) mentioned in the file has a ton more details about this, including links to scripts they use to carefully manage theirs.