### PR TITLE
emg3d solver new

### DIFF
--- a/SimPEG/data.py
+++ b/SimPEG/data.py
@@ -8,7 +8,7 @@ from . import survey
 from .utils import mkvc
 from .utils.code_utils import deprecate_property
 
-__all__ = ["Data", "SyntheticData"]
+__all__ = ["Data", "ComplexData", "SyntheticData"]
 
 
 class UncertaintyArray(properties.Array):
@@ -21,7 +21,6 @@ class UncertaintyArray(properties.Array):
         elif isinstance(value, float):
             return value
         return super(properties.Array, self).validate(instance, value)
-
 
 class Data(properties.HasProperties):
     """
@@ -307,6 +306,8 @@ class Data(properties.HasProperties):
         error=True,
     )
 
+class ComplexData(Data):
+    dobs = None
 
 class SyntheticData(Data):
     """

--- a/SimPEG/data_misfit.py
+++ b/SimPEG/data_misfit.py
@@ -145,7 +145,7 @@ class L2DataMisfit(BaseDataMisfit):
         "__call__(m, f=None)"
 
         R = self.W * self.residual(m, f=f)
-        return 0.5 * np.vdot(R, R)
+        return 0.5 * np.vdot(R, R).real
 
     @timeIt
     def deriv(self, m, f=None):

--- a/SimPEG/electromagnetics/frequency_domain/__init__.py
+++ b/SimPEG/electromagnetics/frequency_domain/__init__.py
@@ -7,6 +7,7 @@ from .simulation import (
     Simulation3DCurrentDensity,
     Simulation3DMagneticField,
 )
+from .simulation_emg3d import Simulation3DEMG3D
 from .fields import (
     Fields3DElectricField,
     Fields3DMagneticFluxDensity,

--- a/SimPEG/electromagnetics/frequency_domain/receivers.py
+++ b/SimPEG/electromagnetics/frequency_domain/receivers.py
@@ -22,7 +22,8 @@ class BaseRx(survey.BaseRx):
         {
             "real": ["re", "in-phase", "in phase"],
             "imag": ["imaginary", "im", "out-of-phase", "out of phase"],
-            "complex":["both"]
+            "complex":["both"], 
+            "amp": ["amplitude"],
         },
     )
 
@@ -48,6 +49,12 @@ class BaseRx(survey.BaseRx):
     def projGLoc(self, f):
         """Grid Location projection (e.g. Ex Fy ...)"""
         return f._GLoc(self.projField) + self.orientation
+    
+    def evalDataComplex(self, data_complex):
+        if self.component == 'amp':
+            return abs(data_complex)
+        else:
+            return data_complex
 
     def eval(self, src, mesh, f):
         """

--- a/SimPEG/electromagnetics/frequency_domain/receivers.py
+++ b/SimPEG/electromagnetics/frequency_domain/receivers.py
@@ -1,4 +1,5 @@
 import properties
+import numpy as np
 from ...utils.code_utils import deprecate_class, deprecate_property
 
 from ... import survey
@@ -14,16 +15,23 @@ class BaseRx(survey.BaseRx):
     """
 
     orientation = properties.StringChoice(
-        "orientation of the receiver. Must currently be 'x', 'y', 'z'", ["x", "y", "z"]
+        "orientation of the receiver (x, y, z, rotated)",
+        {
+            "x": [],
+            "y": [],
+            "z": [],
+            "rotated": ["rot", "arbitrary"],
+        },
     )
 
     component = properties.StringChoice(
-        "component of the field (real or imag)",
+        "component of the field (real, imag, complex, amplitude, phase)",
         {
             "real": ["re", "in-phase", "in phase"],
             "imag": ["imaginary", "im", "out-of-phase", "out of phase"],
-            "complex":["both"], 
-            "amp": ["amplitude"],
+            "complex": ["comp", "both"],
+            "amplitude": ["amp"],
+            "phase": ["pha"],
         },
     )
 
@@ -51,8 +59,10 @@ class BaseRx(survey.BaseRx):
         return f._GLoc(self.projField) + self.orientation
     
     def evalDataComplex(self, data_complex):
-        if self.component == 'amp':
+        if self.component == 'amplitude':
             return abs(data_complex)
+        elif self.component == 'phase':
+            return np.angle(data_complex)
         else:
             return data_complex
 
@@ -124,13 +134,28 @@ class PointElectricField(BaseRx):
     Electric field FDEM receiver
 
     :param numpy.ndarray locations: receiver locations (ie. :code:`np.r_[x,y,z]`)
-    :param string orientation: receiver orientation 'x', 'y' or 'z'
-    :param string component: real or imaginary component 'real' or 'imag'
+    :param string orientation: receiver orientation 'x', 'y', 'z', or 'rotated'
+    :param string component: 'real', 'imag', 'complex', 'amplitude', or 'phase'
+    :param float azimuth: azimuth, only used if `orientation='rotated'`
+    :param float elevation: elevation, only used if `orientation='rotated'`
     """
 
-    def __init__(self, locations, orientation="x", component="real"):
+    # TODO : the current implementation of azimuth/elevation is not good. It
+    #        only allows for one azimuth/elevation for all locations. Ideally
+    #        the angles should have the same size as locations (but 1D).
+
+    azimuth = properties.Float("azimuth (anticlockwise from Easting)", default=0, min=-360.0, max=360)
+
+    elevation = properties.Float("elevation (positive up)", default=0, min=-180.0, max=180)
+
+    def __init__(self, locations, orientation="x", component="real", **kwargs):
+        angles = kwargs.get("azimuth", None) or kwargs.get("elevation", None)
+        if orientation in ["x", "y", "z"] and angles:
+            raise ValueError(
+                "orientation must be 'rotated' if angles are provided."
+            )
         self.projField = "e"
-        super(PointElectricField, self).__init__(locations, orientation, component)
+        super(PointElectricField, self).__init__(locations, orientation, component, **kwargs)
 
 
 class PointMagneticFluxDensity(BaseRx):
@@ -170,13 +195,28 @@ class PointMagneticField(BaseRx):
     Magnetic field FDEM receiver
 
     :param numpy.ndarray locations: receiver locations (ie. :code:`np.r_[x,y,z]`)
-    :param string orientation: receiver orientation 'x', 'y' or 'z'
-    :param string component: real or imaginary component 'real' or 'imag'
+    :param string orientation: receiver orientation 'x', 'y', 'z', or 'rotated'
+    :param string component: 'real', 'imag', 'complex', 'amplitude', or 'phase'
+    :param float azimuth: azimuth, only used if `orientation='rotated'`
+    :param float elevation: elevation, only used if `orientation='rotated'`
     """
 
-    def __init__(self, locations, orientation="x", component="real"):
+    # TODO : the current implementation of azimuth/elevation is not good. It
+    #        only allows for one azimuth/elevation for all locations. Ideally
+    #        the angles should have the same size as locations (but 1D).
+
+    azimuth = properties.Float("azimuth (anticlockwise from Easting)", default=0, min=-360.0, max=360)
+
+    elevation = properties.Float("elevation (positive up)", default=0, min=-180.0, max=180)
+
+    def __init__(self, locations, orientation="x", component="real", **kwargs):
+        angles = kwargs.get("azimuth", None) or kwargs.get("elevation", None)
+        if orientation in ["x", "y", "z"] and angles:
+            raise ValueError(
+                "orientation must be 'rotated' if angles are provided."
+            )
         self.projField = "h"
-        super(PointMagneticField, self).__init__(locations, orientation, component)
+        super(PointMagneticField, self).__init__(locations, orientation, component, **kwargs)
 
 
 class PointCurrentDensity(BaseRx):

--- a/SimPEG/electromagnetics/frequency_domain/receivers.py
+++ b/SimPEG/electromagnetics/frequency_domain/receivers.py
@@ -22,6 +22,7 @@ class BaseRx(survey.BaseRx):
         {
             "real": ["re", "in-phase", "in phase"],
             "imag": ["imaginary", "im", "out-of-phase", "out of phase"],
+            "complex":["both"]
         },
     )
 

--- a/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
@@ -16,6 +16,16 @@ try:
 except ImportError:
     emg3d = False
 
+# Temporary work-around to ensure multiprocessing does not hang if sklearn is
+# installed. This should hopefully not be necessary in the future. See https://scikit-learn.org/stable/faq.html#why-do-i-sometime-get-a-crash-freeze-with-n-jobs-1-under-osx-or-linux
+try:
+    import sklearn
+except ImportError:
+    pass
+else:
+    import multiprocessing
+    multiprocessing.set_start_method('forkserver')
+
 
 @requires({"emg3d": emg3d})
 class Simulation3DEMG3D(BaseFDEMSimulation):

