### PR TITLE
Replace np.matrix by regular ndarrays

### DIFF
--- a/SimPEG/electromagnetics/analytics/NSEM.py
+++ b/SimPEG/electromagnetics/analytics/NSEM.py
@@ -15,14 +15,14 @@ _PCC = lambda siginf, m, t, c, f: siginf * (
 )
 
 # matrix P relating Up and Down components with E and H fields
-_P = lambda z: np.matrix([[1.0, 1,], [-1.0 / z, 1.0 / z],], dtype="complex_",)
-_Pinv = lambda z: np.matrix([[1.0, -z], [1.0, z]], dtype="complex_") / 2.0
+_P = lambda z: np.array([[1.0, 1,], [-1.0 / z, 1.0 / z],], dtype="complex_",)
+_Pinv = lambda z: np.array([[1.0, -z], [1.0, z]], dtype="complex_") / 2.0
 
 # matrix T for transition of Up and Down components accross a layer
-_T = lambda h, k: np.matrix(
+_T = lambda h, k: np.array(
     [[np.exp(1j * k * h), 0.0], [0.0, np.exp(-1j * k * h)]], dtype="complex_"
 )
-_Tinv = lambda h, k: np.matrix(
+_Tinv = lambda h, k: np.array(
     [[np.exp(-1j * k * h), 0.0], [0.0, np.exp(1j * k * h)]], dtype="complex_"
 )
 
@@ -54,8 +54,8 @@ def _Propagate(f, thickness, sig, chg, taux, c, mu_r, eps_r, n):
     K = k(f, sigcm, mu, eps)
     Z = _ImpZ(f, mu, K)
 
-    EH = np.matrix(np.zeros((2, n + 1), dtype="complex_"), dtype="complex_")
-    UD = np.matrix(np.zeros((2, n + 1), dtype="complex_"), dtype="complex_")
+    EH = np.zeros((2, n + 1), dtype="complex_")
+    UD = np.zeros((2, n + 1), dtype="complex_")
 
     UD[1, -1] = 1.0
 
@@ -65,7 +65,7 @@ def _Propagate(f, thickness, sig, chg, taux, c, mu_r, eps_r, n):
         UD = UD / ((np.abs(UD[0, :] + UD[1, :])).max())
 
     for j in range(0, n + 1):
-        EH[:, j] = np.matrix([[1.0, 1,], [-1.0 / Z[j], 1.0 / Z[j]],]) * UD[:, j]
+        EH[:, j] = np.array([[1.0, 1,], [-1.0 / Z[j], 1.0 / Z[j]],]) * UD[:, j]
 
     return UD, EH, Z, K
 

--- a/SimPEG/electromagnetics/analytics/NSEM.py
+++ b/SimPEG/electromagnetics/analytics/NSEM.py
@@ -15,15 +15,15 @@ _PCC = lambda siginf, m, t, c, f: siginf * (
 )
 
 # matrix P relating Up and Down components with E and H fields
-_P = lambda z: np.array([[1.0, 1,], [-1.0 / z, 1.0 / z],], dtype="complex_",)
-_Pinv = lambda z: np.array([[1.0, -z], [1.0, z]], dtype="complex_") / 2.0
+_P = lambda z: np.array([[1.0, 1,], [-1.0 / z, 1.0 / z]])
+_Pinv = lambda z: np.array([[1.0, -z], [1.0, z]]) / 2.0
 
 # matrix T for transition of Up and Down components accross a layer
 _T = lambda h, k: np.array(
-    [[np.exp(1j * k * h), 0.0], [0.0, np.exp(-1j * k * h)]], dtype="complex_"
+    [[np.exp(1j * k * h), 0.0], [0.0, np.exp(-1j * k * h)]],
 )
 _Tinv = lambda h, k: np.array(
-    [[np.exp(-1j * k * h), 0.0], [0.0, np.exp(1j * k * h)]], dtype="complex_"
+    [[np.exp(-1j * k * h), 0.0], [0.0, np.exp(1j * k * h)]],
 )
 
 # Propagate Up and Down component for a certain frequency & evaluate E and H field
@@ -61,11 +61,11 @@ def _Propagate(f, thickness, sig, chg, taux, c, mu_r, eps_r, n):
 
     for i in range(-2, -(n + 2), -1):
 
-        UD[:, i] = _Tinv(H[i + 1], K[i]) * _Pinv(Z[i]) * _P(Z[i + 1]) * UD[:, i + 1]
+        UD[:, i] = _Tinv(H[i + 1], K[i]) @ _Pinv(Z[i]) @ _P(Z[i + 1]) @ UD[:, i + 1]
         UD = UD / ((np.abs(UD[0, :] + UD[1, :])).max())
 
     for j in range(0, n + 1):
-        EH[:, j] = np.array([[1.0, 1,], [-1.0 / Z[j], 1.0 / Z[j]],]) * UD[:, j]
+        EH[:, j] = np.array([[1.0, 1,], [-1.0 / Z[j], 1.0 / Z[j]],]) @ UD[:, j]
 
     return UD, EH, Z, K
 

--- a/SimPEG/electromagnetics/viscous_remanent_magnetization/simulation.py
+++ b/SimPEG/electromagnetics/viscous_remanent_magnetization/simulation.py
@@ -1047,7 +1047,7 @@ class Simulation3DLogUniform(BaseVRMSimulation):
                     self.tau2,
                 )
 
-                f.append(mkvc((self.A[qq] * np.atleast_2d(eta)).T))
+                f.append(mkvc(np.dot(self.A[qq], np.atleast_2d(eta)).T))
 
         return np.array(np.hstack(f))
 

--- a/SimPEG/electromagnetics/viscous_remanent_magnetization/simulation.py
+++ b/SimPEG/electromagnetics/viscous_remanent_magnetization/simulation.py
@@ -695,7 +695,7 @@ class BaseVRMSimulation(BaseSimulation):
                         G[COUNT, :] = c * np.c_[Gxz, Gyz, Gzz]
                         COUNT = COUNT + 1
 
-        return np.atleast_2d(G)
+        return G
 
     def _getAMatricies(self):
 
@@ -917,8 +917,7 @@ class Simulation3DLinear(BaseVRMSimulation):
         self.model = m  # Initiates/updates model and initiates mapping
 
         # Project to active mesh cells
-        # m = np.atleast_2d(self.xiMap * m).T
-        m = np.atleast_2d(self.xiMap * m).T
+        m = self.xiMap * m
 
         # Must return as a numpy array
         return mkvc(sp.coo_matrix.dot(self.T, np.dot(self.A, m)))
@@ -934,10 +933,10 @@ class Simulation3DLinear(BaseVRMSimulation):
         dxidm = self.xiMap.deriv(m)
 
         # dxidm*v
-        v = np.atleast_2d(dxidm * v).T
+        v = dxidm * v
 
         # Dot product with A
-        v = np.dot(self.A, v)
+        v = self.A @ v
 
         # Get active time rows of T
         T = self.T.tocsr()[self.survey.t_active, :]
@@ -1047,7 +1046,7 @@ class Simulation3DLogUniform(BaseVRMSimulation):
                     self.tau2,
                 )
 
