### PR TITLE
Cleanup six and __future__ imports

### DIFF
--- a/SimPEG/__init__.py
+++ b/SimPEG/__init__.py
@@ -132,8 +132,6 @@ Base inversion pieces
   inversion.BaseInversion
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
 
 # import discretize as Mesh
 import discretize

--- a/SimPEG/directives/pgi_directives.py
+++ b/SimPEG/directives/pgi_directives.py
@@ -4,8 +4,6 @@
 #                                                                             #
 ###############################################################################
 
-from __future__ import print_function
-
 import numpy as np
 import matplotlib.pyplot as plt
 import copy
@@ -364,7 +362,9 @@ class PGI_AddMrefInSmooth(InversionDirective):
                         [
                             i,
                             j,
-                            isinstance(regpart, (SmoothnessFirstOrder, SparseSmoothness)),
+                            isinstance(
+                                regpart, (SmoothnessFirstOrder, SparseSmoothness)
+                            ),
                         ]
                     ]
             self.Smooth = np.r_[Smooth]

--- a/SimPEG/electromagnetics/analytics/FDEM.py
+++ b/SimPEG/electromagnetics/analytics/FDEM.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 from scipy.constants import mu_0, pi, epsilon_0
 from SimPEG import utils

--- a/SimPEG/electromagnetics/analytics/FDEMDipolarfields.py
+++ b/SimPEG/electromagnetics/analytics/FDEMDipolarfields.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 from scipy.constants import mu_0, pi, epsilon_0
 from scipy.special import erf

--- a/SimPEG/electromagnetics/analytics/TDEM.py
+++ b/SimPEG/electromagnetics/analytics/TDEM.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 from scipy.constants import mu_0, pi
 from scipy.special import erf

--- a/SimPEG/electromagnetics/natural_source/utils/__init__.py
+++ b/SimPEG/electromagnetics/natural_source/utils/__init__.py
@@ -5,8 +5,6 @@ Collection of utilities that are usefull for the NSEM problem
 NOTE: These utilities are not well test, use with care
 
 """
-from __future__ import absolute_import
-
 from .solutions_1d import get1DEfields  # Add the names of the functions
 from .analytic_1d import getEHfields, getImpedance
 from .data_utils import (

--- a/SimPEG/electromagnetics/natural_source/utils/analytic_1d.py
+++ b/SimPEG/electromagnetics/natural_source/utils/analytic_1d.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # Analytic solution of EM fields due to a plane wave
 
 import numpy as np

--- a/SimPEG/electromagnetics/natural_source/utils/data_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/data_utils.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.lib.recfunctions as recFunc

--- a/SimPEG/electromagnetics/natural_source/utils/edi_files_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/edi_files_utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # Functions to import and export MT EDI files.
 from SimPEG import mkvc
 from scipy.constants import mu_0

--- a/SimPEG/electromagnetics/natural_source/utils/plot_data_types.py
+++ b/SimPEG/electromagnetics/natural_source/utils/plot_data_types.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import division
-
 from matplotlib import pyplot as plt, colors, numpy as np
 
 

--- a/SimPEG/electromagnetics/natural_source/utils/plot_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/plot_utils.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.constants import mu_0
@@ -45,7 +41,7 @@ def _validate_kwargs(input_dict, compare_dict):
     return input_dict
 
 
-class BaseDataNSEMPlots():
+class BaseDataNSEMPlots:
     """
     A class container of matplotlib panels for plotting
     NSEM data.

--- a/SimPEG/electromagnetics/natural_source/utils/test_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/test_utils.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import numpy as np
 
 import discretize

--- a/SimPEG/electromagnetics/static/resistivity/survey.py
+++ b/SimPEG/electromagnetics/static/resistivity/survey.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import numpy as np
 
 from ....utils.code_utils import deprecate_property, validate_string