--- a/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
@@ -1,0 +1,241 @@
+import numpy as np
+import scipy.sparse as sp
+from scipy.constants import mu_0
+import properties
+from ...utils.code_utils import deprecate_class
+
+from ... import props
+from ...data import Data
+from ...utils import mkvc
+from .simulation import BaseFDEMSimulation
+from ..utils import omega
+from .survey import Survey
+from .fields import (
+    Fields3DElectricField,
+)
+import emg3d
+from emg3d import models, surveys, simulations, optimize
+
+
+class Simulation3DEMG3D(BaseFDEMSimulation):
+    """
+    By eliminating the magnetic flux density using
+
+        .. math ::
+
+            \mathbf{b} = \\frac{1}{i \omega}\\left(-\mathbf{C} \mathbf{e} +
+            \mathbf{s_m}\\right)
+
+
+    we can write Maxwell's equations as a second order system in
+    \\\(\\\mathbf{e}\\\) only:
+
+    .. math ::
+
+        \\left(\mathbf{C}^{\\top} \mathbf{M_{\mu^{-1}}^f} \mathbf{C} +
+        i \omega \mathbf{M^e_{\sigma}} \\right)\mathbf{e} =
+        \mathbf{C}^{\\top} \mathbf{M_{\mu^{-1}}^f}\mathbf{s_m}
+        - i\omega\mathbf{M^e}\mathbf{s_e}
+
+    which we solve for :math:`\mathbf{e}`.
+
+    :param discretize.base.BaseMesh mesh: mesh
+    """
+
+    _solutionType = "eSolution"
+    _formulation = "EB"
+    fieldsPair = Fields3DElectricField
+    max_workers = 1
+    storeJ = False
+    _Jmatrix = None
+
+    def __init__(self, mesh, **kwargs):
+        super(Simulation3DEMG3D, self).__init__(mesh, **kwargs)
+  
+    @property
+    def emg3d_survey(self):
+        if getattr(self, "_emg3d_survey", None) is None:
+            self._emg3d_survey = self.generate_emg3d_survey_from_simpeg_survey()
+        return self._emg3d_survey
+    
+    @property
+    def emg3d_sigma(self):
+        self._emg3d_sigma = models.Model(
+            self.mesh, 
+            self.sigma.reshape(self.mesh.vnC, order='F'), 
+            mapping='Conductivity'
+        )
+        return self._emg3d_sigma
+
+    @ property
+    def emg3d_simulation_inputs(self):
+        if getattr(self, "_emg3d_simulation_inputs", None) is None:
+            solver_opts = {
+                'sslsolver': False,
+                'semicoarsening': False,
+                'linerelaxation': False,
+            #     'tol': 5e-5,  # Reduce tolerance to speed-up
+            }
+            self._emg3d_simulation_inputs = {
+                'name': 'Testing',
+                'survey': self.emg3d_survey,
+                'solver_opts': solver_opts,
+                'max_workers': self.max_workers,
+                'gridding': 'same',
+                'verb': -1,
+            }        
+        return self._emg3d_simulation_inputs
+    
+    
+    def generate_emg3d_survey_from_simpeg_survey(self):
+
+        source_list_emg3d = []
+        src_rx_uids = []
+        source_frequency = []
+        for src in self.survey.srcList:
+            source_frequency.append(src.frequency)    
+            src_emg3d = emg3d.TxElectricDipole(
+                (src.location[0], src.location[1], src.location[2], src.dip, src.azimuth)
+            )
+            source_list_emg3d.append(src_emg3d)
+            for rx in src.rxList:
+                src_rx_uids.append([src._uid, rx._uid])
+        src_rx_uids = np.vstack(src_rx_uids)
+
+        # assume all sources have the same receiver locations now
+        if np.unique(src_rx_uids[:,1]).size == 1:
+            # also assume rx only contains a single component
+            if rx.projField == 'e':
+                emg3d_rx_object = emg3d.RxElectricPoint
+            elif rx.projField == 'h':
+                emg3d_rx_object = emg3d.RxMagneticPoint
+            
+            if rx.orientation == 'x':
+                azimuth, dip = 0, 0
+            elif rx.orientation == 'y':
+                azimuth, dip = 90, 0
+            elif rx.orientation == 'z':
+                azimuth, dip = 0, 90
+            else:
+                raise Exception()
+            receivers = emg3d.surveys.txrx_coordinates_to_dict(
+                emg3d_rx_object,
+                (rx.locations[:,0], rx.locations[:,1], rx.locations[:,2], dip, azimuth),
+            )    
+        else:
+            raise Exception()
+        sources = emg3d.surveys.txrx_lists_to_dict(source_list_emg3d)  
+        source_frequency = np.unique(np.array(source_frequency))
+        emg3d_survey = surveys.Survey(
+            name='emg3d survey',
+            sources=sources,
+            receivers=receivers,
+            frequencies=source_frequency,
+            noise_floor=1.,
+            relative_error=None,
+        )
+        self.n_source = len(source_list_emg3d)
+        self.n_frequency = len(source_frequency)
+        self.n_receiver = rx.locations.shape[0]
+        return emg3d_survey
+
+    def Jvec(self, m, v, f=None):
+        if self.verbose:
+            print ("Compute Jvec")
+
+        if self.storeJ:
+            J = self.getJ(m, f=f)
+            Jv = mkvc(np.dot(J, v))
+            return Jv
+
+        self.model = m        
+
+        if f is None:
+            f = self.fields(m=m)       
+        
+        dsig_dm_v = self.sigmaDeriv @ v
+        j_vec = optimize.jvec(f, vec=dsig_dm_v)
+        return j_vec
+
+    def Jtvec(self, m, v, f=None):
+        if self.verbose:
+            print("Compute Jtvec")
+        
+        if self.storeJ:
+            J = self.getJ(m, f=f)
+            Jtv = mkvc(np.dot(J.T, v))
+            return Jtv
+
+        self.model = m
+
+        if f is None:
+            f = self.fields(m=m)        
+
+        return self._Jtvec(m, v=v, f=f)
+    
+    def _Jtvec(self, m, v=None, f=None):
+        """
+            Compute adjoint sensitivity matrix (J^T) and vector (v) product.
+            Full J matrix can be computed by inputing v=None
+        """
+
+        if v is not None:
+
+            jt_sigma_vec = optimize.gradient(f, vec=v)
+            jt_vec = self.sigmaDeriv.T @ jt_sigma_vec
+            return jt_vec
+
+        else:
+            # This is for forming full sensitivity matrix
+            # Currently, it is not correct. 
+            # Requires a fix in optimize.gradient 
+            # Jt is supposed to be a complex value ... 
+            Jt = np.zeros((self.model.size, self.survey.nD), order="F")
+            for i_datum in range(self.survey.nD):
+                v = np.zeros(self.survey.nD)
+                v[i_datum] = 1.
+                jt_sigma_vec = optimize.gradient(f, vec=v)
+                Jt[:, i_datum] = self.sigmaDeriv.T @ jt_sigma_vec
+            
+            return Jt
+
+    def getJ(self, m, f=None):
+        """
+            Generate Full sensitivity matrix
+        """
+        if self._Jmatrix is not None:
+            return self._Jmatrix
+        else:
+            if self.verbose:
+                print("Calculating J and storing")
+            self.model = m
+            if f is None:
+                f = self.fields(m)
+            self._Jmatrix = (self._Jtvec(m, v=None, f=f)).T
+        return self._Jmatrix
+
+
+    def dpred(self, m=None, f=None):
+        if self.verbose:
+            print("Compute predicted")
+        # currently this does not change once self.fields is computed.
+        if f is None:
+            f = self.fields(m=m)
+        # this may not be robust, need to be changed... 
+        data = f.data.synthetic.values.flatten()
+        return data 
+  
+    def fields(self, m=None):
+        if self.verbose:
+            print("Compute fields")
+        self.model = m
+ 
+        f = simulations.Simulation(
+            model=self.emg3d_sigma, 
+            **self.emg3d_simulation_inputs
+        )
+        std = f.survey.standard_deviation
+        # Store weights
+        f.data['weights'] = std**-2        
+        f.compute()
+        return f

--- a/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
@@ -5,6 +5,8 @@ from discretize.utils import requires
 from ...utils import mkvc
 from .simulation import BaseFDEMSimulation
 from .sources import ElectricWire
+from ...data import ComplexData
+from memory_profiler import profile
 
 # emg3d is a soft dependency
 try:
@@ -148,6 +150,7 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
         self.emg3d_sim._misfit = None
         self.emg3d_sim._vec = None  # TODO check back when emg3d-side finished!
 
+    # @profile
     def Jvec(self, m, v, f=None):
         """
         Sensitivity times a vector.
@@ -178,6 +181,7 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
         # Map emg3d-data-array to SimPEG-data-vector
         return j_vec[self._dmap_simpeg_emg3d]
 
+    # @profile
     def Jtvec(self, m, v, f=None):
         """
         Sensitivity transpose times a vector
@@ -189,7 +193,7 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
         :return: Jtvec (nP,)
         """
         if self.verbose:
-            print("Compute Jtvec")
+            print("Compute Jtvec")  
 
         if self.storeJ:
 
@@ -284,8 +288,15 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
             f = self.fields(m=m)
 
         # Map emg3d-data-array to SimPEG-data-vector
-        return f.data.synthetic.data[self._dmap_simpeg_emg3d]
+        data_complex = ComplexData(survey=self.survey, dobs=f.data.synthetic.data[self._dmap_simpeg_emg3d])
+        data = []
+        for src in self.survey.source_list:
+            for rx in src.receiver_list:
+                data_complex_rx = rx.evalDataComplex(data_complex[src, rx])
+                data.append(data_complex_rx)
+        return np.hstack(data)
 
+    # @profile
     def fields(self, m=None):
         """Return the electric fields for a given model.
 
