### PR TITLE
Uncertainty rename in simulation

### DIFF
--- a/SimPEG/data.py
+++ b/SimPEG/data.py
@@ -62,6 +62,10 @@ class Data(properties.HasProperties):
         error to each datum) or as a scalar if you would like to assign a
         the same relative error to all data.
 
+        The standard_deviation is constructed as follows::
+
+            relative_error * np.abs(dobs) + noise_floor
+
         For example, if you set
 
         .. code:: python
@@ -85,6 +89,10 @@ class Data(properties.HasProperties):
         same size as the data (e.g. if you want to assign a different noise
         floor to each datum) or as a scalar if you would like to assign a
         the same noise floor to all data.
+
+        The standard_deviation is constructed as follows::
+
+            relative_error * np.abs(dobs) + noise_floor
 
         For example, if you set
 

--- a/SimPEG/data.py
+++ b/SimPEG/data.py
@@ -25,12 +25,12 @@ class UncertaintyArray(properties.Array):
 
 class Data(properties.HasProperties):
     """
-    Data storage. This class keeps track of observed data, standard deviation
+    Data storage. This class keeps track of observed data, relative error
     of those data and the noise floor.
 
     .. code:: python
 
-        data = Data(survey, dobs=dobs, relative_error=std, noise_floor=floor)
+        data = Data(survey, dobs=dobs, relative_error=relative, noise_floor=floor)
 
     or
 
@@ -57,10 +57,10 @@ class Data(properties.HasProperties):
 
     relative_error = UncertaintyArray(
         """
-        Standard deviation of the data. This can be set using an array of the
-        same size as the data (e.g. if you want to assign a different standard
-        deviation to each datum) or as a scalar if you would like to assign a
-        the same standard deviation to all data.
+        Relative error of the data. This can be set using an array of the
+        same size as the data (e.g. if you want to assign a different relative
+        error to each datum) or as a scalar if you would like to assign a
+        the same relative error to all data.
 
         For example, if you set
 
@@ -134,7 +134,7 @@ class Data(properties.HasProperties):
             if relative_error is not None or noise_floor is not None:
                 warnings.warn(
                     "Setting the standard_deviation overwrites the "
-                    "relative_error and noise floor"
+                    "relative_error and noise_floor"
                 )
             self.standard_deviation = standard_deviation
 
@@ -147,7 +147,7 @@ class Data(properties.HasProperties):
     @property
     def standard_deviation(self):
         """
-        Data uncertainties. If a stardard deviation and noise floor are
+        Data standard deviations. If a relative error and noise floor are
         provided, the standard_deviation is
 
         .. code:: python

--- a/SimPEG/data.py
+++ b/SimPEG/data.py
@@ -36,7 +36,7 @@ class Data(properties.HasProperties):
 
     .. code:: python
 
-        data = Data(survey, dobs=dobs, uncertainty=uncertainty)
+        data = Data(survey, dobs=dobs, standard_deviation=standard_deviation)
     """
 
     dobs = properties.Array(
@@ -69,7 +69,7 @@ class Data(properties.HasProperties):
             data = Data(survey, dobs=dobs)
             data.relative_error = 0.05
 
-        then the contribution to the uncertainty is equal to
+        then the contribution to the standard_deviation is equal to
 
         .. code:: python
 
@@ -93,7 +93,7 @@ class Data(properties.HasProperties):
             data = Data(survey, dobs=dobs)
             data.noise_floor = 1e-10
 
-        then the contribution to the uncertainty is equal to
+        then the contribution to the standard_deviation is equal to
 
         .. code:: python
 
@@ -114,7 +114,7 @@ class Data(properties.HasProperties):
     #######################
     def __init__(
         self, survey, dobs=None, relative_error=None, noise_floor=None,
-        uncertainty=None
+        standard_deviation=None
     ):
         super(Data, self).__init__()
         self.survey = survey
@@ -130,40 +130,40 @@ class Data(properties.HasProperties):
         if noise_floor is not None:
             self.noise_floor = noise_floor
 
-        if uncertainty is not None:
+        if standard_deviation is not None:
             if relative_error is not None or noise_floor is not None:
                 warnings.warn(
-                    "Setting the uncertainty overwrites the "
+                    "Setting the standard_deviation overwrites the "
                     "relative_error and noise floor"
                 )
-            self.uncertainty = uncertainty
+            self.standard_deviation = standard_deviation
 
-        if uncertainty is None and relative_error is None and noise_floor is None:
-            self.uncertainty = 0.0
+        if standard_deviation is None and relative_error is None and noise_floor is None:
+            self.standard_deviation = 0.0
 
     #######################
     # Properties
     #######################
     @property
-    def uncertainty(self):
+    def standard_deviation(self):
         """
         Data uncertainties. If a stardard deviation and noise floor are
-        provided, the uncertainty is
+        provided, the standard_deviation is
 
         .. code:: python
 
-            data.uncertainty = (
+            data.standard_deviation = (
                 data.relative_error*np.abs(data.dobs) +
                 data.noise_floor
             )
 
-        otherwise, the uncertainty can be set directly
+        otherwise, the standard_deviation can be set directly
 
         .. code:: python
 
-            data.uncertainty = 0.05 * np.absolute(self.dobs) + 1e-12
+            data.standard_deviation = 0.05 * np.absolute(self.dobs) + 1e-12
 
-        Note that setting the uncertainty directly will clear the `relative_error`
+        Note that setting the standard_deviation directly will clear the `relative_error`
         and set the value to the `noise_floor` property.
 
         """
@@ -171,7 +171,7 @@ class Data(properties.HasProperties):
             raise Exception(
                 "The relative_error and / or noise_floor must be set "
                 "before asking for uncertainties. Alternatively, the "
-                "uncertainty can be set directly"
+                "standard_deviation can be set directly"
             )
 
         uncert = np.zeros(self.nD)
@@ -182,8 +182,8 @@ class Data(properties.HasProperties):
 
         return uncert
 
-    @uncertainty.setter
-    def uncertainty(self, value):
+    @standard_deviation.setter
+    def standard_deviation(self, value):
         self.relative_error = np.zeros(self.nD)
         self.noise_floor = value
 
@@ -212,7 +212,7 @@ class Data(properties.HasProperties):
             )
 
     @properties.validator(['relative_error', 'noise_floor'])
-    def _uncertainty_validator(self, change):
+    def _standard_deviation_validator(self, change):
         if isinstance(change['value'], float):
             change['value'] = change['value'] * np.ones(self.nD)
         self._dobs_validator(change)

--- a/SimPEG/data.py
+++ b/SimPEG/data.py
@@ -30,7 +30,7 @@ class Data(properties.HasProperties):
 
     .. code:: python
 
-        data = Data(survey, dobs=dobs, standard_deviation=std, noise_floor=floor)
+        data = Data(survey, dobs=dobs, relative_error=std, noise_floor=floor)
 
     or
 
@@ -55,7 +55,7 @@ class Data(properties.HasProperties):
         shape=('*',), required=True
     )
 
