### PR TITLE
Allows logic to cull unused kwargs from inputs to a function

### DIFF
--- a/SimPEG/utils/solver_utils.py
+++ b/SimPEG/utils/solver_utils.py
@@ -93,6 +93,9 @@ def SolverWrapD(fun, factorize=True, checkAccuracy=True, accuracyTol=1e-6, name=
             _checkAccuracy(self.A, b, X, self.accuracyTol)
         return X
 
+    def __matmul__(self, other):
+        return self * other
+
     def clean(self):
         if factorize and hasattr(self.solver, "clean"):
             return self.solver.clean()
@@ -100,7 +103,12 @@ def SolverWrapD(fun, factorize=True, checkAccuracy=True, accuracyTol=1e-6, name=
     return type(
         name if name is not None else fun.__name__,
         (object,),
-        {"__init__": __init__, "clean": clean, "__mul__": __mul__},
+        {
+            "__init__": __init__,
+            "clean": clean,
+            "__mul__": __mul__,
+            "__matmul__": __matmul__,
+        },
     )
 
 
@@ -172,13 +180,21 @@ def SolverWrapI(fun, checkAccuracy=True, accuracyTol=1e-5, name=None):
             _checkAccuracy(self.A, b, X, self.accuracyTol)
         return X
 
+    def __matmul__(self, other):
+        return self * other
+
     def clean(self):
         pass
 
     return type(
         name if name is not None else fun.__name__,
         (object,),
-        {"__init__": __init__, "clean": clean, "__mul__": __mul__},
+        {
+            "__init__": __init__,
+            "clean": clean,
+            "__mul__": __mul__,
+            "__matmul__": __matmul__,
+        },
     )
 
 
@@ -194,6 +210,8 @@ class SolverDiag(object):
     def __init__(self, A, **kwargs):
         self.A = A
         self._diagonal = A.diagonal()
+        for kwarg in kwargs:
+            warnings.warn(f"{kwarg} is not recognized and will be ignored")
 
     def __mul__(self, rhs):
         n = self.A.shape[0]
@@ -209,6 +227,9 @@ class SolverDiag(object):
             return x.flatten()
         elif nrhs > 1:
             return x.reshape((n, nrhs), order="F")
+
+    def __matmul__(self, other):
+        return self * other
 
     def _solve1(self, rhs):
         return rhs.flatten() / self._diagonal

--- a/tests/utils/test_solverwrap.py
+++ b/tests/utils/test_solverwrap.py
@@ -1,0 +1,64 @@
+import unittest
+from SimPEG.utils.solver_utils import Solver, SolverLU, SolverCG, SolverBiCG, SolverDiag
+import scipy.sparse as sp
+import numpy as np
+
+
+class TestSolve(unittest.TestCase):
+    def setUp(self):
+        # Create a random matrix
+        n = 400
+        A = sp.random(n, n, density=0.25)
+
+        self.n = n
+        self.A = 0.5 * (A + A.T) + n * sp.eye(n)
+
+    def test_Solver(self):
+        x = np.random.rand(self.n)
+        b = self.A @ x
+
+        with self.assertWarns(Warning):
+            Ainv = Solver(self.A, bad_kwarg=312)
+        x2 = Ainv @ b
+        np.testing.assert_almost_equal(x, x2)
+
+    def test_SolverLU(self):
+        x = np.random.rand(self.n)
+        b = self.A @ x
+
+        with self.assertWarns(Warning):
+            Ainv = SolverLU(self.A, bad_kwarg=312)
+        x2 = Ainv @ b
+        np.testing.assert_almost_equal(x, x2)
+
+    def test_SolverCG(self):
+        x = np.random.rand(self.n)
+        b = self.A @ x
+
+        with self.assertWarns(Warning):
+            Ainv = SolverCG(self.A, bad_kwarg=312)
+        x2 = Ainv @ b
+        np.testing.assert_almost_equal(x, x2, decimal=4)
+
+    def test_SolverBiCG(self):
+        x = np.random.rand(self.n)
+        b = self.A @ x
+
+        with self.assertWarns(Warning):
+            Ainv = SolverBiCG(self.A, bad_kwarg=312)
+        x2 = Ainv @ b
+        np.testing.assert_almost_equal(x, x2, decimal=4)
+
+    def test_SolverDiag(self):
+        x = np.random.rand(self.n)
+        A = sp.diags(np.random.randn(self.n))
+        b = A @ x
+
+        with self.assertWarns(Warning):
+            Ainv = SolverDiag(A, bad_kwarg=312)
+        x2 = Ainv @ b
+        np.testing.assert_almost_equal(x, x2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This should allow us to set some default kwargs for certain systems by only accepting them if they are valid to the function, and throwing a warning for invalid kwargs.