@@ -422,14 +433,14 @@ def survey_to_emg3d(survey):
             rec_type = rec_types[rec.projField == 'h']
             azimuth = [0, 90][rec.orientation == 'y']
             elevation = [0, 90][rec.orientation == 'z']
+            component = rec.component
 
             # Loop over receivers.
             for i in range(rec.locations[:, 0].size):
 
                 # Create emg3d receiver.
                 receiver = rec_type(
-                        (*rec.locations[i, :], azimuth, elevation))
-
+                        (*rec.locations[i, :], azimuth, elevation), data_type=component)
                 # New receiver: add.
                 if receiver not in rec_list:
                     r_ind = len(rec_list)

--- a/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
@@ -4,6 +4,7 @@ from discretize.utils import requires
 
 from ...utils import mkvc
 from .simulation import BaseFDEMSimulation
+from .sources import ElectricWire
 
 # emg3d is a soft dependency
 try:
@@ -84,10 +85,16 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
             for src in self.survey.source_list:
 
                 # Create emg3d source.
-                source = emg3d.TxElectricDipole(
-                    (*src.location, src.azimuth, src.elevation),
-                    strength=src.strength, length=src.length
-                )
+                if isinstance(src, ElectricWire):
+                    source = emg3d.TxElectricWire(
+                        src.locations,
+                        strength=src.strength
+                    )                    
+                else:
+                    source = emg3d.TxElectricDipole(
+                        (*src.location, src.azimuth, src.elevation),
+                        strength=src.strength, length=src.length
+                    )
 
                 # New frequency: add.
                 if src.frequency not in freq_list:

--- a/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
@@ -4,9 +4,11 @@ from discretize.utils import requires
 
 from ...utils import mkvc
 from .simulation import BaseFDEMSimulation
-from .sources import ElectricWire
+from .sources import ElectricDipole, ElectricWire
+from .receivers import PointElectricField, PointMagneticField
+from .survey import Survey
 from ...data import ComplexData
-from memory_profiler import profile
+# from memory_profiler import profile
 
 # emg3d is a soft dependency
 try:
@@ -21,13 +23,8 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
 
     .. note::
 
-        - Only isotropic model implemented so far. Needs extension to tri-axial
-          anisotropy, mu_r, and epsilon_r.
-
-        - Currently, only electric "point"-dipole sources and electric/magnetic
-          point receivers are implemented. emg3d could do more, e.g., finite
-          length electric dipoles or arbitrary electric wires (and therefore
-          loops). These are *not yet* implemented here.
+        Currently only isotropic models are implemented, with unit relative
+        electric permittivity and unit relative magnetic permeability.
 
 
     Parameters
@@ -35,6 +32,11 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
     simulation_opts : dict
         Input parameters forward to ``emg3d.Simulation``. See the emg3d
         documentation for all the possibilities.
+
+        By default, `gridding='same'`, which is different from the default in
+        emg3d. However, any `gridding` and `gridding_opts` can be provided. In
+        that case one can also provide a `model`, which is used as the
+        reference model for the automatic gridding routine.
 
     """
 
@@ -51,11 +53,6 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
 
         super().__init__(mesh, **kwargs)
 
-        # TODO : Count to store data per iteration.
-        # - Should be replaced by a proper count form SimPEG.inversion.
-        # - Should probably be made optional to store data at each step.
-        self._it_count = 0
-
     @property
     def emg3d_sim(self):
         """emg3d simulation; obtained from SimPEG simulation."""
@@ -65,12 +62,15 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
             # Create twin Simulation in emg3d.
             self._emg3d_sim = emg3d.Simulation(
                 survey=self.emg3d_survey,
-                model=emg3d.Model(self.mesh),  # Dummy values of 1 for init.
-                **{'name': 'Simulation created by SimPEG',
-                   'gridding': 'same',               # Change this eventually!
-                   'tqdm_opts': {'disable': True},   # Switch-off tqdm
-                   'receiver_interpolation': 'linear',  # Should be linear
-                   **self.simulation_opts}              # User input
+                **{  # The following options can be provided by the user
+                    'name': 'Simulation created by SimPEG',
+                    'gridding': 'same',               # Default is same for all
+                    # Model: Dummy 1's for init
+                    'model': emg3d.Model(self.mesh, mapping='Conductivity'),
+                    'tqdm_opts': False,                  # Switch-off tqdm
+                    'receiver_interpolation': 'linear',  # Should be linear
+                    **self.simulation_opts,              # User input
+                }
             )
 
         return self._emg3d_sim
@@ -122,7 +122,7 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
     def emg3d_model(self):
         """emg3d conductivity model; obtained from SimPEG conductivities."""
         self._emg3d_model = emg3d.Model(
-            self.mesh,
+            emg3d.TensorMesh(self.mesh.h, self.mesh.origin),
             property_x=self.sigma.reshape(self.mesh.shape_cells, order='F'),
             # property_y=None,  Not yet implemented
             # property_z=None,   "
@@ -131,24 +131,6 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
             mapping='Conductivity',
         )
         return self._emg3d_model
-
-    @property
-    def _emg3d_simulation_update(self):
-        """Updates emg3d simulation with new model, resetting the fields."""
-
-        # We have to replace the model
-        # Warning:
-        # This will not work for automatic model extension possible in emg3d.
-        self.emg3d_sim.model = self.emg3d_model
-
-        # Re-initiate all dicts _except_ grids (automatic gridding)
-        self.emg3d_sim._dict_model = self.emg3d_sim._dict_initiate
-        self.emg3d_sim._dict_efield = self.emg3d_sim._dict_initiate
-        self.emg3d_sim._dict_hfield = self.emg3d_sim._dict_initiate
-        self.emg3d_sim._dict_efield_info = self.emg3d_sim._dict_initiate
-        self.emg3d_sim._gradient = None
-        self.emg3d_sim._misfit = None
-        self.emg3d_sim._vec = None  # TODO check back when emg3d-side finished!
 
     # @profile
     def Jvec(self, m, v, f=None):
@@ -176,7 +158,7 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
             f = self.fields(m=m)
 
         dsig_dm_v = self.sigmaDeriv @ v
-        j_vec = emg3d.optimize.jvec(f, vec=dsig_dm_v)
+        j_vec = f.jvec(vector=dsig_dm_v)
 
         # Map emg3d-data-array to SimPEG-data-vector
         return j_vec[self._dmap_simpeg_emg3d]
@@ -193,7 +175,7 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
         :return: Jtvec (nP,)
         """
         if self.verbose:
-            print("Compute Jtvec")  
+            print("Compute Jtvec")
 
         if self.storeJ:
 
@@ -222,26 +204,22 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
             # Put v onto emg3d data-array.
             self._emg3d_array[self._dmap_simpeg_emg3d] = v
 
-            # Replace residual by vector if provided
-            f.survey.data['residual'][...] = self._emg3d_array
-
             # Get gradient with `v` as residual.
-            jt_sigma_vec = emg3d.optimize.gradient(f)
+            jt_sigma_vec = f.jtvec(self._emg3d_array)
 
-            jt_vec = self.sigmaDeriv.T @ jt_sigma_vec.ravel('F')
-            return jt_vec
+            return self.sigmaDeriv.T @ jt_sigma_vec.ravel('F')
 
         else:
             # This is for forming full sensitivity matrix
             # Currently, it is not correct.
-            # Requires a fix in optimize.gradient
+            # Requires a fix in f.gradient
             # Jt is supposed to be a complex value ...
             # Jt = np.zeros((self.model.size, self.survey.nD), order="F")
             # for i_datum in range(self.survey.nD):
             #     vec = np.zeros(self.survey.nD)
             #     vec[i_datum] = 1.
-            #     vec = vec.reshape(self.emg3d_survey.shape)
-            #     jt_sigma_vec = emg3d.optimize.gradient(f, vector=vec)
+            #     self._emg3d_array[self._dmap_simpeg_emg3d] = vec
+            #     jt_sigma_vec = f.jtvec(self._emg3d_array)
             #     Jt[:, i_datum] = self.sigmaDeriv.T @ jt_sigma_vec
             # return Jt
 
@@ -288,7 +266,10 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
             f = self.fields(m=m)
 
         # Map emg3d-data-array to SimPEG-data-vector
-        data_complex = ComplexData(survey=self.survey, dobs=f.data.synthetic.data[self._dmap_simpeg_emg3d])
+        data_complex = ComplexData(
+            survey=self.survey,
+            dobs=f.data.synthetic.data[self._dmap_simpeg_emg3d]
+        )
         data = []
         for src in self.survey.source_list:
             for rx in src.receiver_list:
@@ -309,26 +290,46 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
             print("Compute fields")
 
         if m is not None:
-            # Store model.
+
+            # Store model and update emg3d equivalent.
             self.model = m
+            self.emg3d_sim.model = self.emg3d_model
 
-            # Update simulation.
-            self._emg3d_simulation_update
+            # Clean emg3d-Simulation from old computed data.
+            self.emg3d_sim.clean('computed')
 