-    standard_deviation = UncertaintyArray(
+    relative_error = UncertaintyArray(
         """
         Standard deviation of the data. This can be set using an array of the
         same size as the data (e.g. if you want to assign a different standard
@@ -67,13 +67,13 @@ class Data(properties.HasProperties):
         .. code:: python
 
             data = Data(survey, dobs=dobs)
-            data.standard_deviation = 0.05
+            data.relative_error = 0.05
 
         then the contribution to the uncertainty is equal to
 
         .. code:: python
 
-            data.standard_deviation * np.abs(data.dobs)
+            data.relative_error * np.abs(data.dobs)
 
         """,
         shape=('*',)
@@ -113,7 +113,7 @@ class Data(properties.HasProperties):
     # Instantiate the class
     #######################
     def __init__(
-        self, survey, dobs=None, standard_deviation=None, noise_floor=None,
+        self, survey, dobs=None, relative_error=None, noise_floor=None,
         uncertainty=None
     ):
         super(Data, self).__init__()
@@ -124,21 +124,21 @@ class Data(properties.HasProperties):
             dobs = np.nan*np.ones(survey.nD)  # initialize data as nans
         self.dobs = dobs
 
-        if standard_deviation is not None:
-            self.standard_deviation = standard_deviation
+        if relative_error is not None:
+            self.relative_error = relative_error
 
         if noise_floor is not None:
             self.noise_floor = noise_floor
 
         if uncertainty is not None:
-            if standard_deviation is not None or noise_floor is not None:
+            if relative_error is not None or noise_floor is not None:
                 warnings.warn(
                     "Setting the uncertainty overwrites the "
-                    "standard_deviation and noise floor"
+                    "relative_error and noise floor"
                 )
             self.uncertainty = uncertainty
 
-        if uncertainty is None and standard_deviation is None and noise_floor is None:
+        if uncertainty is None and relative_error is None and noise_floor is None:
             self.uncertainty = 0.0
 
     #######################
@@ -153,7 +153,7 @@ class Data(properties.HasProperties):
         .. code:: python
 
             data.uncertainty = (
-                data.standard_deviation*np.abs(data.dobs) +
+                data.relative_error*np.abs(data.dobs) +
                 data.noise_floor
             )
 
@@ -163,20 +163,20 @@ class Data(properties.HasProperties):
 
             data.uncertainty = 0.05 * np.absolute(self.dobs) + 1e-12
 
-        Note that setting the uncertainty directly will clear the `standard_deviation`
+        Note that setting the uncertainty directly will clear the `relative_error`
         and set the value to the `noise_floor` property.
 
         """
-        if self.standard_deviation is None and self.noise_floor is None:
+        if self.relative_error is None and self.noise_floor is None:
             raise Exception(
-                "The standard_deviation and / or noise_floor must be set "
+                "The relative_error and / or noise_floor must be set "
                 "before asking for uncertainties. Alternatively, the "
                 "uncertainty can be set directly"
             )
 
         uncert = np.zeros(self.nD)
-        if self.standard_deviation is not None:
-            uncert = uncert + self.standard_deviation * np.absolute(self.dobs)
+        if self.relative_error is not None:
+            uncert = uncert + self.relative_error * np.absolute(self.dobs)
         if self.noise_floor is not None:
             uncert = uncert + self.noise_floor
 
@@ -184,7 +184,7 @@ class Data(properties.HasProperties):
 
     @uncertainty.setter
     def uncertainty(self, value):
-        self.standard_deviation = np.zeros(self.nD)
+        self.relative_error = np.zeros(self.nD)
         self.noise_floor = value
 
     @property
@@ -211,7 +211,7 @@ class Data(properties.HasProperties):
                 )
             )
 
-    @properties.validator(['standard_deviation', 'noise_floor'])
+    @properties.validator(['relative_error', 'noise_floor'])
     def _uncertainty_validator(self, change):
         if isinstance(change['value'], float):
             change['value'] = change['value'] * np.ones(self.nD)
@@ -279,7 +279,7 @@ class Data(properties.HasProperties):
     ##########################
     # Deprecated
     ##########################
-    std = deprecate_property(standard_deviation, 'std', removal_version='0.15.0')
+    std = deprecate_property(relative_error, 'std', removal_version='0.15.0')
     eps = deprecate_property(noise_floor, 'eps', removal_version='0.15.0')
 
 
@@ -306,12 +306,12 @@ class SyntheticData(Data):
     )
 
     def __init__(
-        self, survey, dobs=None, dclean=None, standard_deviation=None,
+        self, survey, dobs=None, dclean=None, relative_error=None,
         noise_floor=None
     ):
         super(SyntheticData, self).__init__(
             survey=survey, dobs=dobs,
-            standard_deviation=standard_deviation, noise_floor=noise_floor
+            relative_error=relative_error, noise_floor=noise_floor
         )
 
         if dclean is None:

--- a/SimPEG/data_misfit.py
+++ b/SimPEG/data_misfit.py
@@ -106,7 +106,7 @@ class BaseDataMisfit(L2ObjectiveFunction):
                 )
             if any(standard_deviation <= 0):
                 raise Exception(
-                    "data.standard_deviation musy be strictly positive to construct "
+                    "data.standard_deviation must be strictly positive to construct "
                     "the W matrix. Please set data.relative_error and or "
                     "data.noise_floor."
                 )
@@ -209,14 +209,14 @@ class l2_DataMisfit(L2DataMisfit):
         self.survey = survey
         try:
             dobs = survey.dobs
-            std = survey.std
+            rel_err = survey.std
         except AttributeError:
             raise Exception('Survey object must have been given a data object')
         # create a Data object...
         # Get the survey's simulation that was paired to it....
         # simulation = survey.simulation
 
-        self.data = Data(survey, dobs, relative_error=std)
+        self.data = Data(survey, dobs, relative_error=rel_err)
 
         eps_factor = 1e-5  #: factor to multiply by the norm of the data to create floor
         if getattr(self.survey, 'eps', None) is None:

--- a/SimPEG/data_misfit.py
+++ b/SimPEG/data_misfit.py
@@ -96,21 +96,21 @@ class BaseDataMisfit(L2ObjectiveFunction):
                     "dmis.data = Data(dobs=dobs, relative_error=std"
                     ", noise_floor=eps)"
                 )
-            uncertainty = self.data.uncertainty
-            if uncertainty is None:
+            standard_deviation = self.data.standard_deviation
+            if standard_deviation is None:
                 raise Exception(
                     "data uncertainties must be set before the data misfit "
                     "can be constructed (data.relative_error = 0.05, "
                     "data.noise_floor = 1e-5), alternatively, the W matrix "
-                    "can be set directly (dmisfit.W = 1./uncertainty)"
+                    "can be set directly (dmisfit.W = 1./standard_deviation)"
                 )
-            if any(uncertainty <= 0):
+            if any(standard_deviation <= 0):
                 raise Exception(
-                    "data.uncertainty musy be strictly positive to construct "
+                    "data.standard_deviation musy be strictly positive to construct "
                     "the W matrix. Please set data.relative_error and or "
                     "data.noise_floor."
                 )
-            self._W = sdiag(1/(uncertainty))
+            self._W = sdiag(1/(standard_deviation))
         return self._W
 
     @W.setter

--- a/SimPEG/data_misfit.py
+++ b/SimPEG/data_misfit.py
@@ -93,21 +93,21 @@ class BaseDataMisfit(L2ObjectiveFunction):
                 raise Exception(
                     "data with uncertainties must be set before the data "
                     "misfit can be constructed. Please set the data: "
-                    "dmis.data = Data(dobs=dobs, standard_deviation=std"
+                    "dmis.data = Data(dobs=dobs, relative_error=std"
                     ", noise_floor=eps)"
                 )
             uncertainty = self.data.uncertainty
             if uncertainty is None:
                 raise Exception(
                     "data uncertainties must be set before the data misfit "
-                    "can be constructed (data.standard_deviation = 0.05, "
+                    "can be constructed (data.relative_error = 0.05, "
                     "data.noise_floor = 1e-5), alternatively, the W matrix "
                     "can be set directly (dmisfit.W = 1./uncertainty)"
                 )
             if any(uncertainty <= 0):
                 raise Exception(
                     "data.uncertainty musy be strictly positive to construct "
-                    "the W matrix. Please set data.standard_deviation and or "
+                    "the W matrix. Please set data.relative_error and or "
                     "data.noise_floor."
                 )
             self._W = sdiag(1/(uncertainty))
@@ -216,7 +216,7 @@ class l2_DataMisfit(L2DataMisfit):
         # Get the survey's simulation that was paired to it....
         # simulation = survey.simulation
 
-        self.data = Data(survey, dobs, standard_deviation=std)
+        self.data = Data(survey, dobs, relative_error=std)
 
         eps_factor = 1e-5  #: factor to multiply by the norm of the data to create floor
         if getattr(self.survey, 'eps', None) is None:
@@ -237,9 +237,9 @@ class l2_DataMisfit(L2DataMisfit):
     @property
     def noise_floor(self):
         return self.data.noise_floor
-    eps = deprecate_property(noise_floor, 'eps', new_name='data.standard_deviation', removal_version='0.15.0')
+    eps = deprecate_property(noise_floor, 'eps', new_name='data.relative_error', removal_version='0.15.0')
 
     @property
-    def standard_deviation(self):
-        return self.data.standard_deviation
-    std = deprecate_property(standard_deviation, 'std', new_name='data.standard_deviation', removal_version='0.15.0')
+    def relative_error(self):
+        return self.data.relative_error
+    std = deprecate_property(relative_error, 'std', new_name='data.relative_error', removal_version='0.15.0')

--- a/SimPEG/data_misfit.py
+++ b/SimPEG/data_misfit.py
@@ -91,15 +91,15 @@ class BaseDataMisfit(L2ObjectiveFunction):
         if getattr(self, '_W', None) is None:
             if self.data is None:
                 raise Exception(
-                    "data with uncertainties must be set before the data "
+                    "data with standard deviations must be set before the data "
                     "misfit can be constructed. Please set the data: "
-                    "dmis.data = Data(dobs=dobs, relative_error=std"
+                    "dmis.data = Data(dobs=dobs, relative_error=rel"
                     ", noise_floor=eps)"
                 )
             standard_deviation = self.data.standard_deviation
             if standard_deviation is None:
                 raise Exception(
-                    "data uncertainties must be set before the data misfit "
+                    "data standard deviations must be set before the data misfit "
                     "can be constructed (data.relative_error = 0.05, "
                     "data.noise_floor = 1e-5), alternatively, the W matrix "
                     "can be set directly (dmisfit.W = 1./standard_deviation)"
@@ -237,7 +237,7 @@ class l2_DataMisfit(L2DataMisfit):
     @property
     def noise_floor(self):
         return self.data.noise_floor
-    eps = deprecate_property(noise_floor, 'eps', new_name='data.relative_error', removal_version='0.15.0')
+    eps = deprecate_property(noise_floor, 'eps', new_name='data.noise_floor', removal_version='0.15.0')
 
     @property
     def relative_error(self):

--- a/SimPEG/electromagnetics/natural_source/survey.py
+++ b/SimPEG/electromagnetics/natural_source/survey.py
@@ -82,8 +82,8 @@ class Data(BaseData, DataNSEMPlotMethods):
     """
     Data class for NSEMdata. Stores the data vector indexed by the survey.
     """
-    def __init__(self, survey, dobs=None, standard_deviation=None, noise_floor=None):
-        BaseData.__init__(self, survey, dobs, standard_deviation, noise_floor)
+    def __init__(self, survey, dobs=None, relative_error=None, noise_floor=None):
+        BaseData.__init__(self, survey, dobs, relative_error, noise_floor)
 
 
     def toRecArray(self, returnType='RealImag'):

--- a/SimPEG/electromagnetics/natural_source/utils/data_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/data_utils.py
@@ -160,7 +160,7 @@ def resample_data(NSEMdata, locs='All', freqs='All', rxs='All', verbose=False):
                     data_list.append(NSEMdata[src, rx][ind_loc])
                     try:
                         std_list.append(
-                            NSEMdata.standard_deviation[src, rx][ind_loc])
+                            NSEMdata.relative_error[src, rx][ind_loc])
                         floor_list.append(NSEMdata.floor[src, rx][ind_loc])
                     except Exception as e:
                         if verbose:

--- a/SimPEG/electromagnetics/natural_source/utils/data_viewer.py
+++ b/SimPEG/electromagnetics/natural_source/utils/data_viewer.py
@@ -15,7 +15,7 @@ class NSEM_data_viewer(properties.HasProperties):
     in a separate window.
 
     :param SimPEG.electromagnetics.natural_source.Data data: Data object, needs to have assigned
-        standard_deviation and floor
+        relative_error and floor
 
     :param data_dict: A dictionary of other NSEM Data objects
     :type data_dict: dict, optional

--- a/SimPEG/electromagnetics/natural_source/utils/data_viewer.py
+++ b/SimPEG/electromagnetics/natural_source/utils/data_viewer.py
@@ -15,7 +15,7 @@ class NSEM_data_viewer(properties.HasProperties):
     in a separate window.
 
     :param SimPEG.electromagnetics.natural_source.Data data: Data object, needs to have assigned
-        relative_error and floor
+        relative_error and noise_floor
 
     :param data_dict: A dictionary of other NSEM Data objects
     :type data_dict: dict, optional

--- a/SimPEG/electromagnetics/natural_source/utils/plot_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/plot_utils.py
@@ -124,7 +124,7 @@ class TipperAmplitudeStationPlot(BaseDataNSEMPlots):
 
         :param data_list: List of NSEM data objects to plot.
             Has to be of length >= 1. First item is treat as a
-            observed data (Hast to have standard_deviation and floor)
+            observed data (Hast to have relative_error and floor)
             assigned) and the others are plotted on top.
         :param location: Location of the station to plot
         """
@@ -213,7 +213,7 @@ class ApparentResPhsStationPlot(BaseDataNSEMPlots):
 
         :param data_list: List of NSEM data objects to plot.
             Has to be of length >= 1. First item is treat as a
-            observed data (Hast to have standard_deviation and floor)
+            observed data (Hast to have relative_error and floor)
             assigned) and the others are plotted on top.
         :param location: Location of the station to plot
         """
@@ -776,7 +776,7 @@ def _extract_frequency_data(
     loc_arr = rx.locations
     data_arr = data[src, rx]
     if return_uncert:
-        std_arr = data.standard_deviation[src, rx]
+        std_arr = data.relative_error[src, rx]
         floor_arr = data.floor[src, rx]
     if return_uncert:
         return (loc_arr, data_arr, std_arr, floor_arr)
@@ -809,7 +809,7 @@ def _extract_location_data(
 
             if return_uncert:
                 index = data.index_dictionary[src][rx]
-                std_list.append(data.standard_deviation[index][ind_loc])
+                std_list.append(data.relative_error[index][ind_loc])
                 floor_list.append(data.noise_floor[index][ind_loc])
     if return_uncert:
         return (np.array(freq_list), np.concatenate(data_list),

--- a/SimPEG/electromagnetics/natural_source/utils/plot_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/plot_utils.py
@@ -124,7 +124,7 @@ class TipperAmplitudeStationPlot(BaseDataNSEMPlots):
 
         :param data_list: List of NSEM data objects to plot.
             Has to be of length >= 1. First item is treat as a
-            observed data (Hast to have relative_error and floor)
+            observed data (Hast to have relative_error and noise_floor)
             assigned) and the others are plotted on top.
         :param location: Location of the station to plot
         """
@@ -213,7 +213,7 @@ class ApparentResPhsStationPlot(BaseDataNSEMPlots):
 
         :param data_list: List of NSEM data objects to plot.
             Has to be of length >= 1. First item is treat as a
-            observed data (Hast to have relative_error and floor)
+            observed data (Hast to have relative_error and noise_floor)
             assigned) and the others are plotted on top.
         :param location: Location of the station to plot
         """

--- a/SimPEG/electromagnetics/static/resistivity/IODC.py
+++ b/SimPEG/electromagnetics/static/resistivity/IODC.py
@@ -870,11 +870,19 @@ class IO(properties.HasProperties):
             a, b, m, n, survey_type=survey_type, data_dc=voltage
         )
         survey.dobs = voltage[self.sort_inds]
-        survey.std = voltage[self.sort_inds]
+        survey.std = standard_deviation[self.sort_inds]
         survey.topo = topo
         return survey
 
-    def write_to_csv(self, fname, dobs, standard_deviation=None):
+    def write_to_csv(self, fname, dobs, standard_deviation=None, **kwargs):
+        uncert = kwargs.pop('uncertainty', None)
+        if uncert is not None:
+            warnings.warn(
+                "The uncertainty option has been deprecated and will be removed in SimPEG 0.15.0. "
+                "Please use standard_deviation".
+            )
+            standard_deviation = uncert
+
         if standard_deviation is None:
             standard_deviation = np.ones(dobs.size) * np.nan
         data = np.c_[

--- a/SimPEG/electromagnetics/static/resistivity/IODC.py
+++ b/SimPEG/electromagnetics/static/resistivity/IODC.py
@@ -836,7 +836,7 @@ class IO(properties.HasProperties):
             m = np.c_[abmn[:,4], -abmn[:,5]]
             n = np.c_[abmn[:,6], -abmn[:,7]]
             voltage = abmn[:,8]
-            uncertainty = abmn[:,9]
+            standard_deviation = abmn[:,9]
 
         elif input_type == "simple":
             if toponame is not None:
@@ -853,7 +853,7 @@ class IO(properties.HasProperties):
             m = np.c_[tmp[:,2], e]
             n = np.c_[tmp[:,3], e]
             voltage = tmp[:, 4]
-            uncertainty = tmp[:, 5]
+            standard_deviation = tmp[:, 5]
 
         if np.all(a==b):
             if np.all (m==n):
@@ -874,16 +874,16 @@ class IO(properties.HasProperties):
         survey.topo = topo
         return survey
 
-    def write_to_csv(self, fname, dobs, uncertainty=None):
-        if uncertainty is None:
-            uncertainty = np.ones(dobs.size) * np.nan
+    def write_to_csv(self, fname, dobs, standard_deviation=None):
+        if standard_deviation is None:
+            standard_deviation = np.ones(dobs.size) * np.nan
         data = np.c_[
             self.a_locations,
             self.b_locations,
             self.m_locations,
             self.n_locations,
             dobs,
-            uncertainty
+            standard_deviation
         ]
         df = pd.DataFrame(data=data, columns=["Ax", "Az", "Bx", "Bz", "Mx", "Mz", "Nx", "Nz", 'Voltage', 'Uncertainty'])
         df.to_csv(fname)
@@ -896,7 +896,7 @@ class IO(properties.HasProperties):
             m_locations = df[["Mx", "Mz"]].values
             n_locations = df[["Nx", "Nz"]].values
             dobs = df["Voltage"].values
-            uncertainty = df["Uncertainty"].values
+            standard_deviation = df["Uncertainty"].values
 
             if np.all(a_locations == b_locations):
                 src_type = 'pole-'
@@ -915,7 +915,7 @@ class IO(properties.HasProperties):
                 data_dc=dobs,
                 data_dc_type='volt'
             )
-            survey.std = uncertainty[self.sort_inds]
+            survey.std = standard_deviation[self.sort_inds]
             survey.dobs = dobs[self.sort_inds]
         else:
             raise NotImplementedError()

--- a/SimPEG/electromagnetics/static/resistivity/IODC.py
+++ b/SimPEG/electromagnetics/static/resistivity/IODC.py
@@ -878,8 +878,9 @@ class IO(properties.HasProperties):
         uncert = kwargs.pop('uncertainty', None)
         if uncert is not None:
             warnings.warn(
-                "The uncertainty option has been deprecated and will be removed in SimPEG 0.15.0. "
-                "Please use standard_deviation".
+                "The uncertainty option has been deprecated and will be removed"
+                " in SimPEG 0.15.0. Please use standard_deviation.",
+                DeprecationWarning
             )
             standard_deviation = uncert
 

--- a/SimPEG/electromagnetics/static/utils/static_utils.py
+++ b/SimPEG/electromagnetics/static/utils/static_utils.py
@@ -870,7 +870,7 @@ def writeUBC_DCobs(
                     np.c_[
                         A, B, M, N,
                         data.dobs[count:count+nD],
-                        data.standard_deviation[count:count+nD]
+                        data.relative_error[count:count+nD]
                     ],
                     delimiter=str(' '), newline=str('\n'))
                 fid.close()
@@ -903,7 +903,7 @@ def writeUBC_DCobs(
                     np.c_[
                         M, N,
                         data.dobs[count:count+nD],
-                        data.standard_deviation[count:count+nD]
+                        data.relative_error[count:count+nD]
                     ],
                     delimiter=str(' '), newline=str('\n'))
 
@@ -932,13 +932,13 @@ def writeUBC_DCobs(
             fid.close()
 
             fid = open(fileName, 'ab')
-            if isinstance(data.standard_deviation, np.ndarray):
+            if isinstance(data.relative_error, np.ndarray):
                 np.savetxt(
                     fid,
                     np.c_[
                         M, N, data.dobs[count:count+nD],
                         (
-                            data.standard_deviation[count:count+nD] +
+                            data.relative_error[count:count+nD] +
                             data.noise_floor[count:count+nD]
                         )
                     ],
@@ -948,7 +948,7 @@ def writeUBC_DCobs(
                 raise Exception(
                     """Uncertainities SurveyObject.std should be set.
                     Either float or nunmpy.ndarray is expected, """
-                    "not {}".format(type(data.standard_deviation)))
+                    "not {}".format(type(data.relative_error)))
 
             fid.close()
             fid = open(fileName, 'a')
@@ -1451,7 +1451,7 @@ def readUBC_DC3Dobs(fileName):
 
     survey = dc.Survey(srcLists)
     data = Data(
-        survey=survey, dobs=np.asarray(d), standard_deviation=np.asarray(wd)
+        survey=survey, dobs=np.asarray(d), relative_error=np.asarray(wd)
     )
     return data
 

--- a/SimPEG/electromagnetics/static/utils/static_utils.py
+++ b/SimPEG/electromagnetics/static/utils/static_utils.py
@@ -803,7 +803,7 @@ def writeUBC_DCobs(
 
     # if(isinstance(dc_survey.std, float)):
     #     print(
-    #         """survey.std was a float computing uncertainty vector
+    #         """survey.std was a float computing standard_deviation vector
     #         (survey.std*survey.dobs + survey.eps)"""
     #     )
 

