### PR TITLE
Fix bug in IO for DCIP3D data

### DIFF
--- a/SimPEG/utils/io_utils/io_utils_electromagnetics.py
+++ b/SimPEG/utils/io_utils/io_utils_electromagnetics.py
@@ -437,7 +437,7 @@ def read_dcip3d_ubc(file_name, data_type):
     is_pole_rx = False
 
     # IP data for dcip3d has a line with a flag we can remove.
-    if data_type != "volt":
+    if obsfile[0][0:6] == 'IPTYPE':
         obsfile = obsfile[1:]
 
     # Since SimPEG defines secondary potential from IP as voltage,


### PR DESCRIPTION
When loading a DCIP3D or DCIP octree survey files, the code will skip the first line if the data_type flag is not volts. When loading secondary potential of apparent chargeability data, SimPEG assumes the data file has the flag IPTYPE=1,2 (which is not necessary to model IP data when forward modeling with GIF codes).

The IO has been updated to skip the survey line if and only if it finds a line that begins with IPTYPE. This should be a more robust function for the IO.