-        # Compute forward model and sets initial residuals.
+        # Compute forward model and set initial residuals.
         _ = self.emg3d_sim.misfit
-
-        # Store the data at each step in the survey-xarray
-        if m is not None:
-            current_data = self.emg3d_survey.data.synthetic.copy()
-            self.emg3d_survey.data[f"it_{self._it_count}"] = current_data
-            self._it_count += 1  # Update counter
 
         return self.emg3d_sim
 
 
+@requires({"emg3d": emg3d})
 def survey_to_emg3d(survey):
     """Return emg3d survey from provided SimPEG survey.
+
+
+    - A SimPEG survey consists of a list of source-frequency pairs with
+      associated receiver lists:
+
+          [[source_1, frequency, rec_list],
+           [source_2, frequency, rec_list],
+           ...
+          ]
+
+      Frequencies and receiver lists can be different for different sources.
+      Data is not part of the survey, it is handled in a separate data class.
+
+    - An emg3d survey consists of a dictionary each for sources, receivers, and
+      frequencies. It contains the corresponding data in an xarray of dimension
+      ``nsrc x nrec x nfreq``. The xarray can store any amount of data set for
+      the survey. Source-receiver-frequency pair which do not exist in the
+      survey are marked with a NaN in the xarray.
+
+
+    See Also
+    --------
+    :func:`survey_to_simpeg` : Opposite way, from emg3d to SimPEG.
 
 
     Parameters
@@ -375,11 +376,13 @@ def survey_to_emg3d(survey):
                 src.locations,
                 strength=src.strength
             )
-        else:
+        elif isinstance(src, ElectricDipole):
             source = emg3d.TxElectricDipole(
                 (*src.location, src.azimuth, src.elevation),
                 strength=src.strength, length=src.length
             )
+        else:
+            raise NotImplementedError(f"Source type {src} not implemented")
 
         # New frequency: add.
         if src.frequency not in freq_list:
@@ -424,15 +427,16 @@ def survey_to_emg3d(survey):
                     "Only projField = {'e'; 'h'} implemented."
                 )
 
-            if rec.orientation not in ['x', 'y', 'z']:
-                raise NotImplementedError(
-                    "Only orientation = {'x'; 'y'; 'z'} implemented."
-                )
+            # Get azimuth, elevation.
+            if rec.orientation == "rotated":
+                azimuth = rec.azimuth
+                elevation = rec.elevation
+            else:
+                azimuth = [0, 90][rec.orientation == 'y']
+                elevation = [0, 90][rec.orientation == 'z']
 
-            # Get type, azimuth, elevation.
+            # Get type, component.
             rec_type = rec_types[rec.projField == 'h']
-            azimuth = [0, 90][rec.orientation == 'y']
-            elevation = [0, 90][rec.orientation == 'z']
             component = rec.component
 
             # Loop over receivers.
@@ -440,7 +444,9 @@ def survey_to_emg3d(survey):
 
                 # Create emg3d receiver.
                 receiver = rec_type(
-                        (*rec.locations[i, :], azimuth, elevation), data_type=component)
+                    (*rec.locations[i, :], azimuth, elevation),
+                    data_type=component,
+                )
                 # New receiver: add.
                 if receiver not in rec_list:
                     r_ind = len(rec_list)
@@ -489,3 +495,131 @@ def survey_to_emg3d(survey):
     emg3d_survey.data['indices'] = emg3d_survey.data.observed.copy(data=ind)
 
     return emg3d_survey, data_map
+
+
+@requires({"emg3d": emg3d})
+def survey_to_simpeg(survey):
+    """Return SimPEG survey from provided emg3d survey.
+
+
+    - A SimPEG survey consists of a list of source-frequency pairs with
+      associated receiver lists:
+
+          [[source_1, frequency, rec_list],
+           [source_2, frequency, rec_list],
+           ...
+          ]
+
+      Frequencies and receiver lists can be different for different sources.
+      Data is not part of the survey, it is handled in a separate data class.
+
+    - An emg3d survey consists of a dictionary each for sources, receivers, and
+      frequencies. It contains the corresponding data in an xarray of dimension
+      ``nsrc x nrec x nfreq``. The xarray can store any amount of data set for
+      the survey. Source-receiver-frequency pair which do not exist in the
+      survey are marked with a NaN in the xarray.
+
+
+    .. note::
+
+        If the survey contains observed data, then only the src-rec-freq
+        combinations with non-NaN values are added to the SimPEG survey.
+
+
+    See Also
+    --------
+    :func:`survey_to_emg3d` : Opposite way, from SimPEG to emg3d.
+
+
+    Parameters
+    ----------
+    survey : Survey
+        emg3d survey instance.
+
+
+    Returns
+    -------
+    simpeg_survey : Survey
+        SimPEG survey instance.
+
+    simpeg_data : ndarray
+        Data in the layout of SimPEG.
+
+    """
+
+    # Check if survey contains any non-NaN data.
+    data = survey.data.observed
+    check = False
+    if np.any(np.isfinite(data.data)):
+        check = True
+
+    # Start source and data lists
+    src_list = []
+    data_list = []
+
+    # 1. Loop over sources
+    for sname, src in survey.sources.items():
+
+        # If source has no data, skip it.
+        sdata = data.loc[sname, :, :]
+        if check and not np.any(np.isfinite(sdata.data)):
+            continue
+
+        # 2. Loop over frequencies
+        for sfreq, freq in survey.frequencies.items():
+
+            # If frequency has no data, skip it.
+            fdata = sdata.loc[:, sfreq]
+            if check and not np.any(np.isfinite(fdata.data)):
+                continue
+
+            # Start receiver list
+            rec_list = []
+
+            # 3. Loop over non-NaN receivers
+            for srec, rec in survey.receivers.items():
+
+                # If receiver has no data, skip it.
+                rdata = fdata.loc[srec].data
+                if check and not np.isfinite(rdata):
+                    continue
+
+                # Add this receiver to receiver list
+                if isinstance(rec, emg3d.electrodes.RxElectricPoint):
+                    rfunc = PointElectricField
+                elif isinstance(rec, emg3d.electrodes.RxMagneticPoint):
+                    rfunc = PointMagneticField
+                else:
+                    raise NotImplementedError(
+                        f"Receiver type {rec} not implemented."
+                    )
+
+                trec = rfunc(
+                    locations=rec.center, component='complex',
+                    orientation='rotated', azimuth=rec.azimuth,
+                    elevation=rec.elevation,
+                )
+
+                rec_list.append(trec)
+                data_list.append(rdata)
+
+            # Add this source-frequency to source list
+            if isinstance(src, emg3d.electrodes.TxElectricWire):
+                tsrc = ElectricWire(
+                    locations=src.points, receiver_list=rec_list,
+                    frequency=freq, strength=src.strength,
+                )
+            elif isinstance(src, emg3d.electrodes.TxElectricDipole):
+                tsrc = ElectricDipole(
+                    location=src.center, azimuth=src.azimuth,
+                    elevation=src.elevation, receiver_list=rec_list,
+                    frequency=freq, strength=src.strength,
+                )
+            else:
+                raise NotImplementedError(
+                    f"Source type {src} not implemented."
+                )
+
+            src_list.append(tsrc)
+
+    return Survey(src_list), np.array(data_list)

--- a/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
@@ -1,210 +1,319 @@
 import numpy as np
-import scipy.sparse as sp
-from scipy.constants import mu_0
-import properties
-from ...utils.code_utils import deprecate_class
 
-from ... import props
-from ...data import Data
+from discretize.utils import requires
+
 from ...utils import mkvc
 from .simulation import BaseFDEMSimulation
-from ..utils import omega
-from .survey import Survey
-from .fields import (
-    Fields3DElectricField,
-)
-import emg3d
-from emg3d import models, surveys, simulations, optimize
+
+# emg3d is a soft dependency
+try:
+    import emg3d
+except ImportError:
+    emg3d = False
 
 
+@requires({"emg3d": emg3d})
 class Simulation3DEMG3D(BaseFDEMSimulation):
-    """
-    By eliminating the magnetic flux density using
+    """3D simulation of electromagnetic fields using emg3d as a solver.
 
-        .. math ::
+    .. note::
 
-            \mathbf{b} = \\frac{1}{i \omega}\\left(-\mathbf{C} \mathbf{e} +
-            \mathbf{s_m}\\right)
+        - Only isotropic model implemented so far. Needs extension to tri-axial
+          anisotropy, mu_r, and epsilon_r.
+
+        - Currently, only electric "point"-dipole sources and electric/magnetic
+          point receivers are implemented. emg3d could do more, e.g., finite
+          length electric dipoles or arbitrary electric wires (and therefore
+          loops). These are *not yet* implemented here.
 
 
-    we can write Maxwell's equations as a second order system in
-    \\\(\\\mathbf{e}\\\) only:
+    Parameters
+    ----------
+    simulation_opts : dict
+        Input parameters forward to ``emg3d.Simulation``. See the emg3d
+        documentation for all the possibilities.
 
-    .. math ::
-
-        \\left(\mathbf{C}^{\\top} \mathbf{M_{\mu^{-1}}^f} \mathbf{C} +
-        i \omega \mathbf{M^e_{\sigma}} \\right)\mathbf{e} =
-        \mathbf{C}^{\\top} \mathbf{M_{\mu^{-1}}^f}\mathbf{s_m}
-        - i\omega\mathbf{M^e}\mathbf{s_e}
-
-    which we solve for :math:`\mathbf{e}`.
-
-    :param discretize.base.BaseMesh mesh: mesh
     """
 
     _solutionType = "eSolution"
     _formulation = "EB"