--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -357,6 +357,11 @@ class BaseSimulation(props.HasModel):
 
         std = kwargs.pop('std', None)
         if std is not None:
+            warnings.warn(
+                'The std parameter will be deprecated in SimPEG 0.15.0. '
+                'Please use relative_error.',
+                DeprecationWarning,
+            )
             relative_error = std
 
         if f is None:

--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -345,19 +345,19 @@ class BaseSimulation(props.HasModel):
         return mkvc(self.dpred(m, f=f) - dobs)
 
     def make_synthetic_data(
-        self, m, standard_deviation=0.05, noise_floor=0.0, f=None, add_noise=False, **kwargs
+        self, m, relative_error=0.05, noise_floor=0.0, f=None, add_noise=False, **kwargs
     ):
         """
         Make synthetic data given a model, and a standard deviation.
         :param numpy.ndarray m: geophysical model
-        :param numpy.ndarray standard_deviation: standard deviation
+        :param numpy.ndarray relative_error: standard deviation
         :param numpy.ndarray noise_floor: noise floor
         :param numpy.ndarray f: fields for the given model (if pre-calculated)
         """
 
         std = kwargs.pop('std', None)
         if std is not None:
-            standard_deviation = std
+            relative_error = std
 
         if f is None:
             f = self.fields(m)
@@ -365,7 +365,7 @@ class BaseSimulation(props.HasModel):
         dclean = self.dpred(m, f=f)
 
         if add_noise is True:
-            std = (standard_deviation*abs(dclean) + noise_floor)
+            std = (relative_error*abs(dclean) + noise_floor)
             noise = std*np.random.randn(*dclean.shape)
             dobs = dclean + noise
         else:
@@ -373,7 +373,7 @@ class BaseSimulation(props.HasModel):
 
         return SyntheticData(
             survey=self.survey, dobs=dobs, dclean=dclean,
-            standard_deviation=standard_deviation, noise_floor=noise_floor
+            relative_error=relative_error, noise_floor=noise_floor
         )
 
     def pair(self, survey):

--- a/SimPEG/survey.py
+++ b/SimPEG/survey.py
@@ -363,22 +363,22 @@ class BaseSurvey(properties.HasProperties):
                 "0.15.0 of SimPEG", DeprecationWarning
             )
             if std is None and getattr(target, 'std', None) is None:
-                stddev = 0.05
+                rel_err = 0.05
                 print(
-                        'SimPEG.Survey assigned default std '
+                        'SimPEG.Survey assigned default rel_err '
                         'of 5%'
                     )
             elif std is None:
-                stddev = target.std
+                rel_err = target.std
             else:
-                stddev = std
+                rel_err = std
                 print(
-                        'SimPEG.Survey assigned new std '
-                        'of {:.2f}%'.format(100.*stddev)
+                        'SimPEG.Survey assigned new rel_err '
+                        'of {:.2f}%'.format(100.*rel_err)
                     )
 
             data = target.simulation.make_synthetic_data(
-                m, relative_error=stddev, f=f, add_noise=True)
+                m, relative_error=rel_err, f=f, add_noise=True)
             target.dtrue = data.dclean
             target.dobs = data.dobs
             target.std = data.relative_error

--- a/SimPEG/survey.py
+++ b/SimPEG/survey.py
@@ -378,10 +378,10 @@ class BaseSurvey(properties.HasProperties):
                     )
 
             data = target.simulation.make_synthetic_data(
-                m, standard_deviation=stddev, f=f, add_noise=True)
+                m, relative_error=stddev, f=f, add_noise=True)
             target.dtrue = data.dclean
             target.dobs = data.dobs
-            target.std = data.standard_deviation
+            target.std = data.relative_error
             return target.dobs
         self.makeSyntheticData = types.MethodType(dep_makeSyntheticData, self)
 

--- a/SimPEG/utils/io_utils.py
+++ b/SimPEG/utils/io_utils.py
@@ -288,7 +288,7 @@ def readUBCmagneticsObservations(obs_file):
     rxLoc = magnetics.receivers.Point(locXYZ)
     srcField = magnetics.sources.SourceField([rxLoc], parameters=(B[2], B[0], B[1]))
     survey = magnetics.survey.MagneticSurvey(srcField)
-    data_object = data.Data(survey, dobs=d, noise_floor=wd)
+    data_object = data.Data(survey, dobs=d, standard_deviation=wd)
 
     return data_object
 
@@ -372,7 +372,7 @@ def readUBCgravityObservations(obs_file):
     rxLoc = gravity.receivers.Point(locXYZ)
     srcField = gravity.sources.SourceField([rxLoc])
     survey = gravity.survey.GravitySurvey(srcField)
-    data_object = data.Data(survey, dobs=d, noise_floor=wd)
+    data_object = data.Data(survey, dobs=d, standard_deviation=wd)
     return data_object
 
 

--- a/SimPEG/utils/io_utils.py
+++ b/SimPEG/utils/io_utils.py
@@ -318,7 +318,7 @@ def writeUBCmagneticsObservations(filename, data_object):
     rxLoc = survey.source_field.receiver_list[0].locations
 
     d = data_object.dobs
-    wd = data_object.uncertainty
+    wd = data_object.standard_deviation
 
     data = np.c_[rxLoc, d, wd]
     head = ('%6.2f %6.2f %6.2f\n' % (B[1], B[2], B[0]) +
@@ -391,7 +391,7 @@ def writeUBCgravityObservations(filename, data_object):
 
     d = data_object.dobs
 
-    wd = data_object.uncertainty
+    wd = data_object.standard_deviation
 
     data = np.c_[rxLoc, d, wd]
     head = ('%i\n' % len(d))

--- a/examples/00_published/plot_booky_1D_time_freq_inv.py
+++ b/examples/00_published/plot_booky_1D_time_freq_inv.py
@@ -233,7 +233,7 @@ def run(plotIt=True, saveFig=False, cleanup=True):
     uncert = abs(dobs_re) * std + floor
 
     # Data Misfit
-    data_resolve = data.Data(dobs=dobs_re, survey=survey, uncertainty=uncert)
+    data_resolve = data.Data(dobs=dobs_re, survey=survey, standard_deviation=uncert)
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data_resolve)
 
     # Regularization
@@ -344,7 +344,7 @@ def run(plotIt=True, saveFig=False, cleanup=True):
     uncert = abs(dobs_sky) * std + floor
 
     # Data Misfit
-    data_sky = data.Data(dobs=-dobs_sky, survey=survey, uncertainty=uncert)
+    data_sky = data.Data(dobs=-dobs_sky, survey=survey, standard_deviation=uncert)
     dmisfit = data_misfit.L2DataMisfit(simulation=prob, data=data_sky)
 
     # Regularization

--- a/examples/00_published/plot_booky_1D_time_freq_inv.py
+++ b/examples/00_published/plot_booky_1D_time_freq_inv.py
@@ -228,9 +228,9 @@ def run(plotIt=True, saveFig=False, cleanup=True):
     ].flatten() * bp * 1e-6
 
     # Uncertainty
-    std = np.repeat(np.r_[np.ones(3)*0.1, np.ones(2)*0.15], 2)
+    relative = np.repeat(np.r_[np.ones(3)*0.1, np.ones(2)*0.15], 2)
     floor = 20 * abs(bp) * 1e-6
-    uncert = abs(dobs_re) * std + floor
+    uncert = abs(dobs_re) * relative + floor
 
     # Data Misfit
     data_resolve = data.Data(dobs=dobs_re, survey=survey, standard_deviation=uncert)
@@ -339,9 +339,9 @@ def run(plotIt=True, saveFig=False, cleanup=True):
 
     # ------------------ SkyTEM Inversion ------------------ #
     # Uncertainty
-    std = 0.12
+    relative = 0.12
     floor = 7.5e-12
-    uncert = abs(dobs_sky) * std + floor
+    uncert = abs(dobs_sky) * relative + floor
 
     # Data Misfit
     data_sky = data.Data(dobs=-dobs_sky, survey=survey, standard_deviation=uncert)

--- a/examples/00_published/plot_booky_1D_time_freq_inv.py
+++ b/examples/00_published/plot_booky_1D_time_freq_inv.py
@@ -230,10 +230,10 @@ def run(plotIt=True, saveFig=False, cleanup=True):
     # Uncertainty
     relative = np.repeat(np.r_[np.ones(3)*0.1, np.ones(2)*0.15], 2)
     floor = 20 * abs(bp) * 1e-6
-    uncert = abs(dobs_re) * relative + floor
+    std = abs(dobs_re) * relative + floor
 
     # Data Misfit
-    data_resolve = data.Data(dobs=dobs_re, survey=survey, standard_deviation=uncert)
+    data_resolve = data.Data(dobs=dobs_re, survey=survey, standard_deviation=std)
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data_resolve)
 
     # Regularization
@@ -341,10 +341,10 @@ def run(plotIt=True, saveFig=False, cleanup=True):
     # Uncertainty
     relative = 0.12
     floor = 7.5e-12
-    uncert = abs(dobs_sky) * relative + floor
+    std = abs(dobs_sky) * relative + floor
 
     # Data Misfit
-    data_sky = data.Data(dobs=-dobs_sky, survey=survey, standard_deviation=uncert)
+    data_sky = data.Data(dobs=-dobs_sky, survey=survey, standard_deviation=std)
     dmisfit = data_misfit.L2DataMisfit(simulation=prob, data=data_sky)
 
     # Regularization

