### PR TITLE
Add forward only option to 3D FDEM

### DIFF
--- a/SimPEG/electromagnetics/frequency_domain/simulation.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation.py
@@ -62,6 +62,10 @@ class BaseFDEMSimulation(BaseEMSimulation):
     mui, muiMap, muiDeriv = props.Invertible("Inverse Magnetic Permeability (m/H)")
 
     props.Reciprocal(mu, mui)
+    
+    forward_only = properties.Boolean(
+        "If True, A-inverse not stored at each frequency in forward simulation", default=False
+    )
 
     survey = properties.Instance("a survey object", Survey, required=True)
 
@@ -101,6 +105,10 @@ class BaseFDEMSimulation(BaseEMSimulation):
             u = self.Ainv[nf] * rhs
             Srcs = self.survey.get_sources_by_frequency(freq)
             f[Srcs, self._solutionType] = u
+            if self.forward_only:
+                if self.verbose:
+                    print("Fields simulated for frequency {}".format(nf))
+                self.Ainv[nf].clean()
         return f
 
     # @profile


### PR DESCRIPTION
Currently, the factorizations for A inverse are stored simultaneously for all frequencies. In the case you would like to run a forward simulation on many frequencies, you can run out of RAM. Similar to the option for potential fields, we introduce a 'forward_only' argument.