### PR TITLE
Patch for simple regularization and FDEM base simulation class.

### DIFF
--- a/SimPEG/electromagnetics/frequency_domain/simulation.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation.py
@@ -65,6 +65,10 @@ class BaseFDEMSimulation(BaseEMSimulation):
 
     survey = properties.Instance("a survey object", Survey, required=True)
 
+    forward_only = properties.Boolean(
+        "If True, A-inverse not stored at each frequency in forward simulation", default=False
+    )
+
     # @profile
     def fields(self, m=None):
         """
@@ -101,6 +105,10 @@ class BaseFDEMSimulation(BaseEMSimulation):
             u = self.Ainv[nf] * rhs
             Srcs = self.survey.get_sources_by_frequency(freq)
             f[Srcs, self._solutionType] = u
+            if self.forward_only:
+                if self.verbose:
+                    print("Fields simulated for frequency {}".format(nf))
+                self.Ainv[nf].clean()
         return f
 
     # @profile

--- a/SimPEG/regularization/regularization_mesh.py
+++ b/SimPEG/regularization/regularization_mesh.py
@@ -107,22 +107,24 @@ class RegularizationMesh(props.BaseSimPEG):
         """
         if getattr(self, "_Pafx", None) is None:
             if self.indActive is None:
-                self._Pafx = utils.speye(self.mesh.nFx)
+                ind_active = np.ones(self.mesh.nC, dtype='bool')
             else:
-                # if getattr(self.mesh, 'aveCC2Fx', None) is not None:
-                if self.mesh._meshType == "TREE":
-                    if self.regularization_type == "Tikhonov":
-                        indActive_Fx = (self.mesh.aveFx2CC.T * self.indActive) >= 1
-                        self._Pafx = utils.speye(self.mesh.nFx)[:, indActive_Fx]
-                    else:
-                        indActive_Fx = (
-                            self.mesh._aveCC2FxStencil() * self.indActive
-                        ) >= 1
-                        self._Pafx = utils.speye(self.mesh.ntFx)[:, indActive_Fx]
-                else:
-                    indActive_Fx = self.mesh.aveFx2CC.T * self.indActive >= 1
-
+                ind_active = self.indActive
+            
+            # if getattr(self.mesh, 'aveCC2Fx', None) is not None:
+            if self.mesh._meshType == "TREE":
+                if self.regularization_type == "Tikhonov":
+                    indActive_Fx = (self.mesh.aveFx2CC.T * ind_active) >= 1
                     self._Pafx = utils.speye(self.mesh.nFx)[:, indActive_Fx]
+                else:
+                    indActive_Fx = (
+                        self.mesh.average_cell_to_total_face_x() * ind_active
+                    ) >= 1
+                    self._Pafx = utils.speye(self.mesh.ntFx)[:, indActive_Fx]
+            else:
+                indActive_Fx = self.mesh.aveFx2CC.T * ind_active >= 1
+                self._Pafx = utils.speye(self.mesh.nFx)[:, indActive_Fx]
+        
         return self._Pafx
 
     @property
@@ -136,21 +138,23 @@ class RegularizationMesh(props.BaseSimPEG):
         """
         if getattr(self, "_Pafy", None) is None:
             if self.indActive is None:
-                self._Pafy = utils.speye(self.mesh.nFy)
+                ind_active = np.ones(self.mesh.nC, dtype='bool')
             else:
+                ind_active = self.indActive
+            
                 # if getattr(self.mesh, 'aveCC2Fy', None) is not None:
-                if self.mesh._meshType == "TREE":
-                    if self.regularization_type == "Tikhonov":
-                        indActive_Fy = (self.mesh.aveFy2CC.T * self.indActive) >= 1
-                        self._Pafy = utils.speye(self.mesh.nFy)[:, indActive_Fy]
-                    else:
-                        indActive_Fy = (
-                            self.mesh._aveCC2FyStencil() * self.indActive
-                        ) >= 1
-                        self._Pafy = utils.speye(self.mesh.ntFy)[:, indActive_Fy]
-                else:
-                    indActive_Fy = (self.mesh.aveFy2CC.T * self.indActive) >= 1
+            if self.mesh._meshType == "TREE":
+                if self.regularization_type == "Tikhonov":
+                    indActive_Fy = (self.mesh.aveFy2CC.T * ind_active) >= 1
                     self._Pafy = utils.speye(self.mesh.nFy)[:, indActive_Fy]
+                else:
+                    indActive_Fy = (
+                        self.mesh.average_cell_to_total_face_y() * ind_active
+                    ) >= 1
+                    self._Pafy = utils.speye(self.mesh.ntFy)[:, indActive_Fy]
+            else:
+                indActive_Fy = (self.mesh.aveFy2CC.T * ind_active) >= 1
+                self._Pafy = utils.speye(self.mesh.nFy)[:, indActive_Fy]
         return self._Pafy
 
     @property
@@ -164,21 +168,23 @@ class RegularizationMesh(props.BaseSimPEG):
         """
         if getattr(self, "_Pafz", None) is None:
             if self.indActive is None:
-                self._Pafz = utils.speye(self.mesh.nFz)
+                ind_active = np.ones(self.mesh.nC, dtype='bool')
             else:
-                # if getattr(self.mesh, 'aveCC2Fz', None) is not None:
-                if self.mesh._meshType == "TREE":
-                    if self.regularization_type == "Tikhonov":
-                        indActive_Fz = (self.mesh.aveFz2CC.T * self.indActive) >= 1
-                        self._Pafz = utils.speye(self.mesh.nFz)[:, indActive_Fz]
-                    else:
-                        indActive_Fz = (
-                            self.mesh._aveCC2FzStencil() * self.indActive
-                        ) >= 1
-                        self._Pafz = utils.speye(self.mesh.ntFz)[:, indActive_Fz]
-                else:
-                    indActive_Fz = (self.mesh.aveFz2CC.T * self.indActive) >= 1
+                ind_active = self.indActive
+
+            # if getattr(self.mesh, 'aveCC2Fz', None) is not None:
+            if self.mesh._meshType == "TREE":
+                if self.regularization_type == "Tikhonov":
+                    indActive_Fz = (self.mesh.aveFz2CC.T * ind_active) >= 1
                     self._Pafz = utils.speye(self.mesh.nFz)[:, indActive_Fz]
+                else:
+                    indActive_Fz = (
+                        self.mesh.average_cell_to_total_face_z() * ind_active
+                    ) >= 1
+                    self._Pafz = utils.speye(self.mesh.ntFz)[:, indActive_Fz]
+            else:
+                indActive_Fz = (self.mesh.aveFz2CC.T * ind_active) >= 1
+                self._Pafz = utils.speye(self.mesh.nFz)[:, indActive_Fz]
         return self._Pafz
 
     @property
@@ -222,7 +228,7 @@ class RegularizationMesh(props.BaseSimPEG):
                     )
                 else:
                     self._aveCC2Fx = (
-                        self.Pafx.T * self.mesh._aveCC2FxStencil() * self.Pac
+                        self.Pafx.T * self.mesh.average_cell_to_total_face_x() * self.Pac
                     )
             else:
                 self._aveCC2Fx = (
@@ -270,7 +276,7 @@ class RegularizationMesh(props.BaseSimPEG):
                     )
                 else:
                     self._aveCC2Fy = (
-                        self.Pafy.T * self.mesh._aveCC2FyStencil() * self.Pac
+                        self.Pafy.T * self.mesh.average_cell_to_total_face_y() * self.Pac
                     )
             else:
                 self._aveCC2Fy = (
@@ -318,7 +324,7 @@ class RegularizationMesh(props.BaseSimPEG):
                     )
                 else:
                     self._aveCC2Fz = (
-                        self.Pafz.T * self.mesh._aveCC2FzStencil() * self.Pac
+                        self.Pafz.T * self.mesh.average_cell_to_total_face_z() * self.Pac
                     )
             else:
                 self._aveCC2Fz = (


### PR DESCRIPTION
This patch fixes two small bugs:

1) If no active cells model is assigned to the simulation, the projection from cells to active faces (x, y and z) breaks. The patch will simply recognize that *simulation.indActive = None* and temporarily create an active cells model in the functionality of *regularization.Simple*. See issue #985 

2) The base simulation class for frequency domain will store the factorizations of A-inverse at all frequencies even if you are doing a forward simulation. If the forward simulation has many frequencies, you will likely run out of RAM. By introducing a 'forward_only' keyword argument to the simulation, we can delete each factorization of A-inverse once it is used.