--- a/examples/00_published/plot_booky_1Dstitched_resolve_inv.py
+++ b/examples/00_published/plot_booky_1Dstitched_resolve_inv.py
@@ -109,7 +109,7 @@ def resolve_1Dinversions(
     # ------------------- Inversion ------------------- #
     # data misfit term
     uncert = abs(dobs) * std + floor
-    data = data.Data(dobs=dobs, uncertainty=uncert)
+    data = data.Data(dobs=dobs, standard_deviation=uncert)
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data)
 
     # regularization

--- a/examples/00_published/plot_heagyetal2017_cyl_inversions.py
+++ b/examples/00_published/plot_heagyetal2017_cyl_inversions.py
@@ -78,8 +78,8 @@ def run(plotIt=True, saveFig=False):
     surveyFD = FDEM.Survey(srcList)
     prbFD = FDEM.Simulation3DMagneticFluxDensity(
         mesh, survey=surveyFD, sigmaMap=mapping, solver=Solver)
-    std = 0.03
-    dataFD = prbFD.make_synthetic_data(mtrue, relative_error=std, add_noise=True)
+    rel_err = 0.03
+    dataFD = prbFD.make_synthetic_data(mtrue, relative_error=rel_err, add_noise=True)
     dataFD.noise_floor = np.linalg.norm(dataFD.dclean)*1e-5
 
     # FDEM inversion
@@ -120,8 +120,8 @@ def run(plotIt=True, saveFig=False):
         mesh, survey=surveyTD, sigmaMap=mapping, Solver=Solver)
     prbTD.time_steps = [(5e-5, 10), (1e-4, 10), (5e-4, 10)]
 
-    std = 0.03
-    dataTD = prbTD.make_synthetic_data(mtrue, relative_error=std, add_noise=True)
+    rel_err = 0.03
+    dataTD = prbTD.make_synthetic_data(mtrue, relative_error=rel_err, add_noise=True)
     dataTD.noise_floor = np.linalg.norm(dataTD.dclean)*1e-5
 
     # TDEM inversion

--- a/examples/00_published/plot_heagyetal2017_cyl_inversions.py
+++ b/examples/00_published/plot_heagyetal2017_cyl_inversions.py
@@ -79,7 +79,7 @@ def run(plotIt=True, saveFig=False):
     prbFD = FDEM.Simulation3DMagneticFluxDensity(
         mesh, survey=surveyFD, sigmaMap=mapping, solver=Solver)
     std = 0.03
-    dataFD = prbFD.make_synthetic_data(mtrue, standard_deviation=std, add_noise=True)
+    dataFD = prbFD.make_synthetic_data(mtrue, relative_error=std, add_noise=True)
     dataFD.noise_floor = np.linalg.norm(dataFD.dclean)*1e-5
 
     # FDEM inversion
@@ -121,7 +121,7 @@ def run(plotIt=True, saveFig=False):
     prbTD.time_steps = [(5e-5, 10), (1e-4, 10), (5e-4, 10)]
 
     std = 0.03
-    dataTD = prbTD.make_synthetic_data(mtrue, standard_deviation=std, add_noise=True)
+    dataTD = prbTD.make_synthetic_data(mtrue, relative_error=std, add_noise=True)
     dataTD.noise_floor = np.linalg.norm(dataTD.dclean)*1e-5
 
     # TDEM inversion

--- a/examples/01-basic/plot_inversion_linear.py
+++ b/examples/01-basic/plot_inversion_linear.py
@@ -47,7 +47,7 @@ def run(N=100, plotIt=True):
     mtrue[mesh.vectorCCx > 0.6] = 0
 
     prob = simulation.LinearSimulation(mesh, G=G, model_map=maps.IdentityMap(mesh))
-    data = prob.make_synthetic_data(mtrue, standard_deviation=0.01, add_noise=True)
+    data = prob.make_synthetic_data(mtrue, relative_error=0.01, add_noise=True)
 
     M = prob.mesh
 

--- a/examples/01-basic/plot_inversion_linear_irls.py
+++ b/examples/01-basic/plot_inversion_linear_irls.py
@@ -57,7 +57,7 @@ def run(N=100, plotIt=True):
 
     prob = LinearSimulation(mesh, G=G, model_map=maps.IdentityMap(mesh))
     data = prob.make_synthetic_data(mtrue,
-        standard_deviation=0.0,
+        relative_error=0.0,
         noise_floor=std_noise,
         add_noise=True)
 

--- a/examples/03-maps/plot_sumMap.py
+++ b/examples/03-maps/plot_sumMap.py
@@ -90,7 +90,7 @@ def run(plotIt=True):
 
     # Compute linear forward operator and compute some data
     data = prob.make_synthetic_data(
-        model, standard_deviation=0.0, noise_floor=1, add_noise=True)
+        model, relative_error=0.0, noise_floor=1, add_noise=True)
 
     # Create a homogenous maps for the two domains
     domains = [mesh.gridCC[actv,0] < 0, mesh.gridCC[actv,0] >= 0]

--- a/examples/03-maps/plot_sumMap.py
+++ b/examples/03-maps/plot_sumMap.py
@@ -121,7 +121,7 @@ def run(plotIt=True):
     scale = utils.sdiag(np.r_[utils.mkvc(1./homogMap.P.sum(axis=0)),np.ones_like(actv)])
 
     for ii in range(survey.nD):
-        wr += ((prob.G[ii, :]*prob.chiMap.deriv(np.ones(sumMap.shape[1])*1e-4)*scale)/data.uncertainty[ii])**2.
+        wr += ((prob.G[ii, :]*prob.chiMap.deriv(np.ones(sumMap.shape[1])*1e-4)*scale)/data.standard_deviation[ii])**2.
 
     # Scale the model spaces independently
     wr[wires.homo.index] /= (np.max((wires.homo*wr)))

--- a/examples/04-grav/plot_laguna_del_maule_inversion.py
+++ b/examples/04-grav/plot_laguna_del_maule_inversion.py
@@ -66,7 +66,6 @@ def run(plotIt=True, cleanAfterRun=True):
 
     # define gravity data and errors
     d = data_object.dobs
-    wd = data_object.standard_deviation
 
     # Get the active cells
     active = driver.activeCells
@@ -109,7 +108,6 @@ def run(plotIt=True, cleanAfterRun=True):
 
     # Define misfit function (obs-calc)
     dmis = data_misfit.L2DataMisfit(data=data_object, simulation=simulation)
-    dmis.W = 1./wd
 
     # create the default L2 inverse problem from the above objects
     invProb = inverse_problem.BaseInvProblem(dmis, reg, opt)

--- a/examples/04-grav/plot_laguna_del_maule_inversion.py
+++ b/examples/04-grav/plot_laguna_del_maule_inversion.py
@@ -66,7 +66,7 @@ def run(plotIt=True, cleanAfterRun=True):
 
     # define gravity data and errors
     d = data_object.dobs
-    wd = data_object.uncertainty
+    wd = data_object.standard_deviation
 
     # Get the active cells
     active = driver.activeCells

--- a/examples/04-grav/plot_tiled_inversion_grav.py
+++ b/examples/04-grav/plot_tiled_inversion_grav.py
@@ -169,7 +169,7 @@ for ii, local_survey in enumerate(local_surveys):
     data_object = data.Data(
         local_survey,
         dobs=synthetic_data[local_indices[ii]],
-        uncertainty=wd[local_indices[ii]]
+        standard_deviation=wd[local_indices[ii]]
     )
 
     local_misfits.append(

--- a/examples/05-mag/plot_MVI_Sparse_TreeMesh.py
+++ b/examples/05-mag/plot_MVI_Sparse_TreeMesh.py
@@ -234,7 +234,7 @@ synthetic_data = d + np.random.randn(len(d))*std
 wd = np.ones(len(d))*std
 
 # Assign data and uncertainties to the survey
-data_object = data.Data(survey, dobs=synthetic_data, noise_floor=wd)
+data_object = data.Data(survey, dobs=synthetic_data, standard_deviation=wd)
 
 # Create an projection matrix for plotting later
 actv_plot = maps.InjectActiveCells(mesh, actv, np.nan)

--- a/examples/05-mag/plot_MVI_Sparse_TreeMesh.py
+++ b/examples/05-mag/plot_MVI_Sparse_TreeMesh.py
@@ -300,7 +300,7 @@ reg.mref = np.zeros(3*nC)
 
 # Data misfit function
 dmis = data_misfit.L2DataMisfit(simulation=simulation, data=data_object)
-dmis.W = 1./data_object.uncertainty
+dmis.W = 1./data_object.standard_deviation
 
 # Add directives to the inversion
 opt = optimization.ProjectedGNCG(maxIter=10, lower=-10, upper=10.,

--- a/examples/05-mag/plot_nonLinear_Amplitude.py
+++ b/examples/05-mag/plot_nonLinear_Amplitude.py
@@ -150,7 +150,7 @@ synthetic_data += np.random.randn(nD)*std
 wd = np.ones(nD)*std
 
 # Assigne data and uncertainties to the survey
-data_object = data.Data(survey, dobs=synthetic_data, noise_floor=wd)
+data_object = data.Data(survey, dobs=synthetic_data, standard_deviation=wd)
 
 
 # Plot the model and data

--- a/examples/06-dc/plot_dc_schlumberger_array.py
+++ b/examples/06-dc/plot_dc_schlumberger_array.py
@@ -199,7 +199,7 @@ problem = DC.Simulation3DCellCentered(
 # To make synthetic example you can use simulation.make_synthetic_data, which
 # generates related setups.
 
-data = problem.make_synthetic_data(mtrue, standard_deviation=0.01, add_noise=True)
+data = problem.make_synthetic_data(mtrue, relative_error=0.01, add_noise=True)
 
 appres = data.dclean*np.pi*b*(b+a)/a
 appres_obs = data.dobs*np.pi*b*(b+a)/a

--- a/examples/06-dc/plot_dipoledipole_2Dinversion_twocylinders.py
+++ b/examples/06-dc/plot_dipoledipole_2Dinversion_twocylinders.py
@@ -115,7 +115,7 @@ mapping = expmap * mapactive
 problem = DC.Simulation3DCellCentered(
     mesh, survey=survey, sigmaMap=mapping, solver=Solver, bc_type='Neumann')
 
-data = problem.make_synthetic_data(mtrue[actind], standard_deviation=0.05, add_noise=True)
+data = problem.make_synthetic_data(mtrue[actind], relative_error=0.05, add_noise=True)
 
 # Tikhonov Inversion
 ####################

--- a/examples/06-dc/plot_dipoledipole_2_5Dinversion.py
+++ b/examples/06-dc/plot_dipoledipole_2_5Dinversion.py
@@ -111,7 +111,7 @@ def run(plotIt=True, survey_type="dipole-dipole"):
     )
 
     # Make synthetic DC data with 5% Gaussian noise
-    data = prb.make_synthetic_data(mtrue, standard_deviation=0.05, add_noise=True)
+    data = prb.make_synthetic_data(mtrue, relative_error=0.05, add_noise=True)
 
     IO.data_dc = data.dobs
     # Show apparent resisitivty pseudo-section

--- a/examples/06-dc/plot_dipoledipole_2_5Dinversion.py
+++ b/examples/06-dc/plot_dipoledipole_2_5Dinversion.py
@@ -134,9 +134,9 @@ def run(plotIt=True, survey_type="dipole-dipole"):
     # floor (10 ohm-m)
     eps = 1.
     # percentage
-    std = 0.05
+    relative = 0.05
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data)
-    uncert = abs(data.dobs) * std + eps
+    uncert = abs(data.dobs) * relative + eps
     dmisfit.standard_deviation = uncert
 
     # Map for a regularization

--- a/examples/06-dc/plot_dipoledipole_2_5Dinversion.py
+++ b/examples/06-dc/plot_dipoledipole_2_5Dinversion.py
@@ -130,14 +130,14 @@ def run(plotIt=True, survey_type="dipole-dipole"):
     # Set initial model based upon histogram
     m0 = np.ones(actmap.nP)*np.log(100.)
 
-    # Set uncertainty
+    # Set standard_deviation
     # floor (10 ohm-m)
     eps = 1.
     # percentage
     std = 0.05
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data)
     uncert = abs(data.dobs) * std + eps
-    dmisfit.uncertainty = uncert
+    dmisfit.standard_deviation = uncert
 
     # Map for a regularization
     regmap = maps.IdentityMap(nP=int(actind.sum()))

--- a/examples/06-dc/plot_dipoledipole_2_5Dinversion_irls.py
+++ b/examples/06-dc/plot_dipoledipole_2_5Dinversion_irls.py
@@ -113,7 +113,7 @@ def run(plotIt=True, survey_type="dipole-dipole", p=0., qx=2., qz=2.):
     )
 
     # Make synthetic DC data with 5% Gaussian noise
-    data = prb.make_synthetic_data(mtrue, standard_deviation=0.05, add_noise=True)
+    data = prb.make_synthetic_data(mtrue, relative_error=0.05, add_noise=True)
 
     IO.data_dc = data.dobs
     # Show apparent resisitivty pseudo-section