-    fieldsPair = Fields3DElectricField
-    max_workers = 1
     storeJ = False
     _Jmatrix = None
 
     def __init__(self, mesh, **kwargs):
-        super(Simulation3DEMG3D, self).__init__(mesh, **kwargs)
-  
+        """Initialize Simulation using emg3d as solver."""
+
+        # Store simulation options.
+        simulation_opts = kwargs.pop('simulation_opts', {})
+
+        super().__init__(mesh, **kwargs)
+
+        # Create twin Simulation in emg3d.
+        self.emg3d_sim = emg3d.Simulation(
+            survey=self.emg3d_survey,
+            model=emg3d.Model(self.mesh),  # Dummy values of 1 for initiation.
+            **{'name': 'Simulation created by SimPEG',
+               'gridding': 'same',                  # Change this eventually!
+               'tqdm_opts': {'disable': True},      # Switch-off tqdm
+               'receiver_interpolation': 'linear',  # Should be linear
+               **simulation_opts}                   # User input
+        )
+
+        # TODO : Count to store data per iteration.
+        # - Should be replaced by a proper count form SimPEG.inversion.
+        # - Should probably be made optional to store data at each step.
+        self._it_count = 0
+
     @property
     def emg3d_survey(self):
+        """emg3d survey; obtained from SimPEG survey."""
+
         if getattr(self, "_emg3d_survey", None) is None:
-            self._emg3d_survey = self.generate_emg3d_survey_from_simpeg_survey()
-        return self._emg3d_survey
-    
-    @property
-    def emg3d_sigma(self):
-        self._emg3d_sigma = models.Model(
-            self.mesh, 
-            self.sigma.reshape(self.mesh.vnC, order='F'), 
-            mapping='Conductivity'
-        )
-        return self._emg3d_sigma
 
-    @ property
-    def emg3d_simulation_inputs(self):
-        if getattr(self, "_emg3d_simulation_inputs", None) is None:
-            solver_opts = {
-                'sslsolver': False,
-                'semicoarsening': False,
-                'linerelaxation': False,
-            #     'tol': 5e-5,  # Reduce tolerance to speed-up
-            }
-            self._emg3d_simulation_inputs = {
-                'name': 'Testing',
-                'survey': self.emg3d_survey,
-                'solver_opts': solver_opts,
-                'max_workers': self.max_workers,
-                'gridding': 'same',
-                'verb': -1,
-            }        
-        return self._emg3d_simulation_inputs
-    
-    
-    def generate_emg3d_survey_from_simpeg_survey(self):
+            # Allocate lists to create data to/from dicts.
+            src_list = []
+            freq_list = []
+            rec_list = []
+            data_dict = {}
+            indices = np.zeros((self.survey.nD, 3), dtype=int)
 
