### PR TITLE
Run flake8 in CI against a selection of rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 STYLE_CHECK_FILES=SimPEG examples tutorials tests
 
-# Define flake8 warnings that should be catched for now.
+# Define flake8 warnings that shouldn't be catched for now.
 # Every time a new warning is solved througout the entire project, it should be
-# added to this list.
+# removed to this list.
 # This list is only meant to be used in the flake-permissive target and it's
-# a temprary solution until every flake8 warning is solved in SimPEG
-FLAKE8_SELECT=W605,D301
+# a temprary solution until every flake8 warning is solved in SimPEG.
+# The first set of rules (up to W504) are the default ignored ones by flake8.
+# Since we are using the --ignore option we are overriding them. They are
+# included in the list so we keep ignoring them while running the
+# flake-permissive target.
+FLAKE8_IGNORE=E121,E123,E126,E226,E24,E704,W503,W504,A001,A002,A003,B001,B006,B007,B008,B009,B015,B017,B023,D100,D101,D102,D103,D104,D105,D107,D200,D201,D202,D205,D208,D209,D210,D211,D300,D400,D401,D402,D403,D412,D414,E301,E302,E306,E401,E402,E711,E712,E722,E731,F401,F403,F405,F522,F523,F524,F541,F811,F821,F841,RST201,RST203,RST206,RST210,RST212,RST213,RST215,RST219,RST301,RST303,RST304,RST307,RST499,W291,W293
 
 
 .PHONY: build coverage lint graphs tests docs check black flake
@@ -45,4 +49,4 @@ flake:
 
 flake-permissive:
 	flake8 --version
-	flake8 ${FLAKE8_OPTS} --select ${FLAKE8_SELECT} ${STYLE_CHECK_FILES}
+	flake8 ${FLAKE8_OPTS} --ignore ${FLAKE8_IGNORE} ${STYLE_CHECK_FILES}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 STYLE_CHECK_FILES=SimPEG examples tutorials tests
 
+# Define flake8 warnings that should be catched for now.
+# Every time a new warning is solved througout the entire project, it should be
+# added to this list.
+# This list is only meant to be used in the flake-permissive target and it's
+# a temprary solution until every flake8 warning is solved in SimPEG
+FLAKE8_SELECT=W605,D301
+
+
 .PHONY: build coverage lint graphs tests docs check black flake
 
 build:
@@ -33,4 +41,8 @@ black:
 
 flake:
 	flake8 --version
-	flake8 ${STYLE_CHECK_FILES}
+	flake8 ${FLAKE8_OPTS} ${STYLE_CHECK_FILES}
+
+flake-permissive:
+	flake8 --version
+	flake8 ${FLAKE8_OPTS} --select ${FLAKE8_SELECT} ${STYLE_CHECK_FILES}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,11 +29,11 @@ stages:
         - script: |
             pip install -r requirements_style.txt
           displayName: "Install dependencies to run the checks"
-
         - script: make black
           displayName: "Run black"
+
     - job:
-      displayName: Run style checks with flake8
+      displayName: Run (permissive) style checks with flake8
       pool:
         vmImage: ubuntu-latest
       variables:
@@ -42,8 +42,20 @@ stages:
         - script: |
             pip install -r requirements_style.txt
           displayName: "Install dependencies to run the checks"
+        - script: make flake-permissive
+          displayName: "Run flake8"
 
-        - script: make flake
+    - job:
+      displayName: Run style checks with flake8 (allowed to fail)
+      pool:
+        vmImage: ubuntu-latest
+      variables:
+        python.version: '3.7'
+      steps:
+        - script: |
+            pip install -r requirements_style.txt
+          displayName: "Install dependencies to run the checks"
+        - script: FLAKE8_OPTS="--exit-zero" make flake
           displayName: "Run flake8"
 
 - stage: Testing

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,13 +60,12 @@ stages:
 
 - stage: Testing
   dependsOn: StyleChecks
-  condition: ne(dependencies.StyleChecks.result, 'Cancelled')
   jobs:
     - template: ./.azure-pipelines/matrix.yml
 
 - stage: Deploy
   dependsOn: Testing
-  condition: and(in(dependencies.Testing.result, 'Succeeded', 'SucceededWithIssues'), startsWith(variables['build.sourceBranch'], 'refs/tags/'))
+  condition: startsWith(variables['build.sourceBranch'], 'refs/tags/')
   jobs:
     - job:
       displayName: Deploy Docs and source


### PR DESCRIPTION
Create new `flake-permissive` target in Makefile. The new target runs `flake8`
checking if only a selection of rules are being violated. It's being added with
the intention of start catching `flake8` rules that have already been solved
throughout the entire SimPEG. This new rule should be temporary until every
`flake8` rule has been solved. Make Azure to run two `flake8` checks: the
`flake-permissive` target (that checks only of a selection of flake rules) and
the `flake` target but allowing it to fail (it returns exit code zero even if
some rules are being violated).
