### PR TITLE
Replace html links to documentation with local links

### DIFF
--- a/docs/content/basic/getting_started_developers.rst
+++ b/docs/content/basic/getting_started_developers.rst
@@ -182,13 +182,13 @@ launched from a terminal using::
 If all is well ...
 ------------------
 
-You should be able to open a terminal within SimPEG/examples and run an example, ie.::
+You should be able to open a terminal within SimPEG/tutorials and run an example, ie.::
 
-    python 01-basic/plot_inversion_linear.py
+    python 02-linear_inversion/plot_inv_1_inversion_lsq.py
 
-or you can download and run `the notebook from the docs <http://docs.simpeg.xyz/content/examples/01-basic/plot_inversion_linear.html#sphx-glr-content-examples-01-basic-plot-inversion-linear-py>`_.
+or you can download and run the :ref:`notebook from the docs <sphx_glr_content_tutorials_02-linear_inversion_plot_inv_1_inversion_lsq.py>`.
 
-.. image:: http://docs.simpeg.xyz/_images/sphx_glr_plot_inversion_linear_001.png
+.. image:: /content/tutorials/02-linear_inversion/images/sphx_glr_plot_inv_1_inversion_lsq_003.png
 
 You are now set up to SimPEG!
 

--- a/docs/content/basic/installing.rst
+++ b/docs/content/basic/installing.rst
@@ -83,7 +83,8 @@ Success?
 ========
 
 If you have been successful at downloading and installing SimPEG, you should
-be able to download and run any of the `Examples <http://docs.simpeg.xyz/content/examples/index.html>`_.
+be able to download and run any of the :ref:`Examples <sphx_glr_content_examples>`
+or :ref:`Tutorials <simpeg_tuts>`.
 
 If not, you can reach out to other people developing and using SimPEG on the
 `google forum <https://groups.google.com/forum/#!forum/simpeg>`_ or on

--- a/docs/content/basic/practices.rst
+++ b/docs/content/basic/practices.rst
@@ -109,7 +109,7 @@ solution <https://github.com/simpeg/simpeg/blob/master/tests/em/fdem/forward/tes
 Order and Derivative Tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-`Order tests <http://docs.simpeg.xyz/content/api_core/api_Tests.html>`_ can be
+:ref:`Order tests <api_Tests>` can be
 used when you are testing differential operators (we are using a second-order,
 staggered grid discretization for our operators). For example, testing a 2D
 curl operator in `test_operators.py <https://github.com/simpeg/discretize/blob/master/tests/base/test_operators.py>`_

--- a/docs/content/release/0.14.0-notes.rst
+++ b/docs/content/release/0.14.0-notes.rst
@@ -373,7 +373,7 @@ version 0.15.0 of SimPEG. The deprecated utility models will also be removed the
 Pull Requests
 =============
 
-There were 23 pull requests contributing to this release.
+There were 25 pull requests contributing to this release.
 
 * `#786 <https://github.com/simpeg/simpeg/pull/786>`__: Simulation class refactor.
 * `#792 <https://github.com/simpeg/simpeg/pull/792>`__: Use scooby for Versions.
@@ -397,8 +397,9 @@ There were 23 pull requests contributing to this release.
 * `#869 <https://github.com/simpeg/simpeg/pull/869>`__: Simulation tutorials 2.
 * `#872 <https://github.com/simpeg/simpeg/pull/872>`__: Uncertainty rename in simulation.
 * `#874 <https://github.com/simpeg/simpeg/pull/874>`__: Release notes for simulation as part of the Documentation.
-* `#876 <https://github.com/simpeg/simpeg/pull/876>`__: Simulation tutorials cleanup
-* `#879 <https://github.com/simpeg/simpeg/pull/879>`__: Run black on SimPEG
+* `#876 <https://github.com/simpeg/simpeg/pull/876>`__: Simulation tutorials cleanup.
+* `#879 <https://github.com/simpeg/simpeg/pull/879>`__: Run black on SimPEG.
+* `#882 <https://github.com/simpeg/simpeg/pull/882>`__: Replace html links to documentation with local links.
 
 Closed Issues
 =============


### PR DESCRIPTION
Some of the internal documentation links were pointing to html address instead of internal addresses