### PR TITLE
Rename variables to avoid shadowing builtins

### DIFF
--- a/SimPEG/potential_fields/base.py
+++ b/SimPEG/potential_fields/base.py
@@ -250,7 +250,7 @@ class BaseEquivalentSourceLayerSimulation(BasePFSimulation):
         self._unique_inv = None
 
 
-def progress(iter, prog, final):
+def progress(iteration, prog, final):
     """Progress (% complete) for constructing sensitivity matrix
 
     Parameters
@@ -267,7 +267,7 @@ def progress(iter, prog, final):
     float
         % completed
     """
-    arg = np.floor(float(iter) / float(final) * 10.0)
+    arg = np.floor(float(iteration) / float(final) * 10.0)
 
     if arg > prog:
 

--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -190,7 +190,7 @@ class PGIsmallness(Smallness):
             )
 
         if isinstance(maplist, list) and not all(
-            isinstance(map, IdentityMap) for map in maplist
+            isinstance(m, IdentityMap) for m in maplist
         ):
             raise ValueError(
                 f"Attribute 'maplist' should be a list of maps or None.{type(maplist)} was given."
@@ -737,7 +737,7 @@ class PGI(ComboObjectiveFunction):
         if not isinstance(weights_list, list):
             weights_list = [weights_list] * len(self.maplist)
 
-        for map, wire, weights in zip(self.maplist, self.wiresmap.maps, weights_list):
+        for model_map, wire, weights in zip(self.maplist, self.wiresmap.maps, weights_list):
             objfcts += [
                 WeightedLeastSquares(
                     alpha_s=0.0,
@@ -748,7 +748,7 @@ class PGI(ComboObjectiveFunction):
                     alpha_yy=alpha_yy,
                     alpha_zz=alpha_zz,
                     mesh=self.regularization_mesh,
-                    mapping=map * wire[1],
+                    mapping=model_map * wire[1],
                     weights=weights,
                     **kwargs,
                 )

--- a/SimPEG/utils/code_utils.py
+++ b/SimPEG/utils/code_utils.py
@@ -774,10 +774,10 @@ def validate_string(property_name, var, string_list=None, case_sensitive=False):
         if not case_sensitive:
             test_var = var.casefold()
             # also fold the string_list for comparison
-            def fold_input(input):
-                if isinstance(input, (list, tuple)):
-                    return [fold_input(x) for x in input]
-                return input.casefold()
+            def fold_input(input_variable):
+                if isinstance(input_variable, (list, tuple)):
+                    return [fold_input(x) for x in input_variable]
+                return input_variable.casefold()
 
             test_string_list = fold_input(string_list)
         else:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/base/test_validators.py
+++ b/tests/base/test_validators.py
@@ -364,26 +364,26 @@ def test_direction_validation():
     )
 
     # should normalize and return arbitrary array
-    dir = [1, 2, 3]
+    direction = [1, 2, 3]
     # should pass an normalized array through
     np.testing.assert_equal(
-        validate_direction("orient", dir), dir / np.linalg.norm(dir)
+        validate_direction("orient", direction), direction / np.linalg.norm(direction)
     )
 
     # dimensions should be respected for defaults
     np.testing.assert_equal(validate_direction("orient", "x", dim=1), np.r_[1.0])
     np.testing.assert_equal(validate_direction("orient", "x", dim=2), np.r_[1.0, 0.0])
     np.testing.assert_equal(validate_direction("orient", "y", dim=2), np.r_[0.0, 1.0])
-    dir = [
+    direction = [
         2.0,
     ]
     np.testing.assert_equal(
-        validate_direction("orient", dir, dim=1), dir / np.linalg.norm(dir)
+        validate_direction("orient", direction, dim=1), direction / np.linalg.norm(direction)
     )
 
-    dir = [2.0, 1.0]
+    direction = [2.0, 1.0]
     np.testing.assert_equal(
-        validate_direction("orient", dir, dim=2), dir / np.linalg.norm(dir)
+        validate_direction("orient", direction, dim=2), direction / np.linalg.norm(direction)
     )
 
     # should error on incorrect dimension and passed array

--- a/tests/em/em1d/__init__.py
+++ b/tests/em/em1d/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/em/fdem/forward/__init__.py
+++ b/tests/em/fdem/forward/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/em/fdem/inverse/adjoint/__init__.py
+++ b/tests/em/fdem/inverse/adjoint/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/em/fdem/inverse/derivs/__init__.py
+++ b/tests/em/fdem/inverse/derivs/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/em/nsem/forward/__init__.py
+++ b/tests/em/nsem/forward/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/em/nsem/inversion/__init__.py
+++ b/tests/em/nsem/inversion/__init__.py
@@ -4,9 +4,9 @@ import unittest
 
 if __name__ == "__main__":
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/em/static/__init__.py
+++ b/tests/em/static/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/em/tdem/__init__.py
+++ b/tests/em/tdem/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/em/utils/__init__.py
+++ b/tests/em/utils/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/em/vrm/__init__.py
+++ b/tests/em/vrm/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/examples/test_examples_1.py
+++ b/tests/examples/test_examples_1.py
@@ -32,8 +32,8 @@ def create_runner(script_path):
 
 
 # Programatically add tests to Examples
-for dir in dirs_to_test:
-    script_dir = os.path.sep.join(example_dir + [dir])
+for directory in dirs_to_test:
+    script_dir = os.path.sep.join(example_dir + [directory])
     os.chdir(script_dir)
     scripts = glob.glob(os.path.sep.join([script_dir] + ["*.py"]))
     scripts.sort()

--- a/tests/examples/test_examples_2.py
+++ b/tests/examples/test_examples_2.py
@@ -32,8 +32,8 @@ def create_runner(script_path):
 
 
 # Programatically add tests to Examples
-for dir in dirs_to_test:
-    script_dir = os.path.sep.join(example_dir + [dir])
+for directory in dirs_to_test:
+    script_dir = os.path.sep.join(example_dir + [directory])
     os.chdir(script_dir)
     scripts = glob.glob(os.path.sep.join([script_dir] + ["*.py"]))
     scripts.sort()

--- a/tests/examples/test_examples_3.py
+++ b/tests/examples/test_examples_3.py
@@ -32,8 +32,8 @@ def create_runner(script_path):
 
 
 # Programatically add tests to Examples
-for dir in dirs_to_test:
-    script_dir = os.path.sep.join(example_dir + [dir])
+for directory in dirs_to_test:
+    script_dir = os.path.sep.join(example_dir + [directory])
     os.chdir(script_dir)
     scripts = glob.glob(os.path.sep.join([script_dir] + ["*.py"]))
     scripts.sort()

--- a/tests/examples/test_tutorials_1.py
+++ b/tests/examples/test_tutorials_1.py
@@ -37,8 +37,8 @@ def create_runner(script_path):
 
 
 # Programatically add tests to Examples
-for dir in dirs_to_test:
-    script_dir = os.path.sep.join(example_dir + [dir])
+for directory in dirs_to_test:
+    script_dir = os.path.sep.join(example_dir + [directory])
     os.chdir(script_dir)
     scripts = glob.glob(os.path.sep.join([script_dir] + ["*.py"]))
     scripts.sort()

--- a/tests/examples/test_tutorials_2.py
+++ b/tests/examples/test_tutorials_2.py
@@ -32,8 +32,8 @@ def create_runner(script_path):
 
 
 # Programatically add tests to Examples
-for dir in dirs_to_test:
-    script_dir = os.path.sep.join(example_dir + [dir])
+for directory in dirs_to_test:
+    script_dir = os.path.sep.join(example_dir + [directory])
     os.chdir(script_dir)
     scripts = glob.glob(os.path.sep.join([script_dir] + ["*.py"]))
     scripts.sort()

--- a/tests/examples/test_tutorials_3.py
+++ b/tests/examples/test_tutorials_3.py
@@ -40,8 +40,8 @@ def create_runner(script_path):
 
 
 # Programatically add tests to Examples
-for dir in dirs_to_test:
-    script_dir = os.path.sep.join(example_dir + [dir])
+for directory in dirs_to_test:
+    script_dir = os.path.sep.join(example_dir + [directory])
     os.chdir(script_dir)
     scripts = glob.glob(os.path.sep.join([script_dir] + ["*.py"]))
     scripts.sort()

--- a/tests/flow/__init__.py
+++ b/tests/flow/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/pf/__init__.py
+++ b/tests/pf/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 

--- a/tests/seis/__init__.py
+++ b/tests/seis/__init__.py
@@ -3,9 +3,9 @@ if __name__ == "__main__":
     import unittest
 
     test_file_strings = glob.glob("test_*.py")
-    module_strings = [str[0 : len(str) - 3] for str in test_file_strings]
+    module_strings = [s[0 : len(s) - 3] for s in test_file_strings]
     suites = [
-        unittest.defaultTestLoader.loadTestsFromName(str) for str in module_strings
+        unittest.defaultTestLoader.loadTestsFromName(s) for s in module_strings
     ]
     testSuite = unittest.TestSuite(suites)
 


### PR DESCRIPTION
Fix some `flake8` `A00*` warnings that warn the usage of variables and
arguments names that shadow some builtins variables, functions and
modules.
