### PR TITLE
Allow `Data` to take `dobs` as a dictionary for multicomponents data

### DIFF
--- a/SimPEG/data.py
+++ b/SimPEG/data.py
@@ -380,7 +380,7 @@ def _check_data_sizes(observed_data):
     Check that all elements inside observed data dictionary have the same shape
     """
     # Check if every array in observed_data has the same size
-    sizes = [d.size for d in observed_data.values()]
+    sizes = np.array([d.size for d in observed_data.values()])
     if not (sizes[0] == sizes).all():
         raise ValueError(
             "All elements in the data dictionary should have the same size"
@@ -412,7 +412,7 @@ def _observed_data_dict_to_array(observed_data, survey_components):
     """
     # Determine the size of the full array
     n_components = len(survey_components)
-    size_of_single_component = observed_data.values()[0]
+    size_of_single_component = list(observed_data.values())[0].size
     size = n_components * size_of_single_component
     # Allocate the full array
     dobs = np.empty(size, dtype=np.float64)

--- a/SimPEG/data.py
+++ b/SimPEG/data.py
@@ -133,6 +133,14 @@ class Data(properties.HasProperties):
         if dobs is None:
             dobs = np.nan * np.ones(survey.nD)  # initialize data as nans
         if isinstance(dobs, dict):
+            # Check if survey has a components attribute
+            if not hasattr(survey, "components"):
+                raise ValueError(
+                    """
+                    Impossible to take 'dobs' as a dictionary since the passed
+                    survey has not a 'components' attribute.
+                    """
+                )
             # Check if dobs has invalid or missing components
             _check_invalid_and_missing_components(dobs.keys(), survey.components.keys())
             # Check if all elements in dobs have the same size

--- a/tests/base/test_data.py
+++ b/tests/base/test_data.py
@@ -31,6 +31,7 @@ class TestObservedDataDictToArray(unittest.TestCase):
             "gxy": np.array([3, 6, 9]),
             "gz": np.array([1, 4, 7]),
         }
