### PR TITLE
Add notes to gravity examples

### DIFF
--- a/tutorials/03-gravity/plot_1a_gravity_anomaly.py
+++ b/tutorials/03-gravity/plot_1a_gravity_anomaly.py
@@ -189,6 +189,8 @@ simulation = gravity.simulation.Simulation3DIntegral(
 )
 
 # Compute predicted data for some model
+# SimPEG uses right handed coordinate where Z is positive upward. 
+# This causes gravity signals look "inconsistent" with density values in visualization.
 dpred = simulation.dpred(model)
 
 # Plot

--- a/tutorials/03-gravity/plot_inv_1a_gravity_anomaly.py
+++ b/tutorials/03-gravity/plot_inv_1a_gravity_anomaly.py
@@ -393,6 +393,8 @@ plt.show()
 #
 
 # Predicted data with final recovered model
+# SimPEG uses right handed coordinate where Z is positive upward. 
+# This causes gravity signals look "inconsistent" with density values in visualization.
 dpred = inv_prob.dpred
 
 # Observed data | Predicted data | Normalized data misfit

--- a/tutorials/03-gravity/plot_inv_1b_gravity_anomaly_irls.py
+++ b/tutorials/03-gravity/plot_inv_1b_gravity_anomaly_irls.py
@@ -400,6 +400,8 @@ plt.show()
 #
 
 # Predicted data with final recovered model
+# SimPEG uses right handed coordinate where Z is positive upward. 
+# This causes gravity signals look "inconsistent" with density values in visualization.
 dpred = inv_prob.dpred
 
 # Observed data | Predicted data | Normalized data misfit


### PR DESCRIPTION
I noticed a question, "why the gravity signals look "inconsistent" with density values in visualization?", has been asked multiple times, so added notes to the gravity examples to clarify it.