### PR TITLE
Remove LineCurrent1D

### DIFF
--- a/SimPEG/electromagnetics/base_1d.py
+++ b/SimPEG/electromagnetics/base_1d.py
@@ -383,7 +383,7 @@ class BaseEM1DSimulation(BaseSimulation):
                 xyks = []
                 thetas = []
                 weights = []
-                for i_path in range(src.location.shape[0] - 1):
+                for i_path in range(src.n_segments):
                     dx = xy_src_path[i_path + 1, 0] - xy_src_path[i_path, 0]
                     dy = xy_src_path[i_path + 1, 1] - xy_src_path[i_path, 1]
                     dl = np.sqrt(dx ** 2 + dy ** 2)

--- a/SimPEG/electromagnetics/frequency_domain/simulation_1d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_1d.py
@@ -80,7 +80,8 @@ class Simulation1DLayered(BaseEM1DSimulation):
             i_f = np.searchsorted(frequencies, src.frequency)
             for i_rx, rx in enumerate(src.receiver_list):
                 if is_wire_loop:
-                    i_freq.append([i_f] * rx.locations.shape[0] * src.n_quad_points)
+                    n_quad_points = src.n_segments * self.n_points_per_path
+                    i_freq.append([i_f] * rx.locations.shape[0] * n_quad_points)
                 else:
                     i_freq.append([i_f] * rx.locations.shape[0])
         self._i_freq = np.hstack(i_freq)
@@ -157,8 +158,9 @@ class Simulation1DLayered(BaseEM1DSimulation):
 
                     h = h_vec[i_src]
                     if is_wire_loop:
+                        n_quad_points = src.n_segments * self.n_points_per_path
                         nD = sum(
-                            rx.locations.shape[0] * src.n_quad_points
+                            rx.locations.shape[0] * n_quad_points
                             for rx in src.receiver_list
                         )
                     else:
@@ -187,8 +189,9 @@ class Simulation1DLayered(BaseEM1DSimulation):
                     class_name = type(src).__name__
                     is_wire_loop = class_name == "LineCurrent"
                     if is_wire_loop:
+                        n_quad_points = src.n_segments * self.n_points_per_path
                         nD = sum(
-                            rx.locations.shape[0] * src.n_quad_points
+                            rx.locations.shape[0] * n_quad_points
                             for rx in src.receiver_list
                         )
                     else:

--- a/SimPEG/electromagnetics/frequency_domain/simulation_1d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_1d.py
@@ -76,7 +76,7 @@ class Simulation1DLayered(BaseEM1DSimulation):
         i_freq = []
         for i_src, src in enumerate(survey.source_list):
             class_name = type(src).__name__
-            is_wire_loop = class_name == "LineCurrent1D"
+            is_wire_loop = class_name == "LineCurrent"
             i_f = np.searchsorted(frequencies, src.frequency)
             for i_rx, rx in enumerate(src.receiver_list):
                 if is_wire_loop:
@@ -153,7 +153,7 @@ class Simulation1DLayered(BaseEM1DSimulation):
                 i = 0
                 for i_src, src in enumerate(self.survey.source_list):
                     class_name = type(src).__name__
-                    is_wire_loop = class_name == "LineCurrent1D"
+                    is_wire_loop = class_name == "LineCurrent"
 
                     h = h_vec[i_src]
                     if is_wire_loop:
@@ -185,7 +185,7 @@ class Simulation1DLayered(BaseEM1DSimulation):
                 i = 0
                 for i_src, src in enumerate(self.survey.source_list):
                     class_name = type(src).__name__
