### PR TITLE
TDEM exponential waveform

### DIFF
--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -959,9 +959,9 @@ class ExponentialWaveform(BaseWaveform):
 
     @property
     def ramp_on_tau(self):
-        """Ramp on rate
+        """Ramp on rate control parameter.
 
-        Parameter controlling how quickly the waveform ramps on (default is 3)
+        Parameter controlling how quickly the waveform ramps on.
 
         Returns
         -------

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -886,9 +886,9 @@ class ExponentialWaveform(BaseWaveform):
     start_time : float, default: -1e-2
         time at which the transmitter is turned on in units of seconds
     peak_time : float, default: -1e-3
-        the peak time for the waveform
+        the peak time for the waveform in units of seconds
     ramp_on_tau : float, default: 1e-3
-        time constant tau controlling how quickly the waveform ramps on (1-e^(-t/tau))
+        time constant tau in units of seconds controlling how quickly the waveform ramps on (formula: 1-e^(-t/tau))
 
     Examples
     --------

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -919,12 +919,12 @@ class ExponentialWaveform(BaseWaveform):
 
     @property
     def start_time(self):
-        """Peak time
+        """Start time
 
         Returns
         -------
         float
-            The peak time for the Exponential waveform
+            The start time for the Exponential waveform in units of seconds
         """
         return self._start_time
 
@@ -942,7 +942,7 @@ class ExponentialWaveform(BaseWaveform):
         Returns
         -------
         float
-            The peak time for the VTEM waveform
+            The peak time for the Exponential waveform in units of seconds
         """
         return self._peak_time
 
@@ -961,12 +961,12 @@ class ExponentialWaveform(BaseWaveform):
     def ramp_on_tau(self):
         """Ramp on rate control parameter.
 
-        Parameter controlling how quickly the waveform ramps on.
+        Time constant tau controlling how quickly the waveform ramps on in units of seconds
 
         Returns
         -------
         float
-            Ramp on rate
+            Ramp on time constant tau
         """
         return self._ramp_on_tau
 

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -948,7 +948,13 @@ class ExponentialWaveform(BaseWaveform):
 
     @peak_time.setter
     def peak_time(self, value):
-        value = validate_float("peak_time", value, max_val=self.off_time)
+        value = validate_float(
+            "peak_time",
+            value,
+            min_val=self.start_time,
+            max_val=self.off_time,
+            inclusive_min=False,
+        )
         self._peak_time = value
 
     @property

--- a/examples/06-tdem/plot_fwd_tdem_waveforms.py
+++ b/examples/06-tdem/plot_fwd_tdem_waveforms.py
@@ -6,10 +6,10 @@ In this example, we plot the waveforms available in the TDEM module in addition
 to the `StepOffWaveform`
 """
 
-import numpy as np
 import matplotlib.pyplot as plt
-from SimPEG.utils import mkvc
+import numpy as np
 from SimPEG.electromagnetics import time_domain as TDEM
+from SimPEG.utils import mkvc
 
 nT = 1000
 max_t = 5e-3
@@ -30,6 +30,9 @@ quarter_sine = TDEM.Src.QuarterSineRampOnWaveform(
 half_sine = TDEM.Src.HalfSineWaveform(
     ramp_on=np.r_[0.0, 1.5e-3], ramp_off=max_t - np.r_[1.5e-3, 0]
 )
+exponential = TDEM.Src.ExponentialWaveform(
+    start_time=0.0, peak_time=0.003, off_time=0.005, ramp_on_tau=5e-4
+)
 
 waveforms = dict(
     zip(
@@ -40,13 +43,14 @@ waveforms = dict(
             "VTEMWaveform",
             "TriangularWaveform",
             "HalfSineWaveform",
+            "ExponentialWaveform",
         ],
-        [ramp_off, trapezoid, quarter_sine, vtem, triangular, half_sine],
+        [ramp_off, trapezoid, quarter_sine, vtem, triangular, half_sine, exponential],
     )
 )
 
 # plot the waveforms
-fig, ax = plt.subplots(3, 2, figsize=(7, 10))
+fig, ax = plt.subplots(4, 2, figsize=(7, 10))
 ax = mkvc(ax)
 
 for a, key in zip(ax, waveforms):
@@ -55,6 +59,7 @@ for a, key in zip(ax, waveforms):
     a.plot(times, wave_plt)
     a.set_title(key)
     a.set_xlabel("time (s)")
-
+# deactivate last subplot as it is empty
+ax[-1].axis("off")
 plt.tight_layout()
 plt.show()


### PR DESCRIPTION
This PR adds a flexible exponential growth followed by a linear ramp waveform: `ExponentialWaveform`
- parameters: `start_time`, `ramp_on_tau`, `peak_time`, `off_time`
- `eval`, `eval_deriv`, `time_nodes` are implemented
- the gallery example is updated
<img width="694" alt="image" src="https://user-images.githubusercontent.com/97514898/197657206-5d885da8-fca8-4245-9166-377dd3ca674b.png">
