### PR TITLE
TDEM line current h-field update 

### DIFF
--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -936,7 +936,7 @@ class CircularLoop(MagDipole):
 
 class LineCurrent(BaseTDEMSrc):
     """
-    RawVec electric source. It is defined by the user provided vector s_e
+    Line current source.
 
     :param list receiver_list: receiver list
     :param bool integrate: Integrate the source term (multiply by Me) [False]
@@ -1071,12 +1071,12 @@ class LineCurrent(BaseTDEMSrc):
         A = self._getAmmr(simulation)
         Ainv = simulation.solver(A)  # todo: store this
         s_e = self.s_e(simulation, 0)
-        rhs = s_e - self.jInitial(simulation)
+        rhs = s_e + self.jInitial(simulation)
         return Ainv * rhs
 
     def _aInitialDeriv(self, simulation, v, adjoint=False):
         A = self._getAmmr(simulation)
-        Ainv = simulation.solver(A)  # todo: store this - move it to the simulationlem
+        Ainv = simulation.solver(A)  # todo: store this - move it to the simulation
 
         if adjoint is True:
             return -1 * (

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -1059,12 +1059,12 @@ class LineCurrent(BaseTDEMSrc):
             raise NotImplementedError
 
         vol = simulation.mesh.vol
-
+        Div = sdiag(vol) * simulation.mesh.faceDiv
         return (
             simulation.mesh.edgeCurl * simulation.MeMuI * simulation.mesh.edgeCurl.T
-            - simulation.mesh.faceDiv.T
+            - Div.T
             * sdiag(1.0 / vol * simulation.mui)
-            * simulation.mesh.faceDiv  # stabalizing term. See (Chen, Haber & Oldenburg 2002)
+            * Div  # stabalizing term. See (Chen, Haber & Oldenburg 2002)
         )
 
     def _aInitial(self, simulation):
@@ -1079,11 +1079,11 @@ class LineCurrent(BaseTDEMSrc):
         Ainv = simulation.solver(A)  # todo: store this - move it to the simulation
 
         if adjoint is True:
-            return -1 * (
-                self.jInitialDeriv(simulation, Ainv * v, adjoint=True)
+            return self.jInitialDeriv(
+                simulation, Ainv * v, adjoint=True
             )  # A is symmetric
 
-        return -1 * (Ainv * self.jInitialDeriv(simulation, v))
+        return Ainv * self.jInitialDeriv(simulation, v)
 
     def hInitial(self, simulation):
         if simulation._formulation != "HJ":

--- a/tests/em/tdem/test_TDEM_crosscheck.py
+++ b/tests/em/tdem/test_TDEM_crosscheck.py
@@ -18,7 +18,9 @@ FLR = 1e-20
 np.random.seed(25)
 
 
-def setUp_TDEM(prbtype="MagneticFluxDensity", rxcomp="bz", waveform="stepoff"):
+def setUp_TDEM(
+    prbtype="MagneticFluxDensity", rxcomp="bz", waveform="stepoff", src_type=None
+):
     cs = 5.0
     ncx = 8
     ncy = 8
@@ -57,9 +59,17 @@ def setUp_TDEM(prbtype="MagneticFluxDensity", rxcomp="bz", waveform="stepoff"):
     rx = getattr(tdem.Rx, "Point{}".format(rxcomp[:-1]))(
         np.r_[rxOffset, 0.0, -1e-2], rxtimes, rxcomp[-1]
     )
-    src = tdem.Src.MagDipole(
-        [rx], location=np.array([0.0, 0.0, 0.0]), waveform=waveform
-    )
+    if src_type == "LineCurrent":
+        src = tdem.sources.LineCurrent(
+            [rx],
+            location=np.vstack(
+                [np.r_[-cs / 2, -cs / 2, -cs / 2], np.r_[cs / 2, -cs / 2, -cs / 2]]
+            ),
+        )
+    else:
+        src = tdem.Src.MagDipole(
+            [rx], location=np.array([0.0, 0.0, 0.0]), waveform=waveform
+        )
 
     survey = tdem.Survey([src])
 
@@ -78,10 +88,11 @@ def CrossCheck(
     prbtype2="ElectricField",
     rxcomp="bz",
     waveform="stepoff",
+    src_type=None,
 ):
 
-    prb1, m1, mesh1 = setUp_TDEM(prbtype1, rxcomp, waveform)
-    prb2, _, mesh2 = setUp_TDEM(prbtype2, rxcomp, waveform)
+    prb1, m1, mesh1 = setUp_TDEM(prbtype1, rxcomp, waveform, src_type)
+    prb2, _, mesh2 = setUp_TDEM(prbtype2, rxcomp, waveform, src_type)
 
     d1 = prb1.dpred(m1)
     d2 = prb2.dpred(m1)
@@ -91,8 +102,8 @@ def CrossCheck(
     passed = check < tol
 
     print(
-        "Checking {}, {} for {} data, {} waveform".format(
-            prbtype1, prbtype2, rxcomp, waveform
+        "Checking {}, {} for {} data, {} waveform, {}".format(
+            prbtype1, prbtype2, rxcomp, waveform, src_type
         )
     )
     print(
@@ -159,6 +170,24 @@ class TDEM_cross_check_EB(unittest.TestCase):
             prbtype2="CurrentDensity",
             rxcomp="MagneticFieldTimeDerivativex",
             waveform="stepoff",
+        )
+
+    def test_HJ_jx_stepoff_linecurrent(self):
+        CrossCheck(
+            prbtype1="MagneticField",
+            prbtype2="CurrentDensity",
+            rxcomp="CurrentDensityx",
+            waveform="stepoff",
+            src_type="LineCurrent",
+        )
+
+    def test_HJ_jy_stepoff_linecurrent(self):
+        CrossCheck(
+            prbtype1="MagneticField",
+            prbtype2="CurrentDensity",
+            rxcomp="CurrentDensityy",
+            waveform="stepoff",
+            src_type="LineCurrent",
         )
 
     def test_EB_ey_vtem(self):


### PR DESCRIPTION
Bug fixes in the MMR solution for the TDEM h-field problem with a line source. 
- note that `e = - \grad \phi` (hence the sign update)
- the volume term needs to be accounted for in the divergence

Todo:
- [x] add a test that checks consistency with the j formulation 