-                    is_wire_loop = class_name == "LineCurrent1D"
+                    is_wire_loop = class_name == "LineCurrent"
                     if is_wire_loop:
                         nD = sum(
                             rx.locations.shape[0] * src.n_quad_points
@@ -251,7 +251,7 @@ class Simulation1DLayered(BaseEM1DSimulation):
             out = np.zeros((self.survey.nD, v.shape[1]))
         for i_src, src in enumerate(self.survey.source_list):
             class_name = type(src).__name__
-            is_wire_loop = class_name == "LineCurrent1D"
+            is_wire_loop = class_name == "LineCurrent"
             for i_rx, rx in enumerate(src.receiver_list):
                 i_dat_p1 = i_dat + rx.nD
                 i_v_p1 = i_v + rx.locations.shape[0]
@@ -261,7 +261,7 @@ class Simulation1DLayered(BaseEM1DSimulation):
                     if rx.data_type == "ppm":
                         if is_wire_loop:
                             raise NotImplementedError(
-                                "Primary field for LineCurrent1D has not been implemented"
+                                "Primary field for LineCurrent has not been implemented"
                             )
                         if v_slice.ndim == 2:
                             v_slice /= src.hPrimary(self)[i_rx][:, None]
@@ -271,7 +271,7 @@ class Simulation1DLayered(BaseEM1DSimulation):
                 elif isinstance(rx, PointMagneticField):
                     if is_wire_loop:
                         raise NotImplementedError(
-                            "Primary field for LineCurrent1D has not been implemented"
+                            "Primary field for LineCurrent has not been implemented"
                         )
                     if v_slice.ndim == 2:
                         pass

--- a/SimPEG/electromagnetics/frequency_domain/sources.py
+++ b/SimPEG/electromagnetics/frequency_domain/sources.py
@@ -1350,60 +1350,9 @@ class LineCurrent(BaseFDEMSrc):
         elif simulation._formulation == "HJ":
             return self.Mfjs(simulation)
 
-
-class LineCurrent1D(LineCurrent):
-    def __init__(
-        self, receiver_list, frequency, locations, n_points_per_path=3, **kwargs
-    ):
-        super().__init__(
-            receiver_list, frequency=frequency, location=locations, **kwargs
-        )
-        self.n_points_per_path = n_points_per_path
-        # calculate lateral dipole locations
-        x, w = roots_legendre(self.n_points_per_path)
-        xy_src_path = self.location[:, :2]
-        n_path = len(xy_src_path) - 1
-        xyks = []
-        thetas = []
-        weights = []
-        for i_path in range(n_path):
-            dx = xy_src_path[i_path + 1, 0] - xy_src_path[i_path, 0]
-            dy = xy_src_path[i_path + 1, 1] - xy_src_path[i_path, 1]
-            dl = np.sqrt(dx ** 2 + dy ** 2)
-            theta = np.arctan2(dy, dx)
-            lk = np.c_[(x + 1) * dl / 2, np.zeros(self.n_points_per_path)]
-
-            R = np.array([[dx, -dy], [dy, dx]]) / dl
-            xyk = lk.dot(R.T) + xy_src_path[i_path, :]
-
-            xyks.append(xyk)
-            thetas.append(theta * np.ones(xyk.shape[0]))
-            weights.append(w * dl / 2)
-        # store these for future evalution of integrals
-        self._xyks = np.vstack(xyks)
-        self._weights = np.hstack(weights)
-        self._thetas = np.hstack(thetas)
-
-    @property
-    def n_quad_points(self):
-        self._n_quad_points = len(self._weights)
-        return self._n_quad_points
-
-    @property
-    def n_points_per_path(self):
-        """The number of integration points for each line segment.
-
-        Returns
-        -------
-        int
-        """
-        return self._n_points_per_path
-
-    @n_points_per_path.setter
-    def n_points_per_path(self, val):
-        self._n_points_per_path = validate_type("n_points_per_path", val, int)
-
     def hPrimary(self, simulation):
-        raise NotImplementedError(
-            "Primary field calculation for LineCurrent1D has not been implemented"
-        )
+        if simulation._formulation == "1D":
+            raise NotImplementedError(
+                "Primary field calculation for LineCurrent has not been implemented"
+            )
+        return super().hPrimary(simulation)

--- a/SimPEG/electromagnetics/frequency_domain/sources.py
+++ b/SimPEG/electromagnetics/frequency_domain/sources.py
@@ -1257,6 +1257,17 @@ class LineCurrent(BaseFDEMSrc):
             raise ValueError("current must be non-zero.")
         self._current = I
 
+    @property
+    def n_segments(self):
+        """
+        The number of line current segments.
+
+        Returns
+        -------
+        int
+        """
+        return self.location.shape[0] - 1
+
     def Mejs(self, simulation):
         """Integrated electrical source term on edges
 

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -1548,7 +1548,8 @@ class LineCurrent(BaseTDEMSrc):
         List of TDEM receivers
     locations : (n, 3) numpy.ndarray
         Array defining the node locations for the wire path. For inductive sources,
-        you must close the loop.
+        you must close the loop, (i.e. provide the same point as the first and last
+        entry of the array).
     current : float, optional
         A non-zero current value.
     mu : float, optional
@@ -1610,6 +1611,17 @@ class LineCurrent(BaseTDEMSrc):
         if np.abs(I) == 0.0:
             raise ValueError("current must be non-zero.")
         self._current = I
+
+    @property
+    def n_segments(self):
+        """
+        The number of line current segments.
+
+        Returns
+        -------
+        int
+        """
+        return self.location.shape[0] - 1
 
     def Mejs(self, simulation):
         """Integrated electrical source term on edges

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -3,7 +3,6 @@ import warnings
 import numpy as np
 from geoana.em.static import CircularLoopWholeSpace, MagneticDipoleWholeSpace
 from scipy.constants import mu_0
-from scipy.special import roots_legendre
 
 from ...utils.code_utils import (
     deprecate_property,
@@ -1979,81 +1978,6 @@ class LineCurrent(BaseTDEMSrc):
             return self.Mejs(simulation) * self.waveform.eval(time)
         elif simulation._formulation == "HJ":
             return self.Mfjs(simulation) * self.waveform.eval(time)
-
-
-class LineCurrent1D(LineCurrent):
-
-    """1D Line current source.
-
-    Given the wire path provided by the (n_loc, 3) locations array,
-    the cells intersected by the wire path are identified and integrated
-    source terms are computed.
-
-    Parameters
-    ----------
-    receiver_list : list of SimPEG.electromagnetics.time_domain.receivers.BaseRx
-        List of TDEM receivers
-    locations : (n,3) numpy.ndarray
-        Array defining the node locations for the wire path. For inductive sources,
-        you must close the loop.
-    n_points_per_path : int
-        The number of quadrature points to integrate along the path.
-    """
-
-    def __init__(
-        self, receiver_list, locations, current=1.0, n_points_per_path=3, **kwargs
-    ):
-        super().__init__(receiver_list, location=locations, **kwargs)
-        self.n_points_per_path = n_points_per_path
-        # calculate lateral dipole locations
-        x, w = roots_legendre(self.n_points_per_path)
-        xy_src_path = self.location[:, :2]
-        n_path = len(xy_src_path) - 1
-        xyks = []
-        thetas = []
-        weights = []
-        for i_path in range(n_path):
-            dx = xy_src_path[i_path + 1, 0] - xy_src_path[i_path, 0]
-            dy = xy_src_path[i_path + 1, 1] - xy_src_path[i_path, 1]
-            dl = np.sqrt(dx ** 2 + dy ** 2)
-            theta = np.arctan2(dy, dx)
-            lk = np.c_[(x + 1) * dl / 2, np.zeros(self.n_points_per_path)]
-
-            R = np.array([[dx, -dy], [dy, dx]]) / dl
-            xyk = lk.dot(R.T) + xy_src_path[i_path, :]
-
-            xyks.append(xyk)
-            thetas.append(theta * np.ones(xyk.shape[0]))
-            weights.append(w * dl / 2)
-        # store these for future evalution of integrals
-        self._xyks = np.vstack(xyks)
-        self._weights = np.hstack(weights)
-        self._thetas = np.hstack(thetas)
-
-    @property
-    def n_quad_points(self):
-        self._n_quad_points = len(self._weights)
-        return self._n_quad_points
-
-    @property
-    def n_points_per_path(self):
-        """The number of integration points for each line segment.
-
-        Returns
-        -------
-        int
-        """
-        return self._n_points_per_path
-
-    @n_points_per_path.setter
-    def n_points_per_path(self, val):
-        try:
-            val = int(val)
-        except Exception:
-            raise TypeError("n_points_per_path must be an integer")
-        if val <= 0:
-            raise ValueError("n_points_per_path must be positive")
-        self._n_points_per_path = val
 
 
 # TODO: this should be generalized and plugged into getting the Line current

--- a/tests/em/em1d/test_EM1D_FD_fwd.py
+++ b/tests/em/em1d/test_EM1D_FD_fwd.py
@@ -454,7 +454,7 @@ class EM1D_FD_FwdProblemTests(unittest.TestCase):
         self.assertLess(err, 1e-5)
 
 
-class EM1D_FD_LineCurrent1DTest(unittest.TestCase):
+class EM1D_FD_LineCurrentTest(unittest.TestCase):
     def setUp(self):
 
         x_path = np.array([-2, -2, 2, 2, -2])
@@ -476,7 +476,7 @@ class EM1D_FD_LineCurrent1DTest(unittest.TestCase):
         )
 
         for freq in frequencies:
-            source = fdem.sources.LineCurrent1D(receiver_list, freq, wire_paths)
+            source = fdem.sources.LineCurrent(receiver_list, freq, wire_paths)
             source_list.append(source)
 
         # Survey

--- a/tests/em/em1d/test_EM1D_FD_jac_layers.py
+++ b/tests/em/em1d/test_EM1D_FD_jac_layers.py
@@ -329,7 +329,7 @@ class EM1D_FD_Jacobian_Test_CircularLoop(unittest.TestCase):
             print("EM1DFM Circular Loop Jtvec test works")
 
 
-class EM1D_FD_Jacobian_Test_LineCurrent1D(unittest.TestCase):
+class EM1D_FD_Jacobian_Test_LineCurrent(unittest.TestCase):
     # Tests 2nd order convergence of Jvec and Jtvec for piecewise linear loop.
     # - All rx orientations
     # - All rx components
@@ -365,7 +365,7 @@ class EM1D_FD_Jacobian_Test_LineCurrent1D(unittest.TestCase):
                         )
                     )
 
