### PR TITLE
No active cells bug in regularization mesh

### DIFF
--- a/SimPEG/regularization/regularization_mesh.py
+++ b/SimPEG/regularization/regularization_mesh.py
@@ -107,22 +107,24 @@ class RegularizationMesh(props.BaseSimPEG):
         """
         if getattr(self, "_Pafx", None) is None:
             if self.indActive is None:
-                self._Pafx = utils.speye(self.mesh.nFx)
+                ind_active = np.ones(self.mesh.nC, dtype='bool')
             else:
-                # if getattr(self.mesh, 'aveCC2Fx', None) is not None:
-                if self.mesh._meshType == "TREE":
-                    if self.regularization_type == "Tikhonov":
-                        indActive_Fx = (self.mesh.aveFx2CC.T * self.indActive) >= 1
-                        self._Pafx = utils.speye(self.mesh.nFx)[:, indActive_Fx]
-                    else:
-                        indActive_Fx = (
-                            self.mesh._aveCC2FxStencil() * self.indActive
-                        ) >= 1
-                        self._Pafx = utils.speye(self.mesh.ntFx)[:, indActive_Fx]
-                else:
-                    indActive_Fx = self.mesh.aveFx2CC.T * self.indActive >= 1
-
+                ind_active = self.indActive
+            
+            # if getattr(self.mesh, 'aveCC2Fx', None) is not None:
+            if self.mesh._meshType == "TREE":
+                if self.regularization_type == "Tikhonov":
+                    indActive_Fx = (self.mesh.aveFx2CC.T * ind_active) >= 1
                     self._Pafx = utils.speye(self.mesh.nFx)[:, indActive_Fx]
+                else:
+                    indActive_Fx = (
+                        self.mesh.average_cell_to_total_face_x() * ind_active
+                    ) >= 1
+                    self._Pafx = utils.speye(self.mesh.ntFx)[:, indActive_Fx]
+            else:
+                indActive_Fx = self.mesh.aveFx2CC.T * ind_active >= 1
+                self._Pafx = utils.speye(self.mesh.nFx)[:, indActive_Fx]
+        
         return self._Pafx
 
     @property
@@ -136,21 +138,23 @@ class RegularizationMesh(props.BaseSimPEG):
         """
         if getattr(self, "_Pafy", None) is None:
             if self.indActive is None:
-                self._Pafy = utils.speye(self.mesh.nFy)
+                ind_active = np.ones(self.mesh.nC, dtype='bool')
             else:
+                ind_active = self.indActive
+            
                 # if getattr(self.mesh, 'aveCC2Fy', None) is not None:
-                if self.mesh._meshType == "TREE":
-                    if self.regularization_type == "Tikhonov":
-                        indActive_Fy = (self.mesh.aveFy2CC.T * self.indActive) >= 1
-                        self._Pafy = utils.speye(self.mesh.nFy)[:, indActive_Fy]
-                    else:
-                        indActive_Fy = (
-                            self.mesh._aveCC2FyStencil() * self.indActive
-                        ) >= 1
-                        self._Pafy = utils.speye(self.mesh.ntFy)[:, indActive_Fy]
-                else:
-                    indActive_Fy = (self.mesh.aveFy2CC.T * self.indActive) >= 1
+            if self.mesh._meshType == "TREE":
+                if self.regularization_type == "Tikhonov":
+                    indActive_Fy = (self.mesh.aveFy2CC.T * ind_active) >= 1
                     self._Pafy = utils.speye(self.mesh.nFy)[:, indActive_Fy]
+                else:
+                    indActive_Fy = (
+                        self.mesh.average_cell_to_total_face_y() * ind_active
+                    ) >= 1
+                    self._Pafy = utils.speye(self.mesh.ntFy)[:, indActive_Fy]
+            else:
+                indActive_Fy = (self.mesh.aveFy2CC.T * ind_active) >= 1
+                self._Pafy = utils.speye(self.mesh.nFy)[:, indActive_Fy]
         return self._Pafy
 
     @property
@@ -164,21 +168,23 @@ class RegularizationMesh(props.BaseSimPEG):
         """
         if getattr(self, "_Pafz", None) is None:
             if self.indActive is None:
-                self._Pafz = utils.speye(self.mesh.nFz)
+                ind_active = np.ones(self.mesh.nC, dtype='bool')
             else:
-                # if getattr(self.mesh, 'aveCC2Fz', None) is not None:
-                if self.mesh._meshType == "TREE":
-                    if self.regularization_type == "Tikhonov":
-                        indActive_Fz = (self.mesh.aveFz2CC.T * self.indActive) >= 1
-                        self._Pafz = utils.speye(self.mesh.nFz)[:, indActive_Fz]
-                    else:
-                        indActive_Fz = (
-                            self.mesh._aveCC2FzStencil() * self.indActive
-                        ) >= 1
-                        self._Pafz = utils.speye(self.mesh.ntFz)[:, indActive_Fz]
-                else:
-                    indActive_Fz = (self.mesh.aveFz2CC.T * self.indActive) >= 1
+                ind_active = self.indActive
+
+            # if getattr(self.mesh, 'aveCC2Fz', None) is not None:
+            if self.mesh._meshType == "TREE":
+                if self.regularization_type == "Tikhonov":
+                    indActive_Fz = (self.mesh.aveFz2CC.T * ind_active) >= 1
                     self._Pafz = utils.speye(self.mesh.nFz)[:, indActive_Fz]
+                else:
+                    indActive_Fz = (
+                        self.mesh.average_cell_to_total_face_z() * ind_active
+                    ) >= 1
+                    self._Pafz = utils.speye(self.mesh.ntFz)[:, indActive_Fz]
+            else:
+                indActive_Fz = (self.mesh.aveFz2CC.T * ind_active) >= 1
+                self._Pafz = utils.speye(self.mesh.nFz)[:, indActive_Fz]
         return self._Pafz
 
     @property


### PR DESCRIPTION
Currently, the projection from cells to active faces breaks in regularization_mesh.py when no active cells model is applied to the simulation. This is a basic fix for the bug.