--- a/examples/06-dc/plot_dipoledipole_2_5Dinversion_irls.py
+++ b/examples/06-dc/plot_dipoledipole_2_5Dinversion_irls.py
@@ -136,9 +136,9 @@ def run(plotIt=True, survey_type="dipole-dipole", p=0., qx=2., qz=2.):
     # floor
     eps = 10**(-3.2)
     # percentage
-    std = 0.05
+    relative = 0.05
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data)
-    uncert = abs(data.dobs) * std + eps
+    uncert = abs(data.dobs) * relative + eps
     dmisfit.standard_deviation = uncert
 
     # Map for a regularization

--- a/examples/06-dc/plot_dipoledipole_2_5Dinversion_irls.py
+++ b/examples/06-dc/plot_dipoledipole_2_5Dinversion_irls.py
@@ -132,14 +132,14 @@ def run(plotIt=True, survey_type="dipole-dipole", p=0., qx=2., qz=2.):
     # Set initial model based upon histogram
     m0 = np.ones(actmap.nP)*np.log(100.)
 
-    # Set uncertainty
+    # Set standard_deviation
     # floor
     eps = 10**(-3.2)
     # percentage
     std = 0.05
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data)
     uncert = abs(data.dobs) * std + eps
-    dmisfit.uncertainty = uncert
+    dmisfit.standard_deviation = uncert
 
     # Map for a regularization
     regmap = maps.IdentityMap(nP=int(actind.sum()))

--- a/examples/06-dc/plot_dipoledipole_3Dinversion_twospheres.py
+++ b/examples/06-dc/plot_dipoledipole_3Dinversion_twospheres.py
@@ -140,7 +140,7 @@ mapping = expmap * mapactive
 problem = DC.Simulation3DCellCentered(
     mesh, survey=survey, sigmaMap=mapping, solver=Solver, bc_type='Neumann')
 
-data = problem.make_synthetic_data(mtrue[actind], standard_deviation=0.05, add_noise=True)
+data = problem.make_synthetic_data(mtrue[actind], relative_error=0.05, add_noise=True)
 
 # Tikhonov Inversion
 ####################

--- a/examples/06-dc/plot_dipoledipole_parametric_inversion.py
+++ b/examples/06-dc/plot_dipoledipole_parametric_inversion.py
@@ -145,14 +145,14 @@ def run(
     fig = plt.figure()
     out = hist(data.dobs/IO.G, bins=20)
     plt.show()
-    # Set uncertainty
+    # Set standard_deviation
     # floor
     eps = 10**(-3.2)
     # percentage
     std = 0.05
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data)
     uncert = abs(data.dobs) * std + eps
-    dmisfit.uncertainty = uncert
+    dmisfit.standard_deviation = uncert
 
     # Map for a regularization
     mesh_1d = discretize.TensorMesh([parametric_block.nP])

--- a/examples/06-dc/plot_dipoledipole_parametric_inversion.py
+++ b/examples/06-dc/plot_dipoledipole_parametric_inversion.py
@@ -134,7 +134,7 @@ def run(
     )
 
     # Make synthetic DC data with 5% Gaussian noise
-    data = prb.make_synthetic_data(mtrue, std=0.05, add_noise=True)
+    data = prb.make_synthetic_data(mtrue, relative_error=0.05, add_noise=True)
 
     # Show apparent resisitivty pseudo-section
     IO.plotPseudoSection(
@@ -149,9 +149,9 @@ def run(
     # floor
     eps = 10**(-3.2)
     # percentage
-    std = 0.05
+    relative = 0.05
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data)
-    uncert = abs(data.dobs) * std + eps
+    uncert = abs(data.dobs) * relative + eps
     dmisfit.standard_deviation = uncert
 
     # Map for a regularization

--- a/examples/07-fdem/plot_loop_loop_2Dinversion.py
+++ b/examples/07-fdem/plot_loop_loop_2Dinversion.py
@@ -204,7 +204,7 @@ prob = FDEM.Simulation3DMagneticFluxDensity(mesh, survey=survey, sigmaMap=mappin
 t = time.time()
 
 data = prob.make_synthetic_data(
-    m_true, standard_deviation=0.05, noise_floor=1E-11, add_noise=False)
+    m_true, relative_error=0.05, noise_floor=1E-11, add_noise=False)
 
 dclean = data.dclean
 print(

--- a/examples/08-nsem/plot_foward_MTTipper3D.py
+++ b/examples/08-nsem/plot_foward_MTTipper3D.py
@@ -81,8 +81,7 @@ def run(plotIt=True):
     # data = problem.make_synthetic_data(relative_error=0.1, add_noise=True)
     data = NSEM.Data(
         survey=survey, dobs=problem.dpred())
-    # Add standard_deviation to the data - 10% standard
-    # devation and 0 floor
+    # Add standard deviation to the data - 10% relative error and 0 floor
     data.relative_error = 0.1
     data.noise_floor = 0.0
 

--- a/examples/08-nsem/plot_foward_MTTipper3D.py
+++ b/examples/08-nsem/plot_foward_MTTipper3D.py
@@ -81,7 +81,7 @@ def run(plotIt=True):
     # data = problem.make_synthetic_data(relative_error=0.1, add_noise=True)
     data = NSEM.Data(
         survey=survey, dobs=problem.dpred())
-    # Add uncertainty to the data - 10% standard
+    # Add standard_deviation to the data - 10% standard
     # devation and 0 floor
     data.relative_error = 0.1
     data.noise_floor = 0.0

--- a/examples/08-nsem/plot_foward_MTTipper3D.py
+++ b/examples/08-nsem/plot_foward_MTTipper3D.py
@@ -78,12 +78,12 @@ def run(plotIt=True):
         sigma=sig, sigmaPrimary=sigBG)
 
     # Calculate the data
-    # data = problem.make_synthetic_data(standard_deviation=0.1, add_noise=True)
+    # data = problem.make_synthetic_data(relative_error=0.1, add_noise=True)
     data = NSEM.Data(
         survey=survey, dobs=problem.dpred())
     # Add uncertainty to the data - 10% standard
     # devation and 0 floor
-    data.standard_deviation = 0.1
+    data.relative_error = 0.1
     data.noise_floor = 0.0
 
     # Add plots

--- a/examples/09-tdem/plot_inversion_1D.py
+++ b/examples/09-tdem/plot_inversion_1D.py
@@ -53,7 +53,7 @@ def run(plotIt=True):
 
     # create observed data
     std = 0.05
-    data = simulation.make_synthetic_data(mtrue, standard_deviation=std)
+    data = simulation.make_synthetic_data(mtrue, relative_error=std)
 
 
     dmisfit = data_misfit.L2DataMisfit(simulation=simulation, data=data)

--- a/examples/09-tdem/plot_inversion_1D.py
+++ b/examples/09-tdem/plot_inversion_1D.py
@@ -52,8 +52,8 @@ def run(plotIt=True):
 
 
     # create observed data
-    std = 0.05
-    data = simulation.make_synthetic_data(mtrue, relative_error=std)
+    rel_err = 0.05
+    data = simulation.make_synthetic_data(mtrue, relative_error=rel_err)
 
 
     dmisfit = data_misfit.L2DataMisfit(simulation=simulation, data=data)

--- a/examples/09-tdem/plot_inversion_1D_raw_waveform.py
+++ b/examples/09-tdem/plot_inversion_1D_raw_waveform.py
@@ -59,7 +59,7 @@ def run(plotIt=True):
     prb.survey = survey
 
     # create observed data
-    data = prb.make_synthetic_data(mtrue, standard_deviation=0.02, noise_floor=1e-11)
+    data = prb.make_synthetic_data(mtrue, relative_error=0.02, noise_floor=1e-11)
 
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data)
     regMesh = discretize.TensorMesh([mesh.hz[mapping.maps[-1].indActive]])

--- a/examples/10-flow/plot_richards_inverse_1D.py
+++ b/examples/10-flow/plot_richards_inverse_1D.py
@@ -83,9 +83,9 @@ def run(plotIt=True):
     m0 = np.ones(M.nC)*np.log(Ks)
 
     # Create some synthetic data and fields
-    stdev = 0.02  # The standard deviation for the noise
+    relative = 0.02  # The standard deviation for the noise
     Hs = prob.fields(mtrue)
-    data = prob.make_synthetic_data(mtrue, std=stdev, f=Hs, add_noise=True)
+    data = prob.make_synthetic_data(mtrue, relative_error=relative, f=Hs, add_noise=True)
 
     # Setup a pretty standard inversion
     reg = regularization.Tikhonov(M, alpha_s=1e-1)

--- a/examples/11-seis/plot_seis_straight_ray_tomo.py
+++ b/examples/11-seis/plot_seis_straight_ray_tomo.py
@@ -49,7 +49,7 @@ def run(plotIt=False):
         M, survey=survey, slownessMap=maps.IdentityMap(M))
 
     s = utils.mkvc(utils.model_builder.randomModel(M.vnC)) + 1.
-    data = problem.make_synthetic_data(s, standard_deviation=0.01)
+    data = problem.make_synthetic_data(s, relative_error=0.01)
 
     # Create an optimization program
 

--- a/examples/11-seis/plot_tomo_joint_with_volume.py
+++ b/examples/11-seis/plot_tomo_joint_with_volume.py
@@ -131,7 +131,7 @@ def run(plotIt=True):
         cb.set_label('$\\varphi$')
 
     # get observed data
-    data = problem.make_synthetic_data(phitrue, std=0.03, add_noise=True)
+    data = problem.make_synthetic_data(phitrue, relative_error=0.03, add_noise=True)
     dpred = problem.dpred(np.zeros(M.nC))
 
     # objective function pieces

--- a/examples/12-ip/plot_dcip_2_5Dinversion.py
+++ b/examples/12-ip/plot_dcip_2_5Dinversion.py
@@ -172,7 +172,7 @@ def run(plotIt=True, survey_type="dipole-dipole"):
 
     # Set initial model based upon histogram
     m0_dc = np.ones(actmap.nP)*np.log(100.)
-    # Set uncertainty
+    # Set standard_deviation
     # floor
     data_dc.noise_floor = 10**(-3.2)
     # percentage
@@ -237,7 +237,7 @@ def run(plotIt=True, survey_type="dipole-dipole"):
 
     # Set initial model based upon histogram
     m0_ip = np.ones(actmap.nP)*1e-10
-    # Set uncertainty
+    # Set standard_deviation
     # floor
     data_ip.noise_floor = 10**(-4)
     # percentage

--- a/examples/12-ip/plot_dcip_2_5Dinversion.py
+++ b/examples/12-ip/plot_dcip_2_5Dinversion.py
@@ -172,7 +172,7 @@ def run(plotIt=True, survey_type="dipole-dipole"):
 
     # Set initial model based upon histogram
     m0_dc = np.ones(actmap.nP)*np.log(100.)
-    # Set standard_deviation
+    # Set standard deviation
     # floor
     data_dc.noise_floor = 10**(-3.2)
     # percentage
@@ -237,7 +237,7 @@ def run(plotIt=True, survey_type="dipole-dipole"):
 
     # Set initial model based upon histogram
     m0_ip = np.ones(actmap.nP)*1e-10
-    # Set standard_deviation
+    # Set standard deviation
     # floor
     data_ip.noise_floor = 10**(-4)
     # percentage

--- a/examples/12-ip/plot_dcip_2_5Dinversion.py
+++ b/examples/12-ip/plot_dcip_2_5Dinversion.py
@@ -176,7 +176,7 @@ def run(plotIt=True, survey_type="dipole-dipole"):
     # floor
     data_dc.noise_floor = 10**(-3.2)
     # percentage
-    data_dc.standard_deviation = 0.05
+    data_dc.relative_error = 0.05
 
     mopt_dc, pred_dc = DC.run_inversion(
         m0_dc, prb, data_dc, actind, mesh,
@@ -241,7 +241,7 @@ def run(plotIt=True, survey_type="dipole-dipole"):
     # floor
     data_ip.noise_floor = 10**(-4)
     # percentage
-    data_ip.standard_deviation = 0.05
+    data_ip.relative_error = 0.05
     # Clean sensitivity function formed with true resistivity
     prb_ip._Jmatrix = None
     # Input obtained resistivity to form sensitivity

--- a/examples/12-ip/plot_dcip_2_5Dinversion.py
+++ b/examples/12-ip/plot_dcip_2_5Dinversion.py
@@ -125,7 +125,7 @@ def run(plotIt=True, survey_type="dipole-dipole"):
     )
 
     # Make synthetic DC data with 5% Gaussian noise
-    data_dc = prb.make_synthetic_data(mtrue_dc, std=0.05, add_noise=True)
+    data_dc = prb.make_synthetic_data(mtrue_dc, relative_error=0.05, add_noise=True)
     IO.data_dc = data_dc.dobs
 
     # Generate mtrue_ip for chargability
@@ -138,7 +138,7 @@ def run(plotIt=True, survey_type="dipole-dipole"):
         solver=Solver
     )
 