-            source_list.append(fdem.sources.LineCurrent1D(receiver_list, f, wire_paths))
+            source_list.append(fdem.sources.LineCurrent(receiver_list, f, wire_paths))
 
         # Survey
         survey = fdem.Survey(source_list)

--- a/tests/em/em1d/test_EM1D_TD_general_fwd.py
+++ b/tests/em/em1d/test_EM1D_TD_general_fwd.py
@@ -100,7 +100,7 @@ class EM1D_TD_CircularLoop_FwdProblemTests(unittest.TestCase):
         np.testing.assert_allclose(dbdt, dbdt_analytic, atol=0.0, rtol=1e-2)
 
 
-class EM1D_TD_LineCurrent1D_FwdProblemTests(unittest.TestCase):
+class EM1D_TD_LineCurrent_FwdProblemTests(unittest.TestCase):
     def setUp(self):
         # WalkTEM waveform
         # Low moment
@@ -196,10 +196,10 @@ class EM1D_TD_LineCurrent1D_FwdProblemTests(unittest.TestCase):
             hm_waveform_times, hm_waveform_current
         )
 
-        source_lm = tdem.sources.LineCurrent1D(
+        source_lm = tdem.sources.LineCurrent(
             receiver_list_lm, wire_paths, waveform=lm_wave
         )
-        source_hm = tdem.sources.LineCurrent1D(
+        source_hm = tdem.sources.LineCurrent(
             receiver_list_hm, wire_paths, waveform=hm_wave
         )
         source_list.append(source_lm)

--- a/tests/em/em1d/test_EM1D_TD_general_jac_layers.py
+++ b/tests/em/em1d/test_EM1D_TD_general_jac_layers.py
@@ -120,7 +120,7 @@ class EM1D_TD_general_Jac_layers_ProblemTests(unittest.TestCase):
         self.assertTrue(passed)
 
 
-class EM1D_TD_LineCurrent1D_Jac_layers_ProblemTests(unittest.TestCase):
+class EM1D_TD_LineCurrent_Jac_layers_ProblemTests(unittest.TestCase):
     def setUp(self):
         # WalkTEM waveform
         # Low moment
@@ -216,10 +216,10 @@ class EM1D_TD_LineCurrent1D_Jac_layers_ProblemTests(unittest.TestCase):
             hm_waveform_times, hm_waveform_current
         )
 
-        source_lm = tdem.sources.LineCurrent1D(
+        source_lm = tdem.sources.LineCurrent(
             receiver_list_lm, wire_paths, waveform=lm_wave
         )
-        source_hm = tdem.sources.LineCurrent1D(
+        source_hm = tdem.sources.LineCurrent(
             receiver_list_hm, wire_paths, waveform=hm_wave
         )
         source_list.append(source_lm)


### PR DESCRIPTION
Before the next release, this removes the standalone `LineCurrent1D` class in favor of the `LineCurrent` class which was already present.