### PR TITLE
fix alpha multipliers in `PGI`

### DIFF
--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -5,8 +5,7 @@ import warnings
 
 import numpy as np
 import scipy.sparse as sp
-from SimPEG.utils.code_utils import (deprecate_property,
-                                     validate_ndarray_with_shape)
+from SimPEG.utils.code_utils import deprecate_property, validate_ndarray_with_shape
 
 from ..maps import IdentityMap, Wires
 from ..objective_function import ComboObjectiveFunction

--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -9,7 +9,7 @@ from SimPEG.utils.code_utils import deprecate_property, validate_ndarray_with_sh
 
 from ..maps import IdentityMap, Wires
 from ..objective_function import ComboObjectiveFunction
-from ..utils import Identity, mkvc, sdiag, timeIt
+from ..utils import Identity, mkvc, sdiag, timeIt, validate_float
 from .base import RegularizationMesh, Smallness, WeightedLeastSquares
 
 ###############################################################################
@@ -756,14 +756,7 @@ class PGI(ComboObjectiveFunction):
 
     @alpha_pgi.setter
     def alpha_pgi(self, value):
-        if value is None:
-            value = 1.0
-        try:
-            value = float(value)
-        except (ValueError, TypeError):
-            raise TypeError(f"alpha_pgi must be a real number, saw type{type(value)}")
-        if value < 0:
-            raise ValueError(f"alpha_pgi must be non-negative, not {value}")
+        value = validate_float("alpha_pgi", value, min_val=0.0)
         self._alpha_pgi = value
         self._multipliers[0] = value
 

--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -692,7 +692,7 @@ class PGI(ComboObjectiveFunction):
         gmm=None,
         wiresmap=None,
         maplist=None,
-        alpha_pgi=None,
+        alpha_pgi=1.0,
         approx_hessian=True,
         approx_gradient=True,
         approx_eval=True,
@@ -756,11 +756,14 @@ class PGI(ComboObjectiveFunction):
 
     @alpha_pgi.setter
     def alpha_pgi(self, value):
-        if isinstance(value, (float, int)) and value < 0:
-            raise ValueError(
-                "Input 'alpha_pgi' value must me of type float > 0"
-                f"Value {value} of type {type(value)} provided"
-            )
+        if value is None:
+            value = 1.0
+        try:
+            value = float(value)
+        except (ValueError, TypeError):
+            raise TypeError(f"alpha_pgi must be a real number, saw type{type(value)}")
+        if value < 0:
+            raise ValueError(f"alpha_pgi must be non-negative, not {value}")
         self._alpha_pgi = value
         self._multipliers[0] = value
 

--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -1,24 +1,17 @@
 from __future__ import annotations
-import numpy as np
-import scipy.sparse as sp
-import warnings
 
 import copy
-from ..utils import (
-    sdiag,
-    mkvc,
-    timeIt,
-    Identity,
-)
+import warnings
+
+import numpy as np
+import scipy.sparse as sp
+from SimPEG.utils.code_utils import (deprecate_property,
+                                     validate_ndarray_with_shape)
+
 from ..maps import IdentityMap, Wires
 from ..objective_function import ComboObjectiveFunction
-from .base import (
-    WeightedLeastSquares,
-    RegularizationMesh,
-    Smallness,
-)
-
-from SimPEG.utils.code_utils import deprecate_property, validate_ndarray_with_shape
+from ..utils import Identity, mkvc, sdiag, timeIt
+from .base import RegularizationMesh, Smallness, WeightedLeastSquares
 
 ###############################################################################
 #                                                                             #
@@ -691,7 +684,6 @@ class PGI(ComboObjectiveFunction):
         self,
         mesh,
         gmmref,
-        alpha_s=None,
         alpha_x=None,
         alpha_y=None,
         alpha_z=None,
@@ -754,6 +746,7 @@ class PGI(ComboObjectiveFunction):
 
         super().__init__(objfcts=objfcts)
         self.reference_model_in_smooth = reference_model_in_smooth