-    data_ip = prb_ip.make_synthetic_data(mtrue_ip, std=0.05, add_noise=True)
+    data_ip = prb_ip.make_synthetic_data(mtrue_ip, relative_error=0.05, add_noise=True)
 
     IO.data_ip = data_ip.dobs
 

--- a/examples/13-vrm/plot_vrm_inv.py
+++ b/examples/13-vrm/plot_vrm_inv.py
@@ -160,9 +160,9 @@ problem_inv = VRM.Simulation3DLinear(
 survey_vrm.set_active_interval(1e-3, 1e-2)
 
 dobs = fields_tot[survey_vrm.t_active]
-std = 0.05*np.abs(fields_tot[survey_vrm.t_active])
+rel_err = 0.05
 eps = 1e-11
-data_vrm = data.Data(dobs=dobs, survey=survey_vrm, relative_error=std, noise_floor=eps)
+data_vrm = data.Data(dobs=dobs, survey=survey_vrm, relative_error=rel_err, noise_floor=eps)
 
 # Setup and run inversion
 dmis = data_misfit.L2DataMisfit(simulation=problem_inv, data=data_vrm)

--- a/examples/13-vrm/plot_vrm_inv.py
+++ b/examples/13-vrm/plot_vrm_inv.py
@@ -162,7 +162,7 @@ survey_vrm.set_active_interval(1e-3, 1e-2)
 dobs = fields_tot[survey_vrm.t_active]
 std = 0.05*np.abs(fields_tot[survey_vrm.t_active])
 eps = 1e-11
-data_vrm = data.Data(dobs=dobs, survey=survey_vrm, standard_deviation=std, noise_floor=eps)
+data_vrm = data.Data(dobs=dobs, survey=survey_vrm, relative_error=std, noise_floor=eps)
 
 # Setup and run inversion
 dmis = data_misfit.L2DataMisfit(simulation=problem_inv, data=data_vrm)

--- a/tests/base/test_data.py
+++ b/tests/base/test_data.py
@@ -29,13 +29,13 @@ class DataTest(unittest.TestCase):
 
 
     def test_instantiation_relative_error(self):
-        std = 0.5
-        data = Data(self.sim.survey, dobs=self.dobs, relative_error=std)
+        relative = 0.5
+        data = Data(self.sim.survey, dobs=self.dobs, relative_error=relative)
         self.assertTrue(
-            all(data.relative_error == std*np.ones(len(self.dobs)))
+            all(data.relative_error == relative*np.ones(len(self.dobs)))
         )
         self.assertTrue(
-            all(data.standard_deviation == std*np.abs(self.dobs))
+            all(data.standard_deviation == relative*np.abs(self.dobs))
         )
 
     def test_instantiation_noise_floor(self):
@@ -48,24 +48,24 @@ class DataTest(unittest.TestCase):
             all(data.standard_deviation == floor*np.ones(len(self.dobs)))
         )
 
-    def test_instantiation_std_floor(self):
-        std = 0.5
+    def test_instantiation_relative_floor(self):
+        relative = 0.5
         floor = np.min(np.abs(self.dobs))
-        data = Data(self.sim.survey, dobs=self.dobs, relative_error=std, noise_floor=floor)
+        data = Data(self.sim.survey, dobs=self.dobs, relative_error=relative, noise_floor=floor)
         self.assertTrue(
-            all(data.relative_error == std*np.ones(len(self.dobs)))
+            all(data.relative_error == relative*np.ones(len(self.dobs)))
         )
         self.assertTrue(
             all(data.noise_floor == floor*np.ones(len(self.dobs)))
         )
         self.assertTrue(
-            np.allclose(data.standard_deviation, std*np.abs(self.dobs) + floor*np.ones(len(self.dobs)))
+            np.allclose(data.standard_deviation, relative*np.abs(self.dobs) + floor*np.ones(len(self.dobs)))
         )
 
     def test_instantiation_standard_deviation(self):
-        std = 0.5
+        relative = 0.5
         floor = np.min(np.abs(self.dobs))
-        standard_deviation = std*np.abs(self.dobs) + floor*np.ones(len(self.dobs))
+        standard_deviation = relative*np.abs(self.dobs) + floor*np.ones(len(self.dobs))
         data = Data(self.sim.survey, dobs=self.dobs, standard_deviation=standard_deviation)
 
         self.assertTrue(

--- a/tests/base/test_data.py
+++ b/tests/base/test_data.py
@@ -28,11 +28,11 @@ class DataTest(unittest.TestCase):
         self.dobs = self.sim.dpred(model)
 
 
-    def test_instantiation_standard_deviation(self):
+    def test_instantiation_relative_error(self):
         std = 0.5
-        data = Data(self.sim.survey, dobs=self.dobs, standard_deviation=std)
+        data = Data(self.sim.survey, dobs=self.dobs, relative_error=std)
         self.assertTrue(
-            all(data.standard_deviation == std*np.ones(len(self.dobs)))
+            all(data.relative_error == std*np.ones(len(self.dobs)))
         )
         self.assertTrue(
             all(data.uncertainty == std*np.abs(self.dobs))
@@ -51,9 +51,9 @@ class DataTest(unittest.TestCase):
     def test_instantiation_std_floor(self):
         std = 0.5
         floor = np.min(np.abs(self.dobs))
-        data = Data(self.sim.survey, dobs=self.dobs, standard_deviation=std, noise_floor=floor)
+        data = Data(self.sim.survey, dobs=self.dobs, relative_error=std, noise_floor=floor)
         self.assertTrue(
-            all(data.standard_deviation == std*np.ones(len(self.dobs)))
+            all(data.relative_error == std*np.ones(len(self.dobs)))
         )
         self.assertTrue(
             all(data.noise_floor == floor*np.ones(len(self.dobs)))

--- a/tests/base/test_data.py
+++ b/tests/base/test_data.py
@@ -35,7 +35,7 @@ class DataTest(unittest.TestCase):
             all(data.relative_error == std*np.ones(len(self.dobs)))
         )
         self.assertTrue(
-            all(data.uncertainty == std*np.abs(self.dobs))
+            all(data.standard_deviation == std*np.abs(self.dobs))
         )
 
     def test_instantiation_noise_floor(self):
@@ -45,7 +45,7 @@ class DataTest(unittest.TestCase):
             all(data.noise_floor == floor*np.ones(len(self.dobs)))
         )
         self.assertTrue(
-            all(data.uncertainty == floor*np.ones(len(self.dobs)))
+            all(data.standard_deviation == floor*np.ones(len(self.dobs)))
         )
 
     def test_instantiation_std_floor(self):
@@ -59,20 +59,20 @@ class DataTest(unittest.TestCase):
             all(data.noise_floor == floor*np.ones(len(self.dobs)))
         )
         self.assertTrue(
-            np.allclose(data.uncertainty, std*np.abs(self.dobs) + floor*np.ones(len(self.dobs)))
+            np.allclose(data.standard_deviation, std*np.abs(self.dobs) + floor*np.ones(len(self.dobs)))
         )
 
-    def test_instantiation_uncertainty(self):
+    def test_instantiation_standard_deviation(self):
         std = 0.5
         floor = np.min(np.abs(self.dobs))
-        uncertainty = std*np.abs(self.dobs) + floor*np.ones(len(self.dobs))
-        data = Data(self.sim.survey, dobs=self.dobs, uncertainty=uncertainty)
+        standard_deviation = std*np.abs(self.dobs) + floor*np.ones(len(self.dobs))
+        data = Data(self.sim.survey, dobs=self.dobs, standard_deviation=standard_deviation)
 
         self.assertTrue(
-            all(data.noise_floor == uncertainty)
+            all(data.noise_floor == standard_deviation)
         )
         self.assertTrue(
-            all(data.uncertainty == uncertainty)
+            all(data.standard_deviation == standard_deviation)
         )
 
 if __name__ == '__main__':

--- a/tests/base/test_data_misfit.py
+++ b/tests/base/test_data_misfit.py
@@ -31,10 +31,10 @@ class DataMisfitTest(unittest.TestCase):
         synthetic_data = sim.make_synthetic_data(model)
         dobs = synthetic_data.dobs
 
-        self.std = 0.01
+        self.relative = 0.01
         self.eps = 1e-8
 
-        synthetic_data.relative_error = self.std
+        synthetic_data.relative_error = self.relative
         synthetic_data.noise_floor = self.eps
 
         dmis = data_misfit.L2DataMisfit(simulation=sim, data=synthetic_data)
@@ -65,7 +65,7 @@ class DataMisfitTest(unittest.TestCase):
             Worig = self.dmis.W
 
     def test_setting_W(self):
-        self.data.relative_error = self.std
+        self.data.relative_error = self.relative
         self.data.noise_floor = self.eps
         Worig = self.dmis.W
         v = np.random.rand(self.survey.nD)
@@ -80,7 +80,7 @@ class DataMisfitTest(unittest.TestCase):
         self.dmis.W = Worig
 
     def test_DataMisfitOrder(self):
-        self.data.relative_error = self.std
+        self.data.relative_error = self.relative
         self.data.noise_floor = self.eps
         self.dmis.test(x=self.model)
 

--- a/tests/base/test_data_misfit.py
+++ b/tests/base/test_data_misfit.py
@@ -34,7 +34,7 @@ class DataMisfitTest(unittest.TestCase):
         self.std = 0.01
         self.eps = 1e-8
 
-        synthetic_data.standard_deviation = self.std
+        synthetic_data.relative_error = self.std
         synthetic_data.noise_floor = self.eps
 
         dmis = data_misfit.L2DataMisfit(simulation=sim, data=synthetic_data)
@@ -59,13 +59,13 @@ class DataMisfitTest(unittest.TestCase):
         self.assertTrue(self.dmis.nP == self.mesh.nC)
 
     def test_zero_uncertainties(self):
-        self.data.standard_deviation = 0.
+        self.data.relative_error = 0.
         self.data.noise_floor = 0.
         with self.assertRaises(Exception):
             Worig = self.dmis.W
 
     def test_setting_W(self):
-        self.data.standard_deviation = self.std
+        self.data.relative_error = self.std
         self.data.noise_floor = self.eps
         Worig = self.dmis.W
         v = np.random.rand(self.survey.nD)
@@ -80,7 +80,7 @@ class DataMisfitTest(unittest.TestCase):
         self.dmis.W = Worig
 
     def test_DataMisfitOrder(self):
-        self.data.standard_deviation = self.std
+        self.data.relative_error = self.std
         self.data.noise_floor = self.eps
         self.dmis.test(x=self.model)
 

--- a/tests/base/test_directives.py
+++ b/tests/base/test_directives.py
@@ -84,7 +84,7 @@ class ValidationInInversion(unittest.TestCase):
 
         # Data misfit function
         dmis = data_misfit.L2DataMisfit(data)
-        dmis.W = 1./data.standard_deviation
+        dmis.W = 1./data.relative_error
 
         # Add directives to the inversion
         opt = optimization.ProjectedGNCG(

--- a/tests/base/test_simulation.py
+++ b/tests/base/test_simulation.py
@@ -34,7 +34,7 @@ class TestLinearSimulation(unittest.TestCase):
         dclean = self.sim.dpred(self.mtrue)
         data = self.sim.make_synthetic_data(self.mtrue)
         assert np.all(
-            data.standard_deviation == 0.05 * np.ones_like(dclean)
+            data.relative_error == 0.05 * np.ones_like(dclean)
         )
 
 

--- a/tests/base/test_survey_data.py
+++ b/tests/base/test_survey_data.py
@@ -47,13 +47,13 @@ class TestData(unittest.TestCase):
                 v = np.random.rand(rx.nD)
                 V += [v]
                 index = self.D.index_dictionary[src][rx]
-                self.D.standard_deviation[index] = v
-                self.assertTrue(np.all(v == self.D.standard_deviation[index]))
+                self.D.relative_error[index] = v
+                self.assertTrue(np.all(v == self.D.relative_error[index]))
         V = np.concatenate(V)
-        self.assertTrue(np.all(V == self.D.standard_deviation))
+        self.assertTrue(np.all(V == self.D.relative_error))
 
-        D2 = data.Data(self.D.survey, standard_deviation=V)
-        self.assertTrue(np.all(D2.standard_deviation == self.D.standard_deviation))
+        D2 = data.Data(self.D.survey, relative_error=V)
+        self.assertTrue(np.all(D2.relative_error == self.D.relative_error))
 
     def test_uniqueSrcs(self):
         srcs = self.D.survey.source_list

--- a/tests/dask/test_grav_inversion_linear.py
+++ b/tests/dask/test_grav_inversion_linear.py
@@ -85,7 +85,7 @@ class GravInvLinProblemTest(unittest.TestCase):
         # computing sensitivities to ram is best using dask processes
         with dask.config.set(scheduler='processes'):
             data = sim.make_synthetic_data(
-                self.model, standard_deviation=0.0, noise_floor=0.001, add_noise=True
+                self.model, relative_error=0.0, noise_floor=0.001, add_noise=True
             )
         print(sim.G)
 

--- a/tests/dask/test_mag_MVI_Octree.py
+++ b/tests/dask/test_mag_MVI_Octree.py
@@ -98,7 +98,7 @@ class MVIProblemTest(unittest.TestCase):
         # Compute some data and add some random noise
         data = sim.make_synthetic_data(
             utils.mkvc(self.model),
-                standard_deviation=0.0, noise_floor=5.0, add_noise=True
+                relative_error=0.0, noise_floor=5.0, add_noise=True
             )
 
         # This Mapping connects the regularizations for the three-component

--- a/tests/dask/test_mag_inversion_linear_Octree.py
+++ b/tests/dask/test_mag_inversion_linear_Octree.py
@@ -97,7 +97,7 @@ class MagInvLinProblemTest(unittest.TestCase):
         )
         self.sim = sim
         data = sim.make_synthetic_data(
-            self.model, standard_deviation=0.0, noise_floor=1.0, add_noise=True
+            self.model, relative_error=0.0, noise_floor=1.0, add_noise=True
         )
 
         # Create a regularization

