### PR TITLE
Fix for 2D_CC boundary conditions

### DIFF
--- a/SimPEG/electromagnetics/static/resistivity/fields_2d.py
+++ b/SimPEG/electromagnetics/static/resistivity/fields_2d.py
@@ -164,6 +164,9 @@ class Fields2DCellCentered(Fields2D):
     def _j(self, phiSolution, source_list):
         phi_ky = phiSolution
         sim = self.simulation
+        if sim.bc_type == 'Dirichlet':
+            phi = self._phi(phi_ky, source_list)
+            return sim.MfRhoI @ (sim.Grad @ phi)
         j = np.zeros((sim.mesh.n_faces, phi_ky.shape[1]))
         for i, (ky, w) in enumerate(zip(sim._quad_points, sim._quad_weights)):
             j += sim.MfRhoI * (sim.Grad @ phi_ky[..., i] - sim._MBC[ky] @ phi_ky[..., i]) * w
@@ -172,6 +175,9 @@ class Fields2DCellCentered(Fields2D):
     def _e(self, phiSolution, source_list):
         phi_ky = phiSolution
         sim = self.simulation
+        if sim.bc_type == 'Dirichlet':
+            phi = self._phi(phi_ky, source_list)
+            return sim.MfI @ (sim.Grad @ phi)
         e = np.zeros((sim.mesh.n_faces, phi_ky.shape[1]))
         for i, (ky, w) in enumerate(zip(sim._quad_points, sim._quad_weights)):
             e += sim.MfI * (sim.Grad @ phi_ky[..., i] - sim._MBC[ky] @ phi_ky[..., i]) * w

--- a/SimPEG/electromagnetics/static/resistivity/fields_2d.py
+++ b/SimPEG/electromagnetics/static/resistivity/fields_2d.py
@@ -162,14 +162,20 @@ class Fields2DCellCentered(Fields2D):
             raise Exception("Field type must be phi, e, j")
 
     def _j(self, phiSolution, source_list):
-        phi = self._phi(phiSolution, source_list)
+        phi_ky = phiSolution
         sim = self.simulation
-        return sim.MfRhoI * sim.Grad * phi
+        j = np.zeros((sim.mesh.n_faces, phi_ky.shape[1]))
+        for i, (ky, w) in enumerate(zip(sim._quad_points, sim._quad_weights)):
+            j += sim.MfRhoI * (sim.Grad @ phi_ky[..., i] - sim._MBC[ky] @ phi_ky[..., i]) * w
+        return j
 
     def _e(self, phiSolution, source_list):
-        phi = self._phi(phiSolution, source_list)
+        phi_ky = phiSolution
         sim = self.simulation
-        return sim.MfI * sim.Grad * phi
+        e = np.zeros((sim.mesh.n_faces, phi_ky.shape[1]))
+        for i, (ky, w) in enumerate(zip(sim._quad_points, sim._quad_weights)):
+            e += sim.MfI * (sim.Grad @ phi_ky[..., i] - sim._MBC[ky] @ phi_ky[..., i]) * w
+        return e
 
     def _charge(self, phiSolution, source_list):
         """

--- a/tests/em/static/test_DC_2D_analytic.py
+++ b/tests/em/static/test_DC_2D_analytic.py
@@ -378,6 +378,25 @@ class DCProblemAnalyticTests_DPField(unittest.TestCase):
         field[:, "charge_density"]
         print("got fields CC")
 
+    def test_Simulation2DCellCentered_Dirichlet(self, tolerance=0.05):
+        simulation = dc.simulation_2d.Simulation2DCellCentered(
+            self.mesh,
+            survey=self.survey,
+            sigma=self.sigma,
+            solver=self.solver,
+            bc_type='Dirichlet'
+        )
+        field = simulation.fields()
+
+        # just test if we can get each property of the field
+        field[:, "phi"][:, 0]
+        field[:, "j"]
+        field[:, "e"]
+        field[:, "charge"]
+        field[:, "charge_density"]
+        print("got fields CC")
+
+
     def test_Simulation2DNodal(self, tolerance=0.05):
 
         simulation = dc.simulation_2d.Simulation2DNodal(


### PR DESCRIPTION
Takes the boundary condition into account when calculating the `e` and `j` fields for 2D cell_centered dc resistivity.
address #1033.