-        source_list_emg3d = []
-        src_rx_uids = []
-        source_frequency = []
-        for src in self.survey.srcList:
-            source_frequency.append(src.frequency)    
-            src_emg3d = emg3d.TxElectricDipole(
-                (src.location[0], src.location[1], src.location[2], src.dip, src.azimuth)
+            # Counter for SimPEG data object (lists the data continuously).
+            ind = 0
+
+            # Loop over sources.
+            for src in self.survey.source_list:
+
+                # Create emg3d source.
+                source = emg3d.TxElectricDipole(
+                    (*src.location, src.azimuth, src.elevation),
+                    strength=src.strength, length=src.length
+                )
+
+                # New frequency: add.
+                if src.frequency not in freq_list:
+                    f_ind = len(freq_list)
+                    freq_list.append(src.frequency)
+
+                # Existing source: get index.
+                else:
+                    f_ind = freq_list.index(src.frequency)
+
+                # New source: add.
+                if source not in src_list:
+                    s_ind = len(src_list)
+                    data_dict[s_ind] = {f_ind: {}}
+                    src_list.append(source)
+
+                # Existing source: get index.
+                else:
+                    s_ind = src_list.index(source)
+
+                    # If new frequency for existing source, add:
+                    if f_ind not in data_dict[s_ind].keys():
+                        data_dict[s_ind][f_ind] = {}
+
+                # Loop over receiver lists.
+                rec_types = [emg3d.RxElectricPoint, emg3d.RxMagneticPoint]
+                for rec in src.receiver_list:
+
+                    if rec.projField not in ['e', 'h']:
+                        raise NotImplementedError(
+                            "Only projField = {'e'; 'h'} implemented."
+                        )
+
+                    if rec.orientation not in ['x', 'y', 'z']:
+                        raise NotImplementedError(
+                            "Only orientation = {'x'; 'y'; 'z'} implemented."
+                        )
+
+                    # Get type, azimuth, elevation.
+                    rec_type = rec_types[rec.projField == 'h']
+                    azimuth = [0, 90][rec.orientation == 'y']
+                    elevation = [0, 90][rec.orientation == 'z']
+
+                    # Loop over receivers.
+                    for i in range(rec.locations[:, 0].size):
+
+                        # Create emg3d receiver.
+                        receiver = rec_type(
+                                (*rec.locations[i, :], azimuth, elevation))
+
+                        # New receiver: add.
+                        if receiver not in rec_list:
+                            r_ind = len(rec_list)
+                            data_dict[s_ind][f_ind][r_ind] = ind
+                            rec_list.append(receiver)
+
+                        # Existing receiver: get index.
+                        else:
+                            r_ind = rec_list.index(receiver)
+
+                            # If new receiver for existing src-freq, add:
+                            existing = data_dict[s_ind][f_ind].keys()
+                            if r_ind not in existing:
+                                data_dict[s_ind][f_ind][r_ind] = ind
+
+                            # Else, throw an error.
+                            else:
+                                raise ValueError(
+                                    "Duplicate source-receiver-frequency."
+                                )
+
+                        indices[ind, :] = [s_ind, r_ind, f_ind]
+                        ind += 1
+
+            # Create and store survey.
+            survey = emg3d.Survey(
+                name='Survey created by SimPEG',
+                sources=emg3d.surveys.txrx_lists_to_dict(src_list),
+                receivers=emg3d.surveys.txrx_lists_to_dict(rec_list),
+                frequencies=freq_list,
+                noise_floor=1.,       # We deal with std in SimPEG.
+                relative_error=None,  #  "   "   "
             )
-            source_list_emg3d.append(src_emg3d)
-            for rx in src.rxList:
-                src_rx_uids.append([src._uid, rx._uid])
-        src_rx_uids = np.vstack(src_rx_uids)
+            self._emg3d_survey = survey
 
-        # assume all sources have the same receiver locations now
-        if np.unique(src_rx_uids[:,1]).size == 1:
-            # also assume rx only contains a single component
-            if rx.projField == 'e':
-                emg3d_rx_object = emg3d.RxElectricPoint
-            elif rx.projField == 'h':
-                emg3d_rx_object = emg3d.RxMagneticPoint
-            
-            if rx.orientation == 'x':
-                azimuth, dip = 0, 0
-            elif rx.orientation == 'y':
-                azimuth, dip = 90, 0
-            elif rx.orientation == 'z':
-                azimuth, dip = 0, 90
-            else:
-                raise Exception()
-            receivers = emg3d.surveys.txrx_coordinates_to_dict(
-                emg3d_rx_object,
-                (rx.locations[:,0], rx.locations[:,1], rx.locations[:,2], dip, azimuth),
-            )    
-        else:
-            raise Exception()
-        sources = emg3d.surveys.txrx_lists_to_dict(source_list_emg3d)  
-        source_frequency = np.unique(np.array(source_frequency))
-        emg3d_survey = surveys.Survey(
-            name='emg3d survey',
-            sources=sources,
-            receivers=receivers,
-            frequencies=source_frequency,
-            noise_floor=1.,
-            relative_error=None,
+            # Store data-mapping SimPEG <-> emg3d
+            self._dmap_simpeg_emg3d = tuple(indices.T)
+
+            # Create emg3d data dummy; can be re-used.
+            self._emg3d_array = np.full(survey.shape, np.nan+1j*np.nan)
+
+        return self._emg3d_survey
+
+    @property
+    def emg3d_model(self):
+        """emg3d conductivity model; obtained from SimPEG conductivities."""
+        self._emg3d_model = emg3d.Model(
+            self.mesh,
+            property_x=self.sigma.reshape(self.mesh.shape_cells, order='F'),
+            # property_y=None,  Not yet implemented
+            # property_z=None,   "
+            # mu_r=None,         "
+            # epsilon_r=None,    "
+            mapping='Conductivity',
         )
-        self.n_source = len(source_list_emg3d)
-        self.n_frequency = len(source_frequency)
-        self.n_receiver = rx.locations.shape[0]
-        return emg3d_survey
+        return self._emg3d_model
+
+    @property
+    def _emg3d_simulation_update(self):
+        """Updates emg3d simulation with new model, resetting the fields."""
+
+        # We have to replace the model
+        # Warning:
+        # This will not work for automatic model extension possible in emg3d.
+        self.emg3d_sim.model = self.emg3d_model
+
+        # Re-initiate all dicts _except_ grids (automatic gridding)
+        self.emg3d_sim._dict_model = self.emg3d_sim._dict_initiate
+        self.emg3d_sim._dict_efield = self.emg3d_sim._dict_initiate
+        self.emg3d_sim._dict_hfield = self.emg3d_sim._dict_initiate
+        self.emg3d_sim._dict_efield_info = self.emg3d_sim._dict_initiate
+        self.emg3d_sim._gradient = None
+        self.emg3d_sim._misfit = None
+        self.emg3d_sim._vec = None  # TODO check back when emg3d-side finished!
 
     def Jvec(self, m, v, f=None):
+        """
+        Sensitivity times a vector.
+
+        :param numpy.ndarray m: inversion model (nP,)
+        :param numpy.ndarray v: vector which we take sensitivity product with
+            (nP,)
+        :param SimPEG.electromagnetics.frequency_domain.fields.FieldsFDEM f: fields object
+        :rtype: numpy.ndarray
+        :return: Jvec (ndata,)
+        """
         if self.verbose:
-            print ("Compute Jvec")
+            print("Compute Jvec")
 
         if self.storeJ:
             J = self.getJ(m, f=f)
             Jv = mkvc(np.dot(J, v))
             return Jv
 
-        self.model = m        
+        self.model = m
 
         if f is None:
-            f = self.fields(m=m)       
-        
+            f = self.fields(m=m)
+
         dsig_dm_v = self.sigmaDeriv @ v
-        j_vec = optimize.jvec(f, vec=dsig_dm_v)
-        return j_vec
+        j_vec = emg3d.optimize.jvec(f, vec=dsig_dm_v)
+
+        # Map emg3d-data-array to SimPEG-data-vector
+        return j_vec[self._dmap_simpeg_emg3d]
 
     def Jtvec(self, m, v, f=None):
+        """
+        Sensitivity transpose times a vector
+
+        :param numpy.ndarray m: inversion model (nP,)
+        :param numpy.ndarray v: vector which we take adjoint product with (ndata,)
+        :param SimPEG.electromagnetics.frequency_domain.fields.FieldsFDEM f: fields object
+        :rtype: numpy.ndarray
+        :return: Jtvec (nP,)
+        """
         if self.verbose:
             print("Compute Jtvec")
-        
+
         if self.storeJ:
+
+            # Put v onto emg3d data-array.
+            self._emg3d_array[self._dmap_simpeg_emg3d] = v
+
             J = self.getJ(m, f=f)
-            Jtv = mkvc(np.dot(J.T, v))
+            Jtv = mkvc(np.dot(J.T, self._emg3d_array))
+
             return Jtv
 
         self.model = m
 
         if f is None:
-            f = self.fields(m=m)        
+            f = self.fields(m=m)
 
         return self._Jtvec(m, v=v, f=f)
-    
+
     def _Jtvec(self, m, v=None, f=None):
-        """
-            Compute adjoint sensitivity matrix (J^T) and vector (v) product.
-            Full J matrix can be computed by inputing v=None
+        """Compute adjoint sensitivity matrix (J^T) and vector (v) product.
+
+        Full J matrix can be computed by setting v=None (not implemented yet).
         """
 
         if v is not None:
+            # Put v onto emg3d data-array.
+            self._emg3d_array[self._dmap_simpeg_emg3d] = v
 
-            jt_sigma_vec = optimize.gradient(f, vec=v)
-            jt_vec = self.sigmaDeriv.T @ jt_sigma_vec
+            # Replace residual by vector if provided
+            f.survey.data['residual'][...] = self._emg3d_array
+
+            # Get gradient with `v` as residual.
+            jt_sigma_vec = emg3d.optimize.gradient(f)
+
+            jt_vec = self.sigmaDeriv.T @ jt_sigma_vec.ravel('F')
             return jt_vec
 
         else:
             # This is for forming full sensitivity matrix
-            # Currently, it is not correct. 
-            # Requires a fix in optimize.gradient 
-            # Jt is supposed to be a complex value ... 
-            Jt = np.zeros((self.model.size, self.survey.nD), order="F")
-            for i_datum in range(self.survey.nD):
-                v = np.zeros(self.survey.nD)
-                v[i_datum] = 1.
-                jt_sigma_vec = optimize.gradient(f, vec=v)
-                Jt[:, i_datum] = self.sigmaDeriv.T @ jt_sigma_vec
-            
-            return Jt
+            # Currently, it is not correct.
+            # Requires a fix in optimize.gradient
+            # Jt is supposed to be a complex value ...
+            # Jt = np.zeros((self.model.size, self.survey.nD), order="F")
+            # for i_datum in range(self.survey.nD):
+            #     vec = np.zeros(self.survey.nD)
+            #     vec[i_datum] = 1.
+            #     vec = vec.reshape(self.emg3d_survey.shape)
+            #     jt_sigma_vec = emg3d.optimize.gradient(f, vector=vec)
+            #     Jt[:, i_datum] = self.sigmaDeriv.T @ jt_sigma_vec
+            # return Jt
+
+            raise NotImplementedError
 
     def getJ(self, m, f=None):
-        """
-            Generate Full sensitivity matrix
-        """
+        """Generate full sensitivity matrix."""
+
         if self._Jmatrix is not None:
             return self._Jmatrix
+
         else:
             if self.verbose:
                 print("Calculating J and storing")
@@ -212,30 +321,61 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
             if f is None:
                 f = self.fields(m)
             self._Jmatrix = (self._Jtvec(m, v=None, f=f)).T
+
         return self._Jmatrix
 
-
     def dpred(self, m=None, f=None):
+        r"""Return the predicted (modelled) data for a given model.
+
+        The fields, f, (if provided) will be used for the predicted data
+        instead of recalculating the fields (which may be expensive!).
+
+        .. math::
+
+            d_\text{pred} = P(f(m))
+
+        Where P is a projection of the fields onto the data space.
+
+        :param numpy.ndarray m: model
+        :param SimPEG.electromagnetics.frequency_domain.fields.FieldsFDEM f: fields object
+        :rtype: numpy.ndarray
+        :return: data, the data
+        """
+
         if self.verbose:
             print("Compute predicted")
-        # currently this does not change once self.fields is computed.
+
         if f is None:
             f = self.fields(m=m)
-        # this may not be robust, need to be changed... 
-        data = f.data.synthetic.values.flatten()
-        return data 
-  
+
+        # Map emg3d-data-array to SimPEG-data-vector
+        return f.data.synthetic.data[self._dmap_simpeg_emg3d]
+
     def fields(self, m=None):
+        """Return the electric fields for a given model.
+
+        :param numpy.ndarray m: model
+        :rtype: numpy.ndarray
+        :return: f, the fields
+        """
+
         if self.verbose:
             print("Compute fields")
-        self.model = m
- 
-        f = simulations.Simulation(
-            model=self.emg3d_sigma, 
-            **self.emg3d_simulation_inputs
-        )
-        std = f.survey.standard_deviation
-        # Store weights
-        f.data['weights'] = std**-2        
-        f.compute()
-        return f
+
+        if m is not None:
+            # Store model.
+            self.model = m
+
+            # Update simulation.
+            self._emg3d_simulation_update
+
+        # Compute forward model and sets initial residuals.
+        _ = self.emg3d_sim.misfit
+
+        # Store the data at each step in the survey-xarray
+        if m is not None:
+            current_data = self.emg3d_survey.data.synthetic.copy()
+            self.emg3d_survey.data[f"it_{self._it_count}"] = current_data
+            self._it_count += 1  # Update counter
+
+        return self.emg3d_sim

--- a/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_emg3d.py
@@ -8,7 +8,6 @@ from .sources import ElectricDipole, ElectricWire
 from .receivers import PointElectricField, PointMagneticField
 from .survey import Survey
 from ...data import ComplexData
-# from memory_profiler import profile
 
 # emg3d is a soft dependency
 try:
@@ -17,7 +16,8 @@ except ImportError:
     emg3d = False
 
 # Temporary work-around to ensure multiprocessing does not hang if sklearn is
-# installed. This should hopefully not be necessary in the future. See https://scikit-learn.org/stable/faq.html#why-do-i-sometime-get-a-crash-freeze-with-n-jobs-1-under-osx-or-linux
+# installed. This should hopefully not be necessary in the future. See
+# https://scikit-learn.org/stable/faq.html#why-do-i-sometime-get-a-crash-freeze-with-n-jobs-1-under-osx-or-linux
 try:
     import sklearn
 except ImportError:
@@ -142,7 +142,6 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
         )
         return self._emg3d_model
 
-    # @profile
     def Jvec(self, m, v, f=None):
         """
         Sensitivity times a vector.
@@ -167,13 +166,13 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
         if f is None:
             f = self.fields(m=m)
 
-        dsig_dm_v = self.sigmaDeriv @ v
+        dsig_dm_v = (self.sigmaDeriv @ v).reshape(
+                self.emg3d_model.shape, order='F')
         j_vec = f.jvec(vector=dsig_dm_v)
 
         # Map emg3d-data-array to SimPEG-data-vector
         return j_vec[self._dmap_simpeg_emg3d]
 
-    # @profile
     def Jtvec(self, m, v, f=None):
         """
         Sensitivity transpose times a vector
@@ -287,7 +286,6 @@ class Simulation3DEMG3D(BaseFDEMSimulation):
                 data.append(data_complex_rx)
         return np.hstack(data)
 
-    # @profile
     def fields(self, m=None):
         """Return the electric fields for a given model.
 

--- a/SimPEG/electromagnetics/frequency_domain/sources.py
+++ b/SimPEG/electromagnetics/frequency_domain/sources.py
@@ -160,6 +160,30 @@ class RawVec_e(BaseFDEMSrc):
         return self._s_e
 
 
+class ElectricDipole(BaseFDEMSrc):
+    """
+    Electric Dipole source. It is defined by the user provided vector s_e
+
+    :param list receiver_list: receiver list
+    :param float freq: frequency
+    :param float freq: frequency
+    :param float freq: frequency
+
+    """    
+    moment = properties.Float("dipole moment of the transmitter", default=1.0, min=0.0)
+    
+    azimuth = properties.Float("the transmitter aximuth", default=0, min=0.0, max=180)
+    
+    dip = properties.Float("the transmitter dip", default=0, min=0.0, max=90)
+    
+    location = LocationVector(
+        "location of the source", default=np.r_[0.0, 0.0, 0.0], shape=(3,)
+    )
+
+
+    def __init__(self, receiver_list=None, frequency=None, **kwargs):
+        super(ElectricDipole, self).__init__(receiver_list, frequency=frequency, **kwargs)
+            
 class RawVec_m(BaseFDEMSrc):
     """
     RawVec magnetic source. It is defined by the user provided vector s_m

--- a/SimPEG/electromagnetics/frequency_domain/sources.py
+++ b/SimPEG/electromagnetics/frequency_domain/sources.py
@@ -182,6 +182,33 @@ class ElectricDipole(BaseFDEMSrc):
     def __init__(self, receiver_list=None, frequency=None, **kwargs):
         super().__init__(receiver_list, frequency=frequency, **kwargs)
 
+class WireSourceLocationArray(properties.Array):
+
+    class_info = "an array of receiver locations"
+
+    def validate(self, instance, value):
+        value = np.atleast_2d(value)
+        return super(WireSourceLocationArray, self).validate(instance, value)
+
+class ElectricWire(BaseFDEMSrc):
+    """
+    Electric Dipole source. It is defined by the user provided vector s_e
+
+    :param list receiver_list: receiver list
+    :param float freq: frequency
+
+    """
+    strength = properties.Float("dipole strength", default=1.0, min=1e-15)
+
+    length = properties.Float("dipole length", default=1.0, min=1e-15)
+
+    locations = WireSourceLocationArray(
+        "Location of the source [x, y, z] in 3D", shape=("*","*"), required=True
+    )
+
+
+    def __init__(self, receiver_list=None, frequency=None, **kwargs):
+        super().__init__(receiver_list, frequency=frequency, **kwargs)        
 
 class RawVec_m(BaseFDEMSrc):
     """

--- a/SimPEG/electromagnetics/frequency_domain/sources.py
+++ b/SimPEG/electromagnetics/frequency_domain/sources.py
@@ -166,24 +166,23 @@ class ElectricDipole(BaseFDEMSrc):
 
     :param list receiver_list: receiver list
     :param float freq: frequency
-    :param float freq: frequency
-    :param float freq: frequency
 
-    """    
-    moment = properties.Float("dipole moment of the transmitter", default=1.0, min=0.0)
-    
-    azimuth = properties.Float("the transmitter aximuth", default=0, min=0.0, max=180)
-    
-    dip = properties.Float("the transmitter dip", default=0, min=0.0, max=90)
-    
-    location = LocationVector(
-        "location of the source", default=np.r_[0.0, 0.0, 0.0], shape=(3,)
-    )
+    """
+    strength = properties.Float("dipole strength", default=1.0, min=1e-15)
+
+    length = properties.Float("dipole length", default=1.0, min=1e-15)
+
+    azimuth = properties.Float("azimuth (anticlockwise from Easting)", default=0, min=-360.0, max=360)
+
+    elevation = properties.Float("elevation (positive up)", default=0, min=-180.0, max=180)
+
+    location = LocationVector("location of the source", default=np.r_[0.0, 0.0, 0.0], shape=(3,))
 
 
     def __init__(self, receiver_list=None, frequency=None, **kwargs):
-        super(ElectricDipole, self).__init__(receiver_list, frequency=frequency, **kwargs)
-            
+        super().__init__(receiver_list, frequency=frequency, **kwargs)
+
+
 class RawVec_m(BaseFDEMSrc):
     """
     RawVec magnetic source. It is defined by the user provided vector s_m

--- a/SimPEG/electromagnetics/frequency_domain/sources.py
+++ b/SimPEG/electromagnetics/frequency_domain/sources.py
@@ -200,8 +200,6 @@ class ElectricWire(BaseFDEMSrc):
     """
     strength = properties.Float("dipole strength", default=1.0, min=1e-15)
 
-    length = properties.Float("dipole length", default=1.0, min=1e-15)
-
     locations = WireSourceLocationArray(
         "Location of the source [x, y, z] in 3D", shape=("*","*"), required=True
     )

--- a/SimPEG/inverse_problem.py
+++ b/SimPEG/inverse_problem.py
@@ -32,6 +32,8 @@ class BaseInvProblem(BaseSimPEG):
     #: Optimization program
     opt = None
 
+    #: use the solver from the simulation or a default one from BFGS.bfgsH0
+    use_simulation_solver = True
     #: List of strings, e.g. ['_MeSigma', '_MeSigmaI']
     deleteTheseOnModelUpdate = []
 
@@ -90,14 +92,21 @@ class BaseInvProblem(BaseSimPEG):
 
         if isinstance(self.dmisfit, BaseDataMisfit):
             if getattr(self.dmisfit.simulation, "solver", None) is not None:
-                print(
-                    """
-        SimPEG.InvProblem is setting bfgsH0 to the inverse of the eval2Deriv.
-        ***Done using same Solver and solverOpts as the problem***"""
-                )
-                self.opt.bfgsH0 = self.dmisfit.simulation.solver(
-                    self.reg.deriv2(self.model), **self.dmisfit.simulation.solver_opts
-                )
+                if self.use_simulation_solver:
+                    print(
+                        """
+            SimPEG.InvProblem is setting bfgsH0 to the inverse of the eval2Deriv.
+            ***Done using same Solver and solverOpts as the problem***"""
+                    )
+                    self.opt.bfgsH0 = self.dmisfit.simulation.solver(
+                        self.reg.deriv2(self.model), **self.dmisfit.simulation.solver_opts
+                    )
+                else:
+                    print(
+                        """
+            SimPEG.InvProblem is setting bfgsH0 to the inverse of the eval2Deriv.
+            ***Done using default solver of bfgsH0***"""
+                    )                    
         elif isinstance(self.dmisfit, BaseObjectiveFunction):
             for objfct in self.dmisfit.objfcts:
                 if isinstance(objfct, BaseDataMisfit):

--- a/SimPEG/optimization.py
+++ b/SimPEG/optimization.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipy.sparse as sp
 from six import string_types
 
-from .utils.solver_utils import SolverWrapI, Solver
+from .utils.solver_utils import SolverWrapI, Solver, SolverDiag
 from .utils import (
     callHooks,
     checkStoppers,

--- a/SimPEG/optimization.py
+++ b/SimPEG/optimization.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import numpy as np
 import scipy.sparse as sp
 from six import string_types
+from memory_profiler import profile
 
 from .utils.solver_utils import SolverWrapI, Solver, SolverDiag
 from .utils import (
@@ -328,6 +329,7 @@ class Minimize(object):
                 "replaced.".format(self.__class__.__name__)
             )
         self._callback = value
+
 
     @timeIt
     def minimize(self, evalFunction, x0):

--- a/SimPEG/utils/__init__.py
+++ b/SimPEG/utils/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from discretize.utils.interpolation_utils import interpmat
 
 from .mat_utils import (

--- a/SimPEG/utils/pgi_utils.py
+++ b/SimPEG/utils/pgi_utils.py
@@ -6,22 +6,6 @@ from scipy.stats import multivariate_normal
 from scipy import spatial, linalg
 from scipy.special import logsumexp
 from scipy.sparse import diags
-from sklearn.mixture import GaussianMixture
-from sklearn.cluster import KMeans
-from sklearn.utils import check_array
-from sklearn.utils.validation import check_is_fitted
-from sklearn.mixture._gaussian_mixture import (
-    _compute_precision_cholesky,
-    _compute_log_det_cholesky,
-    _estimate_gaussian_covariances_full,
-    _estimate_gaussian_covariances_tied,
-    _estimate_gaussian_covariances_diag,
-    _estimate_gaussian_covariances_spherical,
-    _check_means,
-    _check_precisions,
-    _check_shape,
-)
-from sklearn.mixture._base import check_random_state, ConvergenceWarning
 import warnings
 from .mat_utils import mkvc
 from ..maps import IdentityMap, Wires, Identity
@@ -31,6 +15,34 @@ from ..regularization import (
     Tikhonov,
     PGIwithRelationships,
 )
+from discretize.utils.code_utils import requires
+
+# sklearn is a soft dependency
+try:
+    from sklearn.mixture import GaussianMixture
+    from sklearn.cluster import KMeans
+    from sklearn.utils import check_array
+    from sklearn.utils.validation import check_is_fitted
+    from sklearn.mixture._gaussian_mixture import (
+        _compute_precision_cholesky,
+        _compute_log_det_cholesky,
+        _estimate_gaussian_covariances_full,
+        _estimate_gaussian_covariances_tied,
+        _estimate_gaussian_covariances_diag,
+        _estimate_gaussian_covariances_spherical,
+        _check_means,
+        _check_precisions,
+        _check_shape,
+    )
+    from sklearn.mixture._base import check_random_state, ConvergenceWarning
+
+except ImportError:
+
+    class GaussianMixture:
+        """Dummy Class to prevent failing."""
+        pass
+
+    sklearn = False
 
 
 def make_PGI_regularization(
@@ -292,10 +304,10 @@ def make_PGIwithRelationships_regularization(
 
 ###############################################################################
 # Disclaimer: the following classes built upon the GaussianMixture class      #
-# from Scikit-Learn. New functionalitie are added, as well as modifications to#
-# existing functions, to serve the purposes pursued within SimPEG.            #
+# from Scikit-Learn. New functionalities are added, as well as modifications  #
+# to existing functions, to serve the purposes pursued within SimPEG.         #
 # This use is allowed by the Scikit-Learn licensing (BSD-3-Clause License)    #
-# and we are grateful for their contributions to the open-source community.   #                                                   #
+# and we are grateful for their contributions to the open-source community.   #
 ###############################################################################
 
 
@@ -323,6 +335,7 @@ class WeightedGaussianMixture(GaussianMixture):
     :param numpy.ndarry actv: (optional) active cells index
     """
 
+    @requires({'sklearn': sklearn})
     def __init__(
         self,
         n_components,
@@ -1043,6 +1056,7 @@ class GaussianMixtureWithPrior(WeightedGaussianMixture):
         The first column contains the numeric index of the cells, the second column the respective lithology index.
     """
 
+    @requires({'sklearn': sklearn})
     def __init__(
         self,
         gmmref,
@@ -1409,6 +1423,7 @@ class GaussianMixtureWithNonlinearRelationships(WeightedGaussianMixture):
         a nonlinear relationships between physical properties; one per cluster/unit.
     """
 
+    @requires({'sklearn': sklearn})
     def __init__(
         self,
         mesh,
@@ -1715,6 +1730,7 @@ class GaussianMixtureWithNonlinearRelationshipsWithPrior(GaussianMixtureWithPrio
 
     """
 
+    @requires({'sklearn': sklearn})
     def __init__(
         self,
         gmmref,

--- a/SimPEG/utils/pgi_utils.py
+++ b/SimPEG/utils/pgi_utils.py
@@ -19,6 +19,7 @@ from discretize.utils.code_utils import requires
 
 # sklearn is a soft dependency
 try:
+    import sklearn
     from sklearn.mixture import GaussianMixture
     from sklearn.cluster import KMeans
     from sklearn.utils import check_array

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     install_requires=[
         "numpy>=1.7",
         "scipy>=1.0.0",
-        "scikit-learn>=0.22",
         "pymatsolver>=0.1.1",
         "matplotlib",
         "properties>=0.5.2",

--- a/tests/em/fdem/simulations/test_simulation_emg3d.py
+++ b/tests/em/fdem/simulations/test_simulation_emg3d.py
@@ -1,0 +1,100 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_allclose
+
+import SimPEG.electromagnetics.frequency_domain as fdem
+
+# Soft dependencies
+try:
+    import emg3d
+except ImportError:
+    emg3d = None
+
+
+@pytest.mark.skipif(emg3d is None, reason="emg3d not installed.")
+class TestSurveyToEmg3d():
+    if emg3d:
+
+        ## Receivers
+
+        # recset1 and recset2 have one overlapping receiver
+        # This means that they CANNOT be used with the same source (duplicate
+        # receivers)
+        recset1 = np.array([np.arange(2), np.zeros(2), np.zeros(2)]).T
+        recset2 = np.array([np.arange(3)+1, np.zeros(3), np.zeros(3)]).T
+
+        recset3 = np.array([30, 30, 30]).T
+
+        rx_ex1 = fdem.receivers.PointElectricField(
+                locations=recset1, component='complex', orientation='x')
+        rx_ex2 = fdem.receivers.PointElectricField(
+                locations=recset2, component='complex', orientation='x')
+        rx_ey1 = fdem.receivers.PointElectricField(
+                locations=recset1, component='complex', orientation='y')
+        rx_hy1 = fdem.receivers.PointMagneticField(
+                locations=recset1, component='complex', orientation='x')
+
+        rx_hx3 = fdem.receivers.PointMagneticField(
+                locations=recset3, component='complex', orientation='x')
+
+        ## Sources
+        wire_src_loc = ([-100, -100, 0], [-100, 100, 0])
+
+        # 1b == 1a, to test that the conversion works even so
+        pts_src_loc1a = (-10, -5, 7)
+        pts_src_loc1b = (-10, -5, 7)
+
+        pts_src_loc2 = (-20, -20, -20)
+
+        src_list = []
+
+        # pts_src_loc1a for two freqs
+        for frequency in [1., 2.]:
+            src_list.append(fdem.sources.ElectricDipole(
+                location=pts_src_loc1a, azimuth=90, elevation=0,
+                receiver_list=[rx_ex1, rx_ey1, rx_hy1], frequency=frequency))
+
+        # Another source with the rx_ex2
+        src_list.append(fdem.sources.ElectricDipole(
+            location=pts_src_loc2, azimuth=0, elevation=0,
+            receiver_list=[rx_ex2], frequency=2.))
+
+        # 1 extra freq, for only one receiver, wire source
+        src_list.append(fdem.sources.ElectricWire(
+                locations=wire_src_loc, receiver_list=[rx_hx3, ],
+                frequency=20.))
+
+        # pts source for the same frequency
+        src_list.append(fdem.sources.ElectricDipole(
+            location=pts_src_loc1b, azimuth=90, elevation=0,
+                receiver_list=[rx_ex2], frequency=20.))
+
+        ## SimPEG survey and conversion  [test on its own]
+        simpeg_survey = fdem.Survey(src_list)
+        emg3d_survey, data_map = fdem.simulation_emg3d.survey_to_emg3d(
+                simpeg_survey)
+
+    def test_mapping(self):
+        # Create some random numbers btw 100-999 in SimPEG-shape
+        data = np.random.randint(100, 999, self.simpeg_survey.nD)
+
+        # Create map
+        emg3d_data = np.full(self.emg3d_survey.shape, np.nan)
+
+        # Forward map
+        emg3d_data[self.data_map] = data
+
+        # Map back
+        edata = emg3d_data[self.data_map]
+
+        # Check
+        assert_allclose(data, edata)
+
+    def test_duplicate_src_rec_freq_fails(self):
+        with pytest.raises(ValueError, match="Duplicate source-receiver-freq"):
+            new_simpeg_survey = fdem.Survey([
+                fdem.sources.ElectricDipole(
+                    location=self.pts_src_loc2, azimuth=0, elevation=0,
+                    receiver_list=[self.rx_ex2, self.rx_ex1], frequency=2.)
+            ])
+            fdem.simulation_emg3d.survey_to_emg3d(new_simpeg_survey)


### PR DESCRIPTION
**Note**: This Draft PR will be replaced by a new one, where most stuff goes into emg3d, and only smaller changes are required to SimPEG. I keep this around until that is done.
- emg3d PR: https://github.com/emsig/emg3d/pull/338
- SimPEG PR: TODO

---
# SimPEG(emg3d)

PR to implement the required steps on SimPEG-side to use emg3d as a solver for EM modelling and inversion within SimPEG.

Superseeding #1032

The old PR was quite old, had a few quirky merges (one from my personal GitHub), things that got completely disbanded again. This is a new try, rebased on the newest brain (and on the branch `soft-sklearn`, see Warning below).

## Warning

There seems to be an issue with `scikit-learn` (`sklearn`) and multiprocessing. For this PR to work you must uninstall `sklearn`, otherwise the computation will silently hang and wait forever (under Linux and OSX).

More info: https://scikit-learn.org/stable/faq.html#why-do-i-sometime-get-a-crash-freeze-with-n-jobs-1-under-osx-or-linux

## Related branches
Note, there are a few branches that should be deleted once this is in:
- https://github.com/simpeg/simpeg/tree/emg3d-solver-new : this one.
- https://github.com/simpeg/simpeg/tree/emg3d-solver : the original one of #1032 .
- https://github.com/simpeg/simpeg/tree/emg3d-solver-wip : the cleaned-up version of `emg3d-solver`, all commits cherry-picked and everything from Seogi squashed and everything from Dieter squashed (7 commits total), but NOT rebased to main.
- https://github.com/simpeg/simpeg/tree/soft-sklearn