-                f.append(mkvc(np.dot(self.A[qq], np.atleast_2d(eta)).T))
+                f.append(mkvc(self.A[qq] @ eta))
 
         return np.array(np.hstack(f))
 

--- a/SimPEG/electromagnetics/viscous_remanent_magnetization/simulation.py
+++ b/SimPEG/electromagnetics/viscous_remanent_magnetization/simulation.py
@@ -695,7 +695,7 @@ class BaseVRMSimulation(BaseSimulation):
                         G[COUNT, :] = c * np.c_[Gxz, Gyz, Gzz]
                         COUNT = COUNT + 1
 
-        return np.matrix(G)
+        return np.atleast_2d(G)
 
     def _getAMatricies(self):
 
@@ -894,7 +894,7 @@ class Simulation3DLinear(BaseVRMSimulation):
 
                     I = sp.diags(np.ones(nLoc))
                     eta = waveObj.getCharDecay(rxList[qq].fieldType, times)
-                    eta = np.matrix(eta).T
+                    eta = np.atleast_2d(eta).T
 
                     T.append(sp.kron(I, eta))
 
@@ -917,8 +917,8 @@ class Simulation3DLinear(BaseVRMSimulation):
         self.model = m  # Initiates/updates model and initiates mapping
 
         # Project to active mesh cells
-        # m = np.matrix(self.xiMap * m).T
-        m = np.matrix(self.xiMap * m).T
+        # m = np.atleast_2d(self.xiMap * m).T
+        m = np.atleast_2d(self.xiMap * m).T
 
         # Must return as a numpy array
         return mkvc(sp.coo_matrix.dot(self.T, np.dot(self.A, m)))
@@ -934,7 +934,7 @@ class Simulation3DLinear(BaseVRMSimulation):
         dxidm = self.xiMap.deriv(m)
 
         # dxidm*v
-        v = np.matrix(dxidm * v).T
+        v = np.atleast_2d(dxidm * v).T
 
         # Dot product with A
         v = self.A * v
@@ -953,7 +953,7 @@ class Simulation3DLinear(BaseVRMSimulation):
             AssertionError("A survey must be set to generate A matrix")
 
         # Define v as a column vector
-        v = np.matrix(v).T
+        v = np.atleast_2d(v).T
 
         # Get T'*Pd'*v
         T = self.T.tocsr()[self.survey.t_active, :]
@@ -1047,7 +1047,7 @@ class Simulation3DLogUniform(BaseVRMSimulation):
                     self.tau2,
                 )
 
-                f.append(mkvc((self.A[qq] * np.matrix(eta)).T))
+                f.append(mkvc((self.A[qq] * np.atleast_2d(eta)).T))
 
         return np.array(np.hstack(f))
 

--- a/SimPEG/electromagnetics/viscous_remanent_magnetization/simulation.py
+++ b/SimPEG/electromagnetics/viscous_remanent_magnetization/simulation.py
@@ -937,7 +937,7 @@ class Simulation3DLinear(BaseVRMSimulation):
         v = np.atleast_2d(dxidm * v).T
 
         # Dot product with A
-        v = self.A * v
+        v = np.dot(self.A, v)
 
         # Get active time rows of T
         T = self.T.tocsr()[self.survey.t_active, :]


### PR DESCRIPTION
Done in two distinct ways:
- Replace `np.matrix(x)` by `np.array(x)` where it is obvious that `x` is at least 2D.
- Replace `np.matrix(x)` by `np.atleast_2d(x)` where this is not the case.

This approach will fail if there is any place where the string annotation has been used:
```
np.matrix('1 2; 3 4')
```
I have not seen it though, so fingers crossed. The tests will show.

Also, matrix multiplication and matrix power might be different, which might require further adjustments. Again, the tests will show.