--- a/SimPEG/fields.py
+++ b/SimPEG/fields.py
@@ -1,4 +1,3 @@
-from six import string_types
 import numpy as np
 
 from .simulation import BaseSimulation, BaseTimeSimulation
@@ -259,7 +258,7 @@ class Fields:
             # Aliased fields
             alias, loc, func = self.aliasFields[name]
 
-            if isinstance(func, string_types):
+            if isinstance(func, str):
                 assert hasattr(self, func), (
                     "The alias field function is a string, but it does not "
                     "exist in the Fields class."
@@ -369,7 +368,7 @@ class TimeFields(Fields):
         else:
             # Aliased fields
             alias, loc, func = self.aliasFields[name]
-            if isinstance(func, string_types):
+            if isinstance(func, str):
                 assert hasattr(self, func), (
                     "The alias field function is a string, but it does "
                     "not exist in the Fields class."

--- a/SimPEG/inverse_problem.py
+++ b/SimPEG/inverse_problem.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import numpy as np
 import scipy.sparse as sp
 import gc

--- a/SimPEG/inversion.py
+++ b/SimPEG/inversion.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import scipy.sparse as sp
 import numpy as np
 

--- a/SimPEG/maps.py
+++ b/SimPEG/maps.py
@@ -1,5 +1,3 @@
-from six import integer_types
-from six import string_types
 from collections import namedtuple
 import warnings
 import discretize
@@ -66,10 +64,10 @@ class IdentityMap:
 
     def __init__(self, mesh=None, nP=None, **kwargs):
         if nP is not None:
-            if isinstance(nP, string_types):
+            if isinstance(nP, str):
                 assert nP == "*", "nP must be an integer or '*', not {}".format(nP)
             assert isinstance(
-                nP, integer_types + (np.int64,)
+                nP, (int, np.integer)
             ), "Number of parameters must be an integer. Not `{}`.".format(type(nP))
             nP = int(nP)
         elif mesh is not None:
@@ -183,7 +181,7 @@ class IdentityMap:
         """
         if v is not None:
             return v
-        if isinstance(self.nP, integer_types):
+        if isinstance(self.nP, (int, np.integer)):
             return sp.identity(self.nP)
         return Identity()
 
@@ -214,7 +212,7 @@ class IdentityMap:
             kwargs["plotIt"] = False
 
         assert isinstance(
-            self.nP, integer_types
+            self.nP, (int, np.integer)
         ), "nP must be an integer for {}".format(self.__class__.__name__)
         return check_derivative(
             lambda m: [self * m, self.deriv(m)], m, num=num, **kwargs
@@ -1221,10 +1219,10 @@ class Wires(object):
             assert (
                 isinstance(arg, tuple)
                 and len(arg) == 2
-                and isinstance(arg[0], string_types)
+                and isinstance(arg[0], str)
                 and
                 # TODO: this should be extended to a slice.
-                isinstance(arg[1], integer_types)
+                isinstance(arg[1], (int, np.integer))
             ), (
                 "Each wire needs to be a tuple: (name, length). "
                 "You provided: {}".format(arg)

--- a/SimPEG/models.py
+++ b/SimPEG/models.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 from .maps import IdentityMap
 

--- a/SimPEG/objective_function.py
+++ b/SimPEG/objective_function.py
@@ -1,11 +1,5 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-
 import numpy as np
 import scipy.sparse as sp
-from six import integer_types
 import warnings
 
 from discretize.tests import check_derivative
@@ -228,7 +222,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
 
     """
 
-    _multiplier_types = (float, None, Zero, np.float64) + integer_types  # Directive
+    _multiplier_types = (float, None, Zero, np.float64, int, np.integer)  # Directive
     _multipliers = None
 
     def __init__(self, objfcts=[], multipliers=None, **kwargs):

--- a/SimPEG/optimization.py
+++ b/SimPEG/optimization.py
@@ -1,8 +1,5 @@
-from __future__ import print_function
-
 import numpy as np
 import scipy.sparse as sp
-from six import string_types
 
 from .utils.solver_utils import SolverWrapI, Solver, SolverDiag
 from .utils import (
@@ -741,14 +738,14 @@ class Remember(object):
     def _startupRemember(self, x0):
         self._rememberList = {}
         for param in self._rememberThese:
-            if isinstance(param, string_types):
+            if isinstance(param, str):
                 self._rememberList[param] = []
             elif isinstance(param, tuple):
                 self._rememberList[param[0]] = []
 
     def _doEndIterationRemember(self, *args):
         for param in self._rememberThese:
-            if isinstance(param, string_types):
+            if isinstance(param, str):
                 if self.debug:
                     print("Remember is remembering: " + param)
                 val = getattr(self, param, None)

--- a/SimPEG/potential_fields/gravity/analytics.py
+++ b/SimPEG/potential_fields/gravity/analytics.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from scipy.constants import G
 from SimPEG.utils import mkvc
 import numpy as np

--- a/SimPEG/props.py
+++ b/SimPEG/props.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import numpy as np
 
 from .maps import IdentityMap, ReciprocalMap

--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import inspect
 import numpy as np

--- a/SimPEG/utils/__init__.py
+++ b/SimPEG/utils/__init__.py
@@ -184,8 +184,6 @@ Many of the functions here are used internally to SimPEG and have minimal docume
   validate_active_indices
 
 """
-from __future__ import print_function
-
 from discretize.utils.interpolation_utils import interpmat, interpolation_matrix
 
 from .code_utils import (

--- a/SimPEG/utils/code_utils.py
+++ b/SimPEG/utils/code_utils.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, division, annotations
+from __future__ import annotations
 import types
 from typing import TYPE_CHECKING
 import numpy as np

--- a/SimPEG/utils/counter_utils.py
+++ b/SimPEG/utils/counter_utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from six import string_types
 import time
 import numpy as np
 from functools import wraps
@@ -53,7 +51,7 @@ class Counter(object):
         prop : str
             The property being counted
         """
-        assert isinstance(prop, string_types), "The property must be a string."
+        assert isinstance(prop, str), "The property must be a string."
         if prop not in self._countList:
             self._countList[prop] = 0
         self._countList[prop] += 1
@@ -66,7 +64,7 @@ class Counter(object):
         prop : str
             The property being timed
         """
-        assert isinstance(prop, string_types), "The property must be a string."
+        assert isinstance(prop, str), "The property must be a string."
         if prop not in self._timeList:
             self._timeList[prop] = []
         self._timeList[prop].append(-time.time())
@@ -79,7 +77,7 @@ class Counter(object):
         prop : str
             The property being timed
         """
-        assert isinstance(prop, string_types), "The property must be a string."
+        assert isinstance(prop, str), "The property must be a string."
         assert prop in self._timeList, "The property must already be in the dictionary."
         self._timeList[prop][-1] += time.time()
 

--- a/SimPEG/utils/io_utils/__init__.py
+++ b/SimPEG/utils/io_utils/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
 from .io_utils_general import read_GOCAD_ts, download
 from .io_utils_pf import (
     read_mag3d_ubc,

--- a/SimPEG/utils/io_utils/io_utils_electromagnetics.py
+++ b/SimPEG/utils/io_utils/io_utils_electromagnetics.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 from discretize.utils import mkvc
 import warnings

--- a/SimPEG/utils/io_utils/io_utils_general.py
+++ b/SimPEG/utils/io_utils/io_utils_general.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 
 

--- a/SimPEG/utils/io_utils/io_utils_pf.py
+++ b/SimPEG/utils/io_utils/io_utils_pf.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 from discretize.utils import mkvc
 from ...utils.code_utils import deprecate_method

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 import scipy.ndimage as ndi
 import scipy.sparse as sp

--- a/SimPEG/utils/solver_utils.py
+++ b/SimPEG/utils/solver_utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 from scipy.sparse import linalg
 from .mat_utils import mkvc

--- a/examples/04-dcip/plot_dc_analytic.py
+++ b/examples/04-dcip/plot_dc_analytic.py
@@ -5,7 +5,6 @@ DC Analytic Dipole
 Comparison of the analytic and numerical solution for a direct current
 resistivity dipole in 3D.
 """
-from __future__ import print_function
 import discretize
 from SimPEG import utils
 import numpy as np

--- a/examples/20-published/plot_schenkel_morrison_casing.py
+++ b/examples/20-published/plot_schenkel_morrison_casing.py
@@ -44,7 +44,6 @@ If you would use this example for a code comparison, or build upon it,
 a citation would be much appreciated!
 
 """
-from __future__ import print_function
 import matplotlib.pylab as plt
 import numpy as np
 import discretize

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-
 """SimPEG: Simulation and Parameter Estimation in Geophysics
 
 SimPEG is a python package for simulation and gradient based

--- a/tests/base/test_Fields.py
+++ b/tests/base/test_Fields.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 
 import discretize

--- a/tests/base/test_Props.py
+++ b/tests/base/test_Props.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import unittest
 import numpy as np
 import pickle

--- a/tests/base/test_coordutils.py
+++ b/tests/base/test_coordutils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 from SimPEG import utils

--- a/tests/base/test_data_misfit.py
+++ b/tests/base/test_data_misfit.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import numpy as np

--- a/tests/base/test_joint.py
+++ b/tests/base/test_joint.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import numpy as np

--- a/tests/base/test_objective_function.py
+++ b/tests/base/test_objective_function.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-
 import numpy as np
 import scipy.sparse as sp
 import unittest

--- a/tests/base/test_optimizers.py
+++ b/tests/base/test_optimizers.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 from SimPEG import Solver
 from discretize import TensorMesh

--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -1,8 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import numpy as np
 import unittest
 

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 import scipy.sparse as sp

--- a/tests/dask/test_DC_jvecjtvecadj_dask.py
+++ b/tests/dask/test_DC_jvecjtvecadj_dask.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 import discretize

--- a/tests/dask/test_IP_jvecjtvecadj_dask.py
+++ b/tests/dask/test_IP_jvecjtvecadj_dask.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import discretize
 import numpy as np

--- a/tests/dask/test_grav_inversion_linear.py
+++ b/tests/dask/test_grav_inversion_linear.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 import discretize

--- a/tests/dask/test_mag_MVI_Octree.py
+++ b/tests/dask/test_mag_MVI_Octree.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import SimPEG.dask
 from SimPEG import (

--- a/tests/dask/test_mag_inversion_linear_Octree.py
+++ b/tests/dask/test_mag_inversion_linear_Octree.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import SimPEG.dask
 from SimPEG import (

--- a/tests/dask/test_mag_nonLinear_Amplitude.py
+++ b/tests/dask/test_mag_nonLinear_Amplitude.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 import SimPEG.dask
 from SimPEG import (

--- a/tests/em/fdem/forward/test_FDEM_analytics.py
+++ b/tests/em/fdem/forward/test_FDEM_analytics.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 
 import discretize

--- a/tests/em/fdem/forward/test_FDEM_sources.py
+++ b/tests/em/fdem/forward/test_FDEM_sources.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import warnings
 

--- a/tests/em/fdem/inverse/adjoint/test_FDEM_adjointEB.py
+++ b/tests/em/fdem/inverse/adjoint/test_FDEM_adjointEB.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 from scipy.constants import mu_0

--- a/tests/em/fdem/inverse/adjoint/test_FDEM_adjointHJ.py
+++ b/tests/em/fdem/inverse/adjoint/test_FDEM_adjointHJ.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 from scipy.constants import mu_0

--- a/tests/em/fdem/inverse/derivs/test_FDEM_derivs.py
+++ b/tests/em/fdem/inverse/derivs/test_FDEM_derivs.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 from SimPEG import tests

--- a/tests/em/nsem/forward/test_AnalyticFunctionVsAppResPhs.py
+++ b/tests/em/nsem/forward/test_AnalyticFunctionVsAppResPhs.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 from SimPEG.electromagnetics import natural_source as nsem
 from SimPEG import discretize

--- a/tests/em/nsem/forward/test_Problem1D_AnalyticVsNumeric.py
+++ b/tests/em/nsem/forward/test_Problem1D_AnalyticVsNumeric.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 from SimPEG import mkvc
 from SimPEG.electromagnetics import natural_source as nsem

--- a/tests/em/nsem/forward/test_Problem3D_VsAnalyticSolution.py
+++ b/tests/em/nsem/forward/test_Problem3D_VsAnalyticSolution.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import unittest
 from scipy.constants import mu_0
 

--- a/tests/em/nsem/inversion/test_Problem1D_Adjoint.py
+++ b/tests/em/nsem/inversion/test_Problem1D_Adjoint.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import numpy as np
 import unittest
 from scipy.constants import mu_0

--- a/tests/em/nsem/inversion/test_Problem1D_Derivs.py
+++ b/tests/em/nsem/inversion/test_Problem1D_Derivs.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import unittest
 import numpy as np
 from scipy.constants import mu_0

--- a/tests/em/nsem/inversion/test_Problem3D_Adjoint.py
+++ b/tests/em/nsem/inversion/test_Problem3D_Adjoint.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 import numpy as np
 import unittest
 from SimPEG.electromagnetics import natural_source as nsem

--- a/tests/em/nsem/inversion/test_Problem3D_Derivs.py
+++ b/tests/em/nsem/inversion/test_Problem3D_Derivs.py
@@ -1,7 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-from __future__ import division
-
 # Test functions
 import unittest
 import numpy as np

--- a/tests/em/static/test_DCIP_io_utils.py
+++ b/tests/em/static/test_DCIP_io_utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # import matplotlib
 # matplotlib.use('Agg')
 import unittest

--- a/tests/em/static/test_DC_1D_jvecjtvecadj.py
+++ b/tests/em/static/test_DC_1D_jvecjtvecadj.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 from discretize import TensorMesh

--- a/tests/em/static/test_DC_2D_jvecjtvecadj.py
+++ b/tests/em/static/test_DC_2D_jvecjtvecadj.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 import discretize

--- a/tests/em/static/test_DC_FieldsDipoleFullspace.py
+++ b/tests/em/static/test_DC_FieldsDipoleFullspace.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 
 from discretize import TensorMesh

--- a/tests/em/static/test_DC_FieldsMultipoleFullspace.py
+++ b/tests/em/static/test_DC_FieldsMultipoleFullspace.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 
 from discretize import TensorMesh

--- a/tests/em/static/test_DC_Utils.py
+++ b/tests/em/static/test_DC_Utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # import matplotlib
 # matplotlib.use('Agg')
 import unittest

--- a/tests/em/static/test_DC_analytic.py
+++ b/tests/em/static/test_DC_analytic.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import discretize
 

--- a/tests/em/static/test_DC_jvecjtvecadj.py
+++ b/tests/em/static/test_DC_jvecjtvecadj.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 import discretize

--- a/tests/em/static/test_IP_2D_fwd.py
+++ b/tests/em/static/test_IP_2D_fwd.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import discretize
 

--- a/tests/em/static/test_IP_2D_jvecjtvecadj.py
+++ b/tests/em/static/test_IP_2D_jvecjtvecadj.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import discretize
 import numpy as np

--- a/tests/em/static/test_IP_fwd.py
+++ b/tests/em/static/test_IP_fwd.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 
 import numpy as np

--- a/tests/em/static/test_IP_jvecjtvecadj.py
+++ b/tests/em/static/test_IP_jvecjtvecadj.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import discretize
 import numpy as np

--- a/tests/em/static/test_SIP_2D_jvecjtvecadj.py
+++ b/tests/em/static/test_SIP_2D_jvecjtvecadj.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import discretize
 

--- a/tests/em/static/test_SIP_jvecjtvecadj.py
+++ b/tests/em/static/test_SIP_jvecjtvecadj.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import discretize
 from SimPEG import (

--- a/tests/em/static/test_SPjvecjtvecadj.py
+++ b/tests/em/static/test_SPjvecjtvecadj.py
@@ -1,4 +1,4 @@
-# from __future__ import print_function
+#
 # import unittest
 # import numpy as np
 #

--- a/tests/em/tdem/test_TDEM_DerivAdjoint.py
+++ b/tests/em/tdem/test_TDEM_DerivAdjoint.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import unittest
 import numpy as np
 import time

--- a/tests/em/tdem/test_TDEM_DerivAdjoint_RawWaveform.py
+++ b/tests/em/tdem/test_TDEM_DerivAdjoint_RawWaveform.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import unittest
 import numpy as np
 import time

--- a/tests/em/tdem/test_TDEM_crosscheck.py
+++ b/tests/em/tdem/test_TDEM_crosscheck.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import unittest
 import discretize
 

--- a/tests/em/tdem/test_TDEM_forward_Analytic.py
+++ b/tests/em/tdem/test_TDEM_forward_Analytic.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import unittest
 
 import discretize

--- a/tests/em/tdem/test_TDEM_forward_Analytic_RawWaveform.py
+++ b/tests/em/tdem/test_TDEM_forward_Analytic_RawWaveform.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import unittest
 
 import discretize

--- a/tests/em/tdem/test_TDEM_inductive_permeable.py
+++ b/tests/em/tdem/test_TDEM_inductive_permeable.py
@@ -1,4 +1,3 @@
-from __future__ import division, print_function
 import unittest
 
 import discretize

--- a/tests/flow/test_Richards.py
+++ b/tests/flow/test_Richards.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 

--- a/tests/flow/test_Richards_empirical.py
+++ b/tests/flow/test_Richards_empirical.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 
 import numpy as np

--- a/tests/pf/test_gravity_IO.py
+++ b/tests/pf/test_gravity_IO.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 

--- a/tests/pf/test_mag_MVI_Octree.py
+++ b/tests/pf/test_mag_MVI_Octree.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 from SimPEG import (
     directives,

--- a/tests/pf/test_mag_inversion_linear.py
+++ b/tests/pf/test_mag_inversion_linear.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import discretize
 from SimPEG import (

--- a/tests/pf/test_mag_nonLinear_Amplitude.py
+++ b/tests/pf/test_mag_nonLinear_Amplitude.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import numpy as np
 from SimPEG import (
     data,

--- a/tests/pf/test_magnetics_IO.py
+++ b/tests/pf/test_magnetics_IO.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 

--- a/tests/pf/test_sensitivity_PFproblem.py
+++ b/tests/pf/test_sensitivity_PFproblem.py
@@ -1,4 +1,4 @@
-# from __future__ import print_function
+#
 # import unittest
 # import numpy as np
 # #from simpegPF import BaseMag

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 

--- a/tests/utils/test_mat_utils.py
+++ b/tests/utils/test_mat_utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import numpy as np
 from scipy.sparse.linalg import eigsh

--- a/tutorials/02-linear_inversion/plot_inv_2_inversion_irls.py
+++ b/tutorials/02-linear_inversion/plot_inv_2_inversion_irls.py
@@ -16,7 +16,6 @@ least-squares approach. For this tutorial, we focus on the following:
 
 """
 
-from __future__ import print_function
 
 import numpy as np
 import matplotlib.pyplot as plt


### PR DESCRIPTION
As in the title, removes the unnecessary future imports and the six module from when we used to support python 2 and 3 simultaneously. 