+        self.alpha_pgi = alpha_pgi
 
     @property
     def alpha_pgi(self):

--- a/examples/10-pgi/plot_inv_0_PGI_Linear_1D.py
+++ b/examples/10-pgi/plot_inv_0_PGI_Linear_1D.py
@@ -13,19 +13,19 @@ We explore it through the UBC linear example.
 #####################
 
 import discretize as Mesh
+import matplotlib.pyplot as plt
+import numpy as np
 from SimPEG import (
-    simulation,
-    maps,
     data_misfit,
     directives,
-    optimization,
-    regularization,
     inverse_problem,
     inversion,
+    maps,
+    optimization,
+    regularization,
+    simulation,
     utils,
 )
-import numpy as np
-import matplotlib.pyplot as plt
 
 # Random seed for reproductibility
 np.random.seed(1)
@@ -58,7 +58,7 @@ mtrue[mesh.cell_centers_x > 0.2] = 1.0
 mtrue[mesh.cell_centers_x > 0.35] = 0.0
 t = (mesh.cell_centers_x - 0.65) / 0.25
 indx = np.abs(t) < 1
-mtrue[indx] = -(((1 - t ** 2.0) ** 2.0)[indx])
+mtrue[indx] = -(((1 - t**2.0) ** 2.0)[indx])
 
 mtrue = np.zeros(mesh.nC)
 mtrue[mesh.cell_centers_x > 0.3] = 1.0
@@ -109,7 +109,7 @@ clf.fit(mtrue.reshape(-1, 1))
 reg = regularization.PGI(
     gmmref=clf,
     mesh=mesh,
-    alpha_s=1.0,
+    alpha_pgi=1.0,
     alpha_x=1.0,
 )
 

--- a/tests/base/test_pgi_regularization.py
+++ b/tests/base/test_pgi_regularization.py
@@ -1,15 +1,13 @@
-import numpy as np
 import unittest
+
 import discretize
+import numpy as np
+from pymatsolver import SolverLU
+from scipy.sparse.linalg import LinearOperator, bicgstab, spsolve
+from scipy.stats import multivariate_normal
 from SimPEG import regularization
 from SimPEG.maps import Wires
-from SimPEG.utils import (
-    mkvc,
-    WeightedGaussianMixture,
-)
-from scipy.stats import multivariate_normal
-from scipy.sparse.linalg import spsolve, LinearOperator, bicgstab
-from pymatsolver import SolverLU
+from SimPEG.utils import WeightedGaussianMixture, mkvc
 
 
 class TestPGI(unittest.TestCase):
@@ -80,7 +78,6 @@ class TestPGI(unittest.TestCase):
             clf,
             approx_gradient=True,
             alpha_x=0.0,
-            alpha_s=0.0,
             wiresmap=self.wires,
             weights_list=self.cell_weights_list,
         )
@@ -190,7 +187,6 @@ class TestPGI(unittest.TestCase):
             clf,
             approx_gradient=True,
             alpha_x=0.0,
-            alpha_s=0.0,
             wiresmap=self.wires,
             weights_list=self.cell_weights_list,
         )
@@ -296,7 +292,6 @@ class TestPGI(unittest.TestCase):
             clf,
             approx_gradient=True,
             alpha_x=0.0,
-            alpha_s=0.0,
             wiresmap=self.wires,
             weights_list=self.cell_weights_list,
         )
@@ -402,7 +397,6 @@ class TestPGI(unittest.TestCase):
             clf,
             approx_gradient=True,
             alpha_x=0.0,
-            alpha_s=0.0,
             wiresmap=self.wires,
             weights_list=self.cell_weights_list,
         )


### PR DESCRIPTION
- small bug where `alpha_pgi` was not taken into account in the definition
- removed unused `alpha_s` argument
- the setter needed to be reworked; use `validate_float` instead (if `None` was passed, which was the default, then we ended up with `None` as multiplier)
- fix example that called alpha_s instead of alpha_pgi