--- a/tests/em/static/test_DC_Utils.py
+++ b/tests/em/static/test_DC_Utils.py
@@ -84,7 +84,7 @@ class DCUtilsTests_halfspace(unittest.TestCase):
             problem.solver = Solver
 
             # Create synthetic data
-            dobs = problem.make_synthetic_data(self.model, standard_deviation=0.)
+            dobs = problem.make_synthetic_data(self.model, relative_error=0.)
             dobs.eps = 1e-5
 
             # Testing IO

--- a/tests/pf/test_grav_inversion_linear.py
+++ b/tests/pf/test_grav_inversion_linear.py
@@ -81,7 +81,7 @@ class GravInvLinProblemTest(unittest.TestCase):
 
         # Compute linear forward operator and compute some data
         data = sim.make_synthetic_data(
-            self.model, standard_deviation=0.0, noise_floor=0.001, add_noise=True
+            self.model, relative_error=0.0, noise_floor=0.001, add_noise=True
         )
 
         # Create a regularization

--- a/tests/pf/test_mag_MVI_Octree.py
+++ b/tests/pf/test_mag_MVI_Octree.py
@@ -97,7 +97,7 @@ class MVIProblemTest(unittest.TestCase):
         # Compute some data and add some random noise
         data = sim.make_synthetic_data(
             utils.mkvc(self.model),
-                standard_deviation=0.0, noise_floor=5.0, add_noise=True
+                relative_error=0.0, noise_floor=5.0, add_noise=True
             )
 
         # This Mapping connects the regularizations for the three-component

--- a/tests/pf/test_mag_inversion_linear.py
+++ b/tests/pf/test_mag_inversion_linear.py
@@ -86,7 +86,7 @@ class MagInvLinProblemTest(unittest.TestCase):
         # Compute linear forward operator and compute some data
         data = sim.make_synthetic_data(
             self.model,
-            standard_deviation=0.0, noise_floor=1.0, add_noise=True
+            relative_error=0.0, noise_floor=1.0, add_noise=True
         )
 
         # Create a regularization

--- a/tests/pf/test_mag_inversion_linear_Octree.py
+++ b/tests/pf/test_mag_inversion_linear_Octree.py
@@ -94,7 +94,7 @@ class MagInvLinProblemTest(unittest.TestCase):
         )
         self.sim = sim
         data = sim.make_synthetic_data(
-            self.model, standard_deviation=0.0, noise_floor=1.0, add_noise=True
+            self.model, relative_error=0.0, noise_floor=1.0, add_noise=True
         )
 
         # Create a regularization

--- a/tutorials/basic_inversions/1_gravity/plot_1a_gravity_anomaly_inversion.py
+++ b/tutorials/basic_inversions/1_gravity/plot_1a_gravity_anomaly_inversion.py
@@ -126,7 +126,7 @@ plt.show()
 
 maximum_anomaly = np.max(np.abs(dobs))
 
-uncertainties = 0.01*maximum_anomaly*np.ones(np.shape(dobs))
+std = 0.01*maximum_anomaly*np.ones(np.shape(dobs))
 
 #############################################
 # Defining the Survey
@@ -157,10 +157,10 @@ survey = gravity.survey.GravitySurvey(source_field)
 # -----------------
 #
 # Here is where we define the data that are inverted. The data are defined by
-# the survey, the observation values and the uncertainties.
+# the survey, the observation values and the standard deviation.
 #
 
-data_object = data.Data(survey, dobs=dobs, standard_deviation=uncertainties)
+data_object = data.Data(survey, dobs=dobs, standard_deviation=std)
 
 
 #############################################
