### PR TITLE
Fix pgi tutorials accounting volume twice

### DIFF
--- a/examples/10-pgi/plot_inv_1_PGI_Linear_1D_joint_WithRelationships.py
+++ b/examples/10-pgi/plot_inv_1_PGI_Linear_1D_joint_WithRelationships.py
@@ -128,9 +128,9 @@ dmis = dmis1 + dmis2
 minit = np.zeros_like(m)
 
 # Distance weighting
-wr1 = np.sum(prob1.G ** 2.0, axis=0) ** 0.5
+wr1 = np.sum(prob1.G ** 2.0, axis=0) ** 0.5 / mesh.cell_volumes 
 wr1 = wr1 / np.max(wr1)
-wr2 = np.sum(prob2.G ** 2.0, axis=0) ** 0.5
+wr2 = np.sum(prob2.G ** 2.0, axis=0) ** 0.5 / mesh.cell_volumes
 wr2 = wr2 / np.max(wr2)
 wr = np.r_[wr1, wr2]
 W = utils.sdiag(wr)

--- a/tutorials/13-pgi/plot_inv_1_joint_pf_pgi_full_info_tutorial.py
+++ b/tutorials/13-pgi/plot_inv_1_joint_pf_pgi_full_info_tutorial.py
@@ -314,10 +314,10 @@ plt.show()
 #
 
 # Sensitivity weighting
-wr_grav = np.sum(simulation_grav.G ** 2.0, axis=0) ** 0.5
+wr_grav = np.sum(simulation_grav.G ** 2.0, axis=0) ** 0.5 / (mesh.cell_volumes[actv])
 wr_grav = wr_grav / np.max(wr_grav)
 
-wr_mag = np.sum(simulation_mag.G ** 2.0, axis=0) ** 0.5
+wr_mag = np.sum(simulation_mag.G ** 2.0, axis=0) ** 0.5 / (mesh.cell_volumes[actv])
 wr_mag = wr_mag / np.max(wr_mag)
 
 # create joint PGI regularization with smoothness

--- a/tutorials/13-pgi/plot_inv_2_joint_pf_pgi_no_info_tutorial.py
+++ b/tutorials/13-pgi/plot_inv_2_joint_pf_pgi_no_info_tutorial.py
@@ -334,10 +334,10 @@ plt.show()
 
 # Create PGI regularization
 # Sensitivity weighting
-wr_grav = np.sum(simulation_grav.G ** 2.0, axis=0) ** 0.5
+wr_grav = np.sum(simulation_grav.G ** 2.0, axis=0) ** 0.5 / (mesh.cell_volumes[actv])
 wr_grav = wr_grav / np.max(wr_grav)
 
-wr_mag = np.sum(simulation_mag.G ** 2.0, axis=0) ** 0.5
+wr_mag = np.sum(simulation_mag.G ** 2.0, axis=0) ** 0.5 / (mesh.cell_volumes[actv])
 wr_mag = wr_mag / np.max(wr_mag)
 
 # create joint PGI regularization with smoothness


### PR DESCRIPTION
The tutorial were still running smoothly but they actually now account volume twice. Final Alphas are still different than before because volume and normalization are done in a different order since 0.15.2.