### PR TITLE
Update receivers.py

### DIFF
--- a/SimPEG/potential_fields/magnetics/receivers.py
+++ b/SimPEG/potential_fields/magnetics/receivers.py
@@ -9,7 +9,7 @@ class Point(survey.BaseRx):
     Magnetic point receiver class for integral formulation
 
     :param numpy.ndarray locs: receiver locations index (ie. :code:`np.c_[ind_1, ind_2, ...]`)
-    :param string component: receiver component
+    :param string components: receiver component (string or list)
          "bxx", "bxy", "bxz", "byy",
          "byz", "bzz", "bx", "by", "bz", "tmi" [default]
     """


### PR DESCRIPTION
typo in the mag receiver docs ("components" rather than "component" is the keyword. 

Out of curiosity, is there a benefit to providing a list here `components = ["bx", "by", "bz"]` as opposed to creating three receivers? 

```
rx_x = mag.receivers.Point(locations=survey_xyz, components="bx")
rx_y = mag.receivers.Point(locations=survey_xyz, components="by")
rx_z = mag.receivers.Point(locations=survey_xyz, components="bz")
```