@@ -230,7 +230,8 @@ simulation = gravity.simulation.Simulation3DIntegral(
 
 # Define the data misfit. Here the data misfit is the L2 norm of the weighted
 # residual between the observed data and the data predicted for a given model.
-# The weighting is defined by the reciprocal of the uncertainties.
+# Within the data misfit, the residual between predicted and observed data are
+# normalized by the data's standard deviation.
 dmis = data_misfit.L2DataMisfit(data=data_object, simulation=simulation)
 
 # Define the regularization (model objective function).
@@ -358,7 +359,7 @@ plt.show()
 dpred = inv_prob.dpred
 
 # Observed data | Predicted data | Normalized data misfit
-data_array = np.c_[dobs, dpred, (dobs-dpred)/uncertainties]
+data_array = np.c_[dobs, dpred, (dobs-dpred)/std]
 
 fig = plt.figure(figsize=(17, 4))
 plot_title=['Observed', 'Predicted', 'Normalized Misfit']

--- a/tutorials/basic_inversions/1_gravity/plot_1a_gravity_anomaly_inversion.py
+++ b/tutorials/basic_inversions/1_gravity/plot_1a_gravity_anomaly_inversion.py
@@ -117,11 +117,11 @@ plt.show()
 # Assign Uncertainties
 # --------------------
 #
-# Inversion with SimPEG requires that we define uncertainties on our data. The
-# uncertainty represents our estimate of the standard deviation of the noise on
-# our data. For gravity inversion, a constant floor value is generall applied to
-# all data. For this tutorial, the uncertainty on each datum will be 1% of the
-# maximum observed gravity anomaly value.
+# Inversion with SimPEG requires that we define standard deviation on our data.
+# This represents our estimate of the noise in our data. For gravity inversion,
+# a constant floor value is generally applied to all data. For this tutorial,
+# the standard deviation on each datum will be 1% of the maximum observed
+# gravity anomaly value.
 #
 
 maximum_anomaly = np.max(np.abs(dobs))
@@ -160,7 +160,7 @@ survey = gravity.survey.GravitySurvey(source_field)
 # the survey, the observation values and the uncertainties.
 #
 
-data_object = data.Data(survey, dobs=dobs, noise_floor=uncertainties)
+data_object = data.Data(survey, dobs=dobs, standard_deviation=uncertainties)
 
 
 #############################################
@@ -232,7 +232,6 @@ simulation = gravity.simulation.Simulation3DIntegral(
 # residual between the observed data and the data predicted for a given model.
 # The weighting is defined by the reciprocal of the uncertainties.
 dmis = data_misfit.L2DataMisfit(data=data_object, simulation=simulation)
-dmis.W = utils.sdiag(1/uncertainties)
 
 # Define the regularization (model objective function).
 reg = regularization.Simple(

--- a/tutorials/basic_inversions/2_magnetics/plot_2a_magnetics_induced_inversion.py
+++ b/tutorials/basic_inversions/2_magnetics/plot_2a_magnetics_induced_inversion.py
@@ -118,11 +118,11 @@ plt.show()
 # Assign Uncertainty
 # ------------------
 #
-# Inversion with SimPEG requires that we define uncertainties on our data. The
-# uncertainty represents our estimate of the standard deviation of the noise on
-# our data. For magnetic inversions, a constant floor value is generall applied to
-# all data. For this tutorial, the uncertainty on each datum will be 2% of the
-# maximum observed gravity anomaly value.
+# Inversion with SimPEG requires that we define standard deviation on our data.
+# This represents our estimate of the noise in our data. For magnetic inversions,
+# a constant floor value is generall applied to all data. For this tutorial, the
+# standard deviation on each datum will be 2% of the maximum observed magnetics
+# anomaly value.
 #
 
 maximum_anomaly = np.max(np.abs(dobs))
@@ -172,7 +172,7 @@ survey = magnetics.survey.MagneticSurvey(source_field)
 # the survey, the observation values and the uncertainties.
 #
 
-data_object = data.Data(survey, dobs=dobs, noise_floor=uncertainties)
+data_object = data.Data(survey, dobs=dobs, standard_deviation=uncertainties)
 
 
 #############################################
@@ -245,7 +245,6 @@ simulation = magnetics.simulation.Simulation3DIntegral(
 # residual between the observed data and the data predicted for a given model.
 # The weighting is defined by the reciprocal of the uncertainties.
 dmis = data_misfit.L2DataMisfit(data=data_object, simulation=simulation)
-dmis.W = utils.sdiag(1/uncertainties)
 
 # Define the regularization (model objective function)
 reg = regularization.Sparse(

--- a/tutorials/basic_inversions/2_magnetics/plot_2a_magnetics_induced_inversion.py
+++ b/tutorials/basic_inversions/2_magnetics/plot_2a_magnetics_induced_inversion.py
@@ -127,7 +127,7 @@ plt.show()
 
 maximum_anomaly = np.max(np.abs(dobs))
 
-uncertainties = 0.02*maximum_anomaly*np.ones(len(dobs))
+std = 0.02*maximum_anomaly*np.ones(len(dobs))
 
 #############################################
 # Defining the Survey
@@ -169,10 +169,10 @@ survey = magnetics.survey.MagneticSurvey(source_field)
 # -----------------
 #
 # Here is where we define the data that is inverted. The data is defined by
-# the survey, the observation values and the uncertainties.
+# the survey, the observation values and the standard deviations.
 #
 
-data_object = data.Data(survey, dobs=dobs, standard_deviation=uncertainties)
+data_object = data.Data(survey, dobs=dobs, standard_deviation=std)
 
 
 #############################################
@@ -243,7 +243,8 @@ simulation = magnetics.simulation.Simulation3DIntegral(
 
 # Define the data misfit. Here the data misfit is the L2 norm of the weighted
 # residual between the observed data and the data predicted for a given model.
-# The weighting is defined by the reciprocal of the uncertainties.
+# Within the data misfit, the residual between predicted and observed data are
+# normalized by the data's standard deviation.
 dmis = data_misfit.L2DataMisfit(data=data_object, simulation=simulation)
 
 # Define the regularization (model objective function)
@@ -378,7 +379,7 @@ plt.show()
 dpred = inv_prob.dpred
 
 # Observed data | Predicted data | Normalized data misfit
-data_array = np.c_[dobs, dpred, (dobs-dpred)/uncertainties]
+data_array = np.c_[dobs, dpred, (dobs-dpred)/std]
 
 fig = plt.figure(figsize=(17, 4))
 plot_title=['Observed', 'Predicted', 'Normalized Misfit']

--- a/tutorials/basic_inversions/3_dcip/plot_3a_dcr_sounding_inv.py
+++ b/tutorials/basic_inversions/3_dcip/plot_3a_dcr_sounding_inv.py
@@ -137,7 +137,7 @@ plt.show()
 # a relative error is applied to each datum. For this tutorial, the relative
 # error on each datum will be 2%.
 
-uncertainties = 0.02*np.abs(dobs)
+std = 0.02*np.abs(dobs)
 
 
 ###############################################
@@ -145,10 +145,10 @@ uncertainties = 0.02*np.abs(dobs)
 # --------------------
 #
 # Here is where we define the data that are inverted. The data are defined by
-# the survey, the observation values and the uncertainties.
+# the survey, the observation values and the standard deviation.
 #
 
-data_object = data.Data(survey, dobs=dobs, standard_deviation=uncertainties)
+data_object = data.Data(survey, dobs=dobs, standard_deviation=std)
 
 
 ###############################################
@@ -214,7 +214,8 @@ simulation = dc.simulation_1d.Simulation1DLayers(
 
 # Define the data misfit. Here the data misfit is the L2 norm of the weighted
 # residual between the observed data and the data predicted for a given model.
-# The weighting is defined by the reciprocal of the uncertainties.
+# Within the data misfit, the residual between predicted and observed data are
+# normalized by the data's standard deviation.
 dmis = data_misfit.L2DataMisfit(simulation=simulation, data=data_object)
 
 # Define the regularization (model objective function)

--- a/tutorials/basic_inversions/3_dcip/plot_3a_dcr_sounding_inv.py
+++ b/tutorials/basic_inversions/3_dcip/plot_3a_dcr_sounding_inv.py
@@ -132,11 +132,10 @@ plt.show()
 # Assign Uncertainties
 # --------------------
 #
-# Inversion with SimPEG requires that we define uncertainties on our data. The
-# uncertainty represents our estimate of the standard deviation of the noise on
-# our data. For DC sounding data, a percent uncertainty is applied to each datum.
-# For this tutorial, the uncertainty on each datum will be 2%.
-#
+# Inversion with SimPEG requires that we define standard deviation on our data.
+# This represents our estimate of the noise in our data. For DC sounding data,
+# a relative error is applied to each datum. For this tutorial, the relative
+# error on each datum will be 2%.
 
 uncertainties = 0.02*np.abs(dobs)
 
@@ -149,7 +148,7 @@ uncertainties = 0.02*np.abs(dobs)
 # the survey, the observation values and the uncertainties.
 #
 
-data_object = data.Data(survey, dobs=dobs, noise_floor=uncertainties)
+data_object = data.Data(survey, dobs=dobs, standard_deviation=uncertainties)
 
 
 ###############################################
@@ -217,7 +216,6 @@ simulation = dc.simulation_1d.Simulation1DLayers(
 # residual between the observed data and the data predicted for a given model.
 # The weighting is defined by the reciprocal of the uncertainties.
 dmis = data_misfit.L2DataMisfit(simulation=simulation, data=data_object)
-dmis.W = 1./uncertainties
 
 # Define the regularization (model objective function)
 reg = regularization.Simple(

--- a/tutorials/basic_inversions/3_dcip/plot_3a_dcr_sounding_layers_inv.py
+++ b/tutorials/basic_inversions/3_dcip/plot_3a_dcr_sounding_layers_inv.py
@@ -137,7 +137,7 @@ plt.show()
 # error on each datum will be 2.5%.
 #
 
-uncertainties = 0.025*dobs
+std = 0.025*dobs
 
 
 ###############################################
@@ -145,10 +145,10 @@ uncertainties = 0.025*dobs
 # --------------------
 #
 # Here is where we define the data that are inverted. The data are defined by
-# the survey, the observation values and the uncertainties.
+# the survey, the observation values and the standard deviation.
 #
 
-data_object = data.Data(survey, dobs=dobs, standard_deviation=uncertainties)
+data_object = data.Data(survey, dobs=dobs, standard_deviation=std)
 
 ###############################################################
 # Defining the Starting Model and Mapping
@@ -208,9 +208,9 @@ simulation = dc.simulation_1d.Simulation1DLayers(
 
 # Define the data misfit. Here the data misfit is the L2 norm of the weighted
 # residual between the observed data and the data predicted for a given model.
-# The weighting is defined by the reciprocal of the uncertainties.
+# Within the data misfit, the residual between predicted and observed data are
+# normalized by the data's standard deviation.
 dmis = data_misfit.L2DataMisfit(simulation=simulation, data=data_object)
-dmis.W = 1./uncertainties
 
 # Define the regularization on the parameters related to resistivity
 mesh_rho = TensorMesh([mesh.hx.size])

--- a/tutorials/basic_inversions/3_dcip/plot_3a_dcr_sounding_layers_inv.py
+++ b/tutorials/basic_inversions/3_dcip/plot_3a_dcr_sounding_layers_inv.py
@@ -131,10 +131,10 @@ plt.show()
 # Assign Uncertainties
 # --------------------
 #
-# Inversion with SimPEG requires that we define uncertainties on our data. The
-# uncertainty represents our estimate of the standard deviation of the noise on
-# our data. For DC sounding data, a percent uncertainty is applied to each datum.
-# For this tutorial, the uncertainty on each datum will be 2.5%.
+# Inversion with SimPEG requires that we define standard deviation on our data.
+# This represents our estimate of the noise in our data. For DC sounding data,
+# a relative error is applied to each datum. For this tutorial, the relative
+# error on each datum will be 2.5%.
 #
 
 uncertainties = 0.025*dobs
@@ -148,7 +148,7 @@ uncertainties = 0.025*dobs
 # the survey, the observation values and the uncertainties.
 #
 
-data_object = data.Data(survey, dobs=dobs, noise_floor=uncertainties)
+data_object = data.Data(survey, dobs=dobs, standard_deviation=uncertainties)
 
 ###############################################################
 # Defining the Starting Model and Mapping

--- a/tutorials/basic_inversions/3_dcip/plot_3b_dcip2d_inv.py
+++ b/tutorials/basic_inversions/3_dcip/plot_3b_dcip2d_inv.py
@@ -169,13 +169,13 @@ plt.show()
 # 1% of the corresponding DC data value.
 #
 
-# Compute uncertainties
-uncertainties_dc = 0.05*np.abs(dobs_dc)
-uncertainties_ip = 0.01*np.abs(dobs_dc)
+# Compute standard deviations
+std_dc = 0.05*np.abs(dobs_dc)
+std_ip = 0.01*np.abs(dobs_dc)
 
-# Add uncertainties to data object
-dc_data.standard_deviation = uncertainties_dc
-ip_data.standard_deviation = uncertainties_ip
+# Add standard deviations to data object
+dc_data.standard_deviation = std_dc
+ip_data.standard_deviation = std_ip
 
 ########################################################
 # Create OcTree Mesh
@@ -289,7 +289,8 @@ dc_simulation = dc.simulation_2d.Simulation2DNodal(
 
 # Define the data misfit. Here the data misfit is the L2 norm of the weighted
 # residual between the observed data and the data predicted for a given model.
-# The weighting is defined by the reciprocal of the uncertainties.
+# Within the data misfit, the residual between predicted and observed data are
+# normalized by the data's standard deviation.
 dc_data_misfit = data_misfit.L2DataMisfit(data=dc_data, simulation=dc_simulation)
 
 # Define the regularization (model objective function)
@@ -425,7 +426,7 @@ dpred_dc = dc_inverse_problem.dpred
 dc_data_predicted = data.Data(dc_survey, dobs=dpred_dc)
 
 data_array = [dc_data, dc_data_predicted, dc_data]
-dobs_array = [None, None, (dobs_dc-dpred_dc)/uncertainties_dc]
+dobs_array = [None, None, (dobs_dc-dpred_dc)/std_dc]
 
 fig = plt.figure(figsize=(17, 5.5))
 plot_title=['Observed', 'Predicted', 'Normalized Misfit']
@@ -621,7 +622,7 @@ ip_data_predicted = data.Data(ip_survey, dobs=dpred_ip)
 # Convert from voltage measurements to apparent chargeability by normalizing by
 # the DC voltage
 dobs_array = np.c_[
-    dobs_ip/dobs_dc, dpred_ip/dobs_dc, (dobs_ip-dpred_ip)/uncertainties_ip
+    dobs_ip/dobs_dc, dpred_ip/dobs_dc, (dobs_ip-dpred_ip)/std_ip
 ]
 
 fig = plt.figure(figsize=(17, 5.5))

--- a/tutorials/basic_inversions/3_dcip/plot_3b_dcip2d_inv.py
+++ b/tutorials/basic_inversions/3_dcip/plot_3b_dcip2d_inv.py
@@ -161,12 +161,12 @@ plt.show()
 # Assign Uncertainties
 # --------------------
 #
-# Inversion with SimPEG requires that we define uncertainties on our data. The
-# uncertainty represents our estimate of the standard deviation of the noise on
-# our data. For DC data, a percent uncertainty is applied to each datum.
-# For this tutorial, the uncertainty on each datum will be 5%. For IP data, a
-# percent of the DC data is used for the uncertainties. For this tutorial, the
-# uncertainties on IP data are 1% of the corresponding DC data value.
+# Inversion with SimPEG requires that we define standard deviation on our data.
+# This represents our estimate of the noise in our data. For DC data, a relative
+# error is applied to each datum. For this tutorial, the relative error on each
+# datum will be 5%. For IP data, a percent of the DC data is used for the
+# standard deviation. For this tutorial, the standard deviation on IP data are
+# 1% of the corresponding DC data value.
 #
 
 # Compute uncertainties
@@ -174,8 +174,8 @@ uncertainties_dc = 0.05*np.abs(dobs_dc)
 uncertainties_ip = 0.01*np.abs(dobs_dc)
 
 # Add uncertainties to data object
-dc_data.noise_floor = uncertainties_dc
-ip_data.noise_floor = uncertainties_ip
+dc_data.standard_deviation = uncertainties_dc
+ip_data.standard_deviation = uncertainties_ip
 
 ########################################################
 # Create OcTree Mesh
@@ -291,7 +291,6 @@ dc_simulation = dc.simulation_2d.Simulation2DNodal(
 # residual between the observed data and the data predicted for a given model.
 # The weighting is defined by the reciprocal of the uncertainties.
 dc_data_misfit = data_misfit.L2DataMisfit(data=dc_data, simulation=dc_simulation)
-dc_data_misfit.W = utils.sdiag(1./uncertainties_dc)
 
 # Define the regularization (model objective function)
 dc_regularization = regularization.Simple(
@@ -499,7 +498,6 @@ ip_simulation = ip.simulation_2d.Simulation2DNodal(
 
 # Define the data misfit (Here we use weighted L2-norm)
 ip_data_misfit = data_misfit.L2DataMisfit(data=ip_data, simulation=ip_simulation)
-ip_data_misfit.W = utils.sdiag(1./uncertainties_ip)
 
 # Define the regularization (model objective function)
 ip_regularization = regularization.Simple(

--- a/tutorials/temporary/plot_4c_fdem3d_inversion.py
+++ b/tutorials/temporary/plot_4c_fdem3d_inversion.py
@@ -16,7 +16,7 @@ this tutorial, we focus on the following:
 
 Although we consider gravity anomaly data in this tutorial, the same approach
 can be used to invert other types of geophysical data.
-    
+
 
 """
 
@@ -127,11 +127,11 @@ plt.show()
 # Assign Uncertainties
 # --------------------
 #
-# Inversion with SimPEG requires that we define uncertainties on our data. The
-# uncertainty represents our estimate of the standard deviation of the noise on
-# our data. For gravity inversion, a constant floor value is generall applied to
-# all data. For this tutorial, the uncertainty on each datum will be 1% of the
-# maximum observed gravity anomaly value.
+# Inversion with SimPEG requires that we define standard deviation on our data.
+# This represents our estimate of the noise in our data. For gravity inversion,
+# a constant floor value is generally applied to all data. For this tutorial,
+# the standard deviation on each datum will be 1% of the maximum observed
+# gravity anomaly value.
 #
 
 uncertainties_real = 1e-14*np.ones(len(dobs_real))
@@ -165,16 +165,16 @@ for ii in range(n_data):
             receiver_locations[ii, :], 'z', 'imag'
             )
     receivers_list = [bzr_receiver, bzi_receiver]
-    
+
     # Must define the transmitter properties and associated receivers
     source_location = receiver_locations[ii, :] + np.c_[0, 0, 20]
-    
+
     source_list.append(
         fdem.sources.MagDipole(
             receivers_list, frequencies[ii], source_location, orientation='z'
         )
     )
-    
+
 survey = fdem.Survey(source_list)
 
 #############################################
@@ -200,7 +200,7 @@ data_object = data.Data(survey, dobs=dobs, noise_floor=uncertainties)
 # Here we define the OcTree mesh that is used for this example.
 # We chose to design a coarser mesh to decrease the run time.
 # When designing a mesh to solve practical frequency domain problems:
-# 
+#
 #     - Your smallest cell size should be 10%-20% the size of your smallest skin depth
 #     - The thickness of your padding needs to be 2-3 times biggest than your largest skin depth
 #     - The skin depth is ~500*np.sqrt(rho/f)
@@ -266,7 +266,7 @@ starting_model = background_conductivity*np.ones(nC)
 #
 # Here, we define the physics of the gravity problem by using the simulation
 # class.
-# 
+#
 
 simulation = fdem.simulation.Simulation3DMagneticFluxDensity(
         mesh, survey=survey, sigmaMap=model_map, Solver=Solver
@@ -439,7 +439,7 @@ v_lim = [
 ]
 
 for ii in range(0, 3):
-    
+
     ax1[ii] = fig.add_axes([0.33*ii+0.03, 0.11, 0.23, 0.84])
     cplot[ii] = plot2Ddata(
         receiver_locations[k], data_array[:, ii], ax=ax1[ii], ncontour=30,
@@ -448,7 +448,7 @@ for ii in range(0, 3):
     ax1[ii].set_title(plot_title[ii])
     ax1[ii].set_xlabel('x (m)')
     ax1[ii].set_ylabel('y (m)')
-    
+
     ax2[ii] = fig.add_axes([0.33*ii+0.27, 0.11, 0.01, 0.85])
     norm[ii] = mpl.colors.Normalize(vmin=-v_lim[ii], vmax=v_lim[ii])
     cbar[ii] = mpl.colorbar.ColorbarBase(
@@ -457,4 +457,3 @@ for ii in range(0, 3):
     cbar[ii].set_label(plot_units[ii], rotation=270, labelpad=15, size=12)
 
 plt.show()
-


### PR DESCRIPTION
This PR address #846. 

``data.uncertainty`` -> ``data.standard_deviation``
``data.standard_deviation`` -> ``data.relative_error``

Every occurrence of these terms have also been changed within the respective functions.
Therefore there are many other changes to the documentation, examples, and tutorials.