### PR TITLE
Fix for issue 771

### DIFF
--- a/SimPEG/optimization.py
+++ b/SimPEG/optimization.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipy.sparse as sp
 from six import string_types
 
-from .utils.solver_utils import SolverWrapI, Solver
+from .utils.solver_utils import SolverWrapI, Solver, SolverCG
 from .utils import (
     callHooks,
     checkStoppers,
@@ -1010,7 +1010,7 @@ class GaussNewton(Minimize, Remember):
 
     @timeIt
     def findSearchDirection(self):
-        return Solver(self.H) * (-self.g)
+        return SolverCG(self.H) * (-self.g)
 
 
 class InexactGaussNewton(BFGS, Minimize, Remember):


### PR DESCRIPTION
Not sure if I'm supposed to do it like this. 

Using an iterative solver instead of a direct solver solves the bug that was exposed in #771  (the wrapper of the direct solver requires sparse matrices, instead of sparse linear operators).

I'm not completely sure if iterative solvers are optimal here, but it works. 