### PR TITLE
Fix IP simulation when model or field is None

### DIFF
--- a/SimPEG/electromagnetics/static/induced_polarization/simulation.py
+++ b/SimPEG/electromagnetics/static/induced_polarization/simulation.py
@@ -185,6 +185,9 @@ class BaseIPSimulation(BaseEMSimulation):
             Full J matrix can be computed by inputing v=None
         """
 
+        if f is None:
+            f = self.fields(m)
+
         if v is not None:
             # Ensure v is a data object.
             if not isinstance(v, Data):
@@ -192,7 +195,7 @@ class BaseIPSimulation(BaseEMSimulation):
             Jtv = np.zeros(m.size)
         else:
             # This is for forming full sensitivity matrix
-            Jtv = np.zeros((self.model.size, self.survey.nD), order="F")
+            Jtv = np.zeros((self.etaMap.nP, self.survey.nD), order="F")
             istrt = int(0)
             iend = int(0)
 


### PR DESCRIPTION
I believe this fixes the issue posted by @rolandhill about the IP simulation in #955 

two things: 
- there were a `if f is None` call missing, resulting in indexing a None.
- It is preferable to use the mapping to set the size I believe, as `self.model` could be None (which happened in @rolandhill case)

Note: This PR is close to what I fixed for Mag in #958.