+        # Define a survey that has components
         receiver_locations = np.array(
             [
                 [0, 0, 100],
@@ -43,6 +44,10 @@ class TestObservedDataDictToArray(unittest.TestCase):
         receivers = Point(receiver_locations, components=components)
         source_field = SourceField(receiver_list=[receivers])
         self.survey = Survey(source_field)
+        # Define a survey that doesn't have components
+        receivers = survey.BaseRx(20 * [[0.0]])
+        source = survey.BaseSrc([receivers])
+        self.survey_without_components = survey.BaseSurvey([source])
 
     def test_observed_data_dict_to_array(self):
         """
@@ -61,6 +66,13 @@ class TestObservedDataDictToArray(unittest.TestCase):
         data = Data(self.survey, dobs=self.dobs)
         expected_array = np.linspace(1, 9, 9, dtype=int)
         npt.assert_allclose(data.dobs, expected_array)
+
+    def test_data_class_with_survey_without_components(self):
+        """
+        Test if SimPEG.Data raises error if survey doesn't have components
+        """
+        with self.assertRaises(ValueError):
+            Data(self.survey_without_components, dobs=self.dobs)
 
 
 class TestChecksForDobsAsDicts(unittest.TestCase):
@@ -168,7 +180,7 @@ class DataTest(unittest.TestCase):
                 data.standard_deviation,
                 np.sqrt(
                     (relative * np.abs(self.dobs)) ** 2
-                    + floor ** 2 * np.ones(len(self.dobs)),
+                    + floor**2 * np.ones(len(self.dobs)),
                 ),
             )
         )

--- a/tests/base/test_data.py
+++ b/tests/base/test_data.py
@@ -1,14 +1,131 @@
 import unittest
 
 import numpy as np
+import numpy.testing as npt
 import scipy.sparse as sp
 import discretize
 
 from SimPEG import maps, utils
 from SimPEG import data_misfit, simulation, survey
 from SimPEG import Data
+from SimPEG.data import (
+    _check_invalid_and_missing_components,
+    _check_data_sizes,
+    _observed_data_dict_to_array,
+)
+
+from SimPEG.potential_fields.gravity.receivers import Point
+from SimPEG.potential_fields.gravity.sources import SourceField
+from SimPEG.potential_fields.gravity.survey import Survey
 
 np.random.seed(17)
+
+
+class TestObservedDataDictToArray(unittest.TestCase):
+    def setUp(self):
+        """
+        Create sample objects for the following tests
+        """
+        self.dobs = {
+            "guv": np.array([2, 5, 8]),
+            "gxy": np.array([3, 6, 9]),
+            "gz": np.array([1, 4, 7]),
+        }
+        receiver_locations = np.array(
+            [
+                [0, 0, 100],
+                [1, 1, 100],
+                [-1, -1, 100],
+            ],
+            dtype=float,
+        )
+        components = ["gz", "guv", "gxy"]
+        receivers = Point(receiver_locations, components=components)
+        source_field = SourceField(receiver_list=[receivers])
+        self.survey = Survey(source_field)
+
+    def test_observed_data_dict_to_array(self):
+        """
+        Test if the conversion of dobs dict to array works properly
+        """
+        dobs_array = _observed_data_dict_to_array(
+            self.dobs, self.survey.components.keys()
+        )
+        expected_array = np.linspace(1, 9, 9, dtype=int)
+        npt.assert_allclose(dobs_array, expected_array)
+
+    def test_data_class_with_dobs_as_dict(self):
+        """
+        Test SimPEG.Data when passing dobs as a dict
+        """
+        data = Data(self.survey, dobs=self.dobs)
+        expected_array = np.linspace(1, 9, 9, dtype=int)
+        npt.assert_allclose(data.dobs, expected_array)
+
+
+class TestChecksForDobsAsDicts(unittest.TestCase):
+    def test_check_data_sizes(self):
+        """
+        Check if _check_data_sizes doesn't raise error on valid dict
+        """
+        dobs = {
+            "a": np.array([1, 4, 7]),
+            "b": np.array([2, 5, 8]),
+            "c": np.array([3, 6, 9]),
+        }
+        _check_data_sizes(dobs)
+
+    def test_check_data_sizes_invalid(self):
+        """
+        Check if _check_data_sizes catch invalid sizes of data arrays
+        """
+        dobs = {
+            "a": np.array([1, 4, 7]),
+            "b": np.ones(10),
+            "c": np.array([3, 6, 9]),
+        }
+        with self.assertRaises(ValueError):
+            _check_data_sizes(dobs)
+
+    def test_check_invalid_and_missing_components(self):
+        """
+        Check if _check_invalid_and_missing_components doesn't raise error on
+        valid dict_keys
+        """
+        dobs = {
+            "a": np.array([1, 4, 7]),
+            "b": np.array([2, 5, 8]),
+            "c": np.array([3, 6, 9]),
+        }
+        survey_components = {"c": None, "a": None, "b": None}
+        _check_invalid_and_missing_components(dobs.keys(), survey_components.keys())
+
+    def test_check_invalid_and_missing_components_invalid(self):
+        """
+        Check if _check_invalid_and_missing_components raises error on
+        invalid dict_keys
+        """
+        dobs = {
+            "z": np.array([1, 4, 7]),
+            "b": np.array([2, 5, 8]),
+            "c": np.array([3, 6, 9]),
+        }
+        survey_components = {"c": None, "a": None, "b": None}
+        with self.assertRaises(ValueError):
+            _check_invalid_and_missing_components(dobs.keys(), survey_components.keys())
+
+    def test_check_invalid_and_missing_components_missing(self):
+        """
+        Check if _check_invalid_and_missing_components raises error on
+        missing dict_keys
+        """
+        dobs = {
+            "b": np.array([2, 5, 8]),
+            "c": np.array([3, 6, 9]),
+        }
+        survey_components = {"c": None, "a": None, "b": None}
+        with self.assertRaises(ValueError):
+            _check_invalid_and_missing_components(dobs.keys(), survey_components.keys())
 
 
 class DataTest(unittest.TestCase):


### PR DESCRIPTION
When working with potential field data we might want to perform multicomponent
inversions. In those cases we need to create a single 1D array that host every
observed data from each one of the components. This array should interleave the
values of each component on each receiver in the same order as the components
are laid out in the survey object. Now we would be able to pass the `dobs`
argument as a dictionary whose keys are the components and whose values are
their corresponding observed data values.


Todo:

- [ ] Allow the `relative_error`, `noise_floor` and `standard_deviation` to be
  dictionaries
- [ ] Update the docs (should we still use `properties` here?)
