### PR TITLE
Show memory usage in examples

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -340,6 +340,7 @@ sphinx_gallery_conf = {
     "gallery_dirs": ["content/examples"] + tut_gallery_dirs,
     "within_subsection_order": FileNameSortKey,
     "backreferences_dir": None,
+    "show_memory": True,
 }
 
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -18,3 +18,4 @@ scooby
 black
 pre-commit
 twine
+memory_profiler


### PR DESCRIPTION
I think it would be good to show memory consumption in the examples. This way users will know what is expected, and if a certain example didn't run because of the limitations of their machine. The change makes that in addition to the runtime (blue) it also shows memory (red):
![Selection_001](https://user-images.githubusercontent.com/8020943/94144577-9e5ee480-fe71-11ea-9fd9-5978634174ec.png)

As a response to https://simpeg.discourse.group/t/run-the-example-heagy-et-al-2017-casing-example/138 (btw that discourse thread is still open @lheagy , I don't know what the issue is).

