### PR TITLE
Typo cleanup & use isinstance for type checks

### DIFF
--- a/SimPEG/directives.py
+++ b/SimPEG/directives.py
@@ -297,8 +297,8 @@ class SaveEveryIteration(InversionDirective):
     """SaveEveryIteration
 
     This directive saves an array at each iteration. The default
-    direcroty is the current directoy and the models are saved as
-    `InversionModel-YYYY-MM-DD-HH-MM-iter.npy`
+    directory is the current directoy and the models are saved as
+    ``InversionModel-YYYY-MM-DD-HH-MM-iter.npy``
     """
 
     directory = properties.String("directory to save results in", default=".")
@@ -330,8 +330,8 @@ class SaveModelEveryIteration(SaveEveryIteration):
     """SaveModelEveryIteration
 
     This directive saves the model as a numpy array at each iteration. The
-    default direcroty is the current directoy and the models are saved as
-    `InversionModel-YYYY-MM-DD-HH-MM-iter.npy`
+    default directory is the current directoy and the models are saved as
+    ``InversionModel-YYYY-MM-DD-HH-MM-iter.npy``
     """
 
     def initialize(self):
@@ -560,7 +560,7 @@ class SaveOutputEveryIteration(SaveEveryIteration):
 
 class SaveOutputDictEveryIteration(SaveEveryIteration):
     """
-        Saves inversion parameters at every iteraion.
+        Saves inversion parameters at every iteration.
     """
 
     # Initialize the output dict
@@ -586,7 +586,6 @@ class SaveOutputDictEveryIteration(SaveEveryIteration):
         #     regCombo += ["phi_msz"]
 
         # Initialize the output dict
-        iterDict = None
         iterDict = {}
 
         # Save the data.

--- a/SimPEG/fields.py
+++ b/SimPEG/fields.py
@@ -97,7 +97,7 @@ class Fields(properties.HasProperties):
 
         loc = self.knownFields[name]
 
-        if type(self.dtype) is dict:
+        if isinstance(self.dtype, dict):
             dtype = self.dtype[name]
         else:
             dtype = self.dtype
@@ -142,7 +142,7 @@ class Fields(properties.HasProperties):
         return name
 
     def _indexAndNameFromKey(self, key, accessType):
-        if type(key) is not tuple:
+        if not isinstance(key, tuple):
             key = (key,)
         if len(key) == 1:
             key += (None,)
@@ -158,7 +158,7 @@ class Fields(properties.HasProperties):
         ind, name = self._indexAndNameFromKey(key, "set")
         if name is None:
             assert (
-                type(value) is dict
+                isinstance(value, dict)
             ), "New fields must be a dictionary, if field is not specified."
             newFields = value
         elif name in self.knownFields:
@@ -239,7 +239,7 @@ class TimeFields(Fields):
         return (nP, nSrc, nT)
 
     def _indexAndNameFromKey(self, key, accessType):
-        if type(key) is not tuple:
+        if not isinstance(key, tuple):
             key = (key,)
         if len(key) == 1:
             key += (None,)

--- a/SimPEG/flow/richards/simulation.py
+++ b/SimPEG/flow/richards/simulation.py
@@ -74,7 +74,7 @@ class SimulationNDCellCentered(BaseTimeSimulation):
             self.water_retention.model = model
 
     def getBoundaryConditions(self, ii, u_ii):
-        if type(self.boundary_conditions) is np.ndarray:
+        if isinstance(self.boundary_conditions, np.ndarray):
             return self.boundary_conditions
 
         time = self.time_mesh.vectorCCx[ii]

--- a/SimPEG/inversion.py
+++ b/SimPEG/inversion.py
@@ -27,7 +27,7 @@ class BaseInversion(object):
 
     @directiveList.setter
     def directiveList(self, value):
-        if type(value) is list:
+        if isinstance(value, list):
             value = DirectiveList(*value)
         assert isinstance(value, DirectiveList), "Must be a DirectiveList"
         value.validate()  # validate before setting

--- a/SimPEG/optimization.py
+++ b/SimPEG/optimization.py
@@ -746,9 +746,9 @@ class ProjectedGradient(Minimize, Remember):
 
     def _startup(self, x0):
         # ensure bound vectors are the same size as the model
-        if type(self.lower) is not np.ndarray:
+        if not isinstance(self.lower, np.ndarray):
             self.lower = np.ones_like(x0) * self.lower
-        if type(self.upper) is not np.ndarray:
+        if not isinstance(self.upper, np.ndarray):
             self.upper = np.ones_like(x0) * self.upper
 
         self.explorePG = True
@@ -1156,9 +1156,9 @@ class ProjectedGNCG(BFGS, Minimize, Remember):
 
     def _startup(self, x0):
         # ensure bound vectors are the same size as the model
-        if type(self.lower) is not np.ndarray:
+        if not isinstance(self.lower, np.ndarray):
             self.lower = np.ones_like(x0) * self.lower
-        if type(self.upper) is not np.ndarray:
+        if not isinstance(self.upper, np.ndarray):
             self.upper = np.ones_like(x0) * self.upper
 
     @count

--- a/SimPEG/survey.py
+++ b/SimPEG/survey.py
@@ -205,7 +205,7 @@ class BaseSrc(BaseSimPEG):
     )
 
     def getReceiverIndex(self, receiver):
-        if type(receiver) is not list:
+        if not isinstance(receiver, list):
             receiver = [receiver]
         for rx in receiver:
             if getattr(rx, "_uid", None) is None:
@@ -266,7 +266,7 @@ class BaseSurvey(properties.HasProperties):
 
     # TODO: this should be private
     def getSourceIndex(self, sources):
-        if type(sources) is not list:
+        if not isinstance(sources, list):
             sources = [sources]
 
         for src in sources:

--- a/SimPEG/utils/counter_utils.py
+++ b/SimPEG/utils/counter_utils.py
@@ -88,7 +88,7 @@ def count(f):
     @wraps(f)
     def wrapper(self, *args, **kwargs):
         counter = getattr(self, "counter", None)
-        if type(counter) is Counter:
+        if isinstance(counter, Counter):
             counter.count(self.__class__.__name__ + "." + f.__name__)
         out = f(self, *args, **kwargs)
         return out
@@ -100,10 +100,10 @@ def timeIt(f):
     @wraps(f)
     def wrapper(self, *args, **kwargs):
         counter = getattr(self, "counter", None)
-        if type(counter) is Counter:
+        if isinstance(counter, Counter):
             counter.countTic(self.__class__.__name__ + "." + f.__name__)
         out = f(self, *args, **kwargs)
-        if type(counter) is Counter:
+        if isinstance(counter, Counter):
             counter.countToc(self.__class__.__name__ + "." + f.__name__)
         return out
 

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -8,9 +8,9 @@ from scipy.spatial import Delaunay
 import sys
 
 if sys.version_info < (3,):
-    num_types = [int, long, float]
+    num_types = (int, long, float)
 else:
-    num_types = [int, float]
+    num_types = (int, float)
 
 
 def addBlock(gridCC, modelCC, p0, p1, blockProp):
@@ -327,7 +327,7 @@ def randomModel(shape, seed=None, anisotropy=None, its=100, bounds=None):
         seed = np.random.randint(1e3)
         print("Using a seed of: ", seed)
 
-    if type(shape) in num_types:
+    if isinstance(shape, num_types):
         shape = (shape,)  # make it a tuple for consistency
 
     np.random.seed(seed)

--- a/SimPEG/utils/solver_utils.py
+++ b/SimPEG/utils/solver_utils.py
@@ -46,7 +46,7 @@ def SolverWrapD(fun, factorize=True, checkAccuracy=True, accuracyTol=1e-6, name=
             self.solver = fun(self.A, **kwargs)
 
     def __mul__(self, b):
-        if type(b) is not np.ndarray:
+        if not isinstance(b, np.ndarray):
             raise TypeError("Can only multiply by a numpy array.")
 
         if len(b.shape) == 1 or b.shape[1] == 1:
@@ -111,14 +111,14 @@ def SolverWrapI(fun, checkAccuracy=True, accuracyTol=1e-5, name=None):
         self.kwargs = kwargs
 
     def __mul__(self, b):
-        if type(b) is not np.ndarray:
+        if not isinstance(b, np.ndarray):
             raise TypeError("Can only multiply by a numpy array.")
 
         if len(b.shape) == 1 or b.shape[1] == 1:
             b = b.flatten()
             # Just one RHS
             out = fun(self.A, b, **self.kwargs)
-            if type(out) is tuple and len(out) == 2:
+            if isinstance(out, tuple) and len(out) == 2:
                 # We are dealing with scipy output with an info!
                 X = out[0]
                 self.info = out[1]
@@ -128,7 +128,7 @@ def SolverWrapI(fun, checkAccuracy=True, accuracyTol=1e-5, name=None):
             X = np.empty_like(b)
             for i in range(b.shape[1]):
                 out = fun(self.A, b[:, i], **self.kwargs)
-                if type(out) is tuple and len(out) == 2:
+                if isinstance(out, tuple) and len(out) == 2:
                     # We are dealing with scipy output with an info!
                     X[:, i] = out[0]
                     self.info = out[1]


### PR DESCRIPTION
I came across these easy-to-fix stuff when I was reading simpeg code, so decided to submit a short PR before I forgot.

* Minor typo fixes
* Use `isinstance` for type checking (for those who's interested, this [SO answer](https://stackoverflow.com/a/1549854) goes into more detail on `type` vs . `isinstance`). My linter was yelling at me so I obliged. :)
* Double backquote (as opposed to single) for [sphinx inline code formatting](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#inline-markup)