### PR TITLE
Add truncation factor for sensitivity weights

### DIFF
--- a/SimPEG/directives/directives.py
+++ b/SimPEG/directives/directives.py
@@ -1606,6 +1606,7 @@ class UpdateSensitivityWeights(InversionDirective):
     everyIter = True
     threshold = 1e-12
     switch = True
+    truncation_factor = 1e-10
 
     def initialize(self):
 
@@ -1669,6 +1670,7 @@ class UpdateSensitivityWeights(InversionDirective):
 
             wr = wr ** 0.5
             wr /= wr.max()
+            wr[wr < self.truncation_factor] = self.truncation_factor
         else:
             wr += 1.0
 

--- a/SimPEG/directives/directives.py
+++ b/SimPEG/directives/directives.py
@@ -1669,7 +1669,7 @@ class UpdateSensitivityWeights(InversionDirective):
 
             wr = wr ** 0.5
             wr /= wr.max()
-            wr += self.threshold
+            wr[wr<self.threshold] = self.threshold
         else:
             wr += 1.0
 

--- a/SimPEG/directives/directives.py
+++ b/SimPEG/directives/directives.py
@@ -1606,7 +1606,6 @@ class UpdateSensitivityWeights(InversionDirective):
     everyIter = True
     threshold = 1e-12
     switch = True
-    truncation_factor = 1e-10
 
     def initialize(self):
 
@@ -1666,11 +1665,11 @@ class UpdateSensitivityWeights(InversionDirective):
                 self.JtJdiag, self.simulation, self.dmisfit.objfcts
             ):
 
-                wr += prob_JtJ + self.threshold
+                wr += prob_JtJ
 
             wr = wr ** 0.5
             wr /= wr.max()
-            wr[wr < self.truncation_factor] = self.truncation_factor
+            wr += self.threshold
         else:
             wr += 1.0
 


### PR DESCRIPTION
Currently, sensitivity weights in directives are stabilized through the 'threshold' property. However, it is difficult to adjust this parameter if one would like to truncate the sensitivity weights. Here we introduce a truncation factor as a final step when creating the sensitivity weights.