### PR TITLE
Flexible dc boundary

### DIFF
--- a/SimPEG/electromagnetics/static/resistivity/simulation_2d.py
+++ b/SimPEG/electromagnetics/static/resistivity/simulation_2d.py
@@ -10,6 +10,7 @@ from ....utils import (
     validate_type,
     validate_string,
     validate_integer,
+    validate_active_indices,
 )
 from ....base import BaseElectricalPDESimulation
 from ....data import Data
@@ -41,12 +42,14 @@ class BaseDCSimulation2D(BaseElectricalPDESimulation):
         miniaturize=False,
         do_trap=False,
         fix_Jmatrix=False,
+        surface_faces=None,
         **kwargs,
     ):
         super().__init__(mesh=mesh, survey=survey, **kwargs)
         self.nky = nky
         self.storeJ = storeJ
         self.fix_Jmatrix = fix_Jmatrix
+        self.surface_faces = surface_faces
 
         do_trap = validate_type("do_trap", do_trap, bool)
         if not do_trap:
@@ -183,6 +186,27 @@ class BaseDCSimulation2D(BaseElectricalPDESimulation):
     @fix_Jmatrix.setter
     def fix_Jmatrix(self, value):
         self._fix_Jmatrix = validate_type("fix_Jmatrix", value, bool)
+
+    @property
+    def surface_faces(self):
+        """Array defining which faces to interpret as surfaces of Neumann boundary
+
+        DC problems will always enforce a Neumann boundary on surface interfaces.
+        The default (available on semi-structured grids) assumes the top interface
+        is the surface.
+
+        Returns
+        -------
+        None or numpy.ndarray of bool
+        """
+        return self._surface_faces
+
+    @surface_faces.setter
+    def surface_faces(self, value):
+        if value is not None:
+            n_bf = self.mesh.boundary_faces.shape[0]
+            value = validate_active_indices("surface_faces", value, n_bf)
+        self._surface_faces = value
 
     def fields(self, m=None):
         if self.verbose:
@@ -555,17 +579,20 @@ class Simulation2DCellCentered(BaseDCSimulation2D):
             r_hat = r_vec / r[:, None]
             r_dot_n = np.einsum("ij,ij->i", r_hat, boundary_normals)
 
-            # determine faces that are on the sides and bottom of the mesh...
-            if mesh._meshType.lower() == "tree":
-                not_top = boundary_faces[:, -1] != top_v
+            if self.surface_faces is None:
+                # determine faces that are on the sides and bottom of the mesh...
+                if mesh._meshType.lower() == "tree":
+                    not_top = boundary_faces[:, -1] != top_v
+                else:
+                    # mesh faces are ordered, faces_x, faces_y, faces_z so...
+                    is_b = make_boundary_bool(mesh.shape_faces_y)
+                    is_t = np.zeros(mesh.shape_faces_y, dtype=bool, order="F")
+                    is_t[:, -1] = True
+                    is_t = is_t.reshape(-1, order="F")[is_b]
+                    not_top = np.ones(boundary_faces.shape[0], dtype=bool)
+                    not_top[-len(is_t) :] = ~is_t
             else:
-                # mesh faces are ordered, faces_x, faces_y, faces_z so...
-                is_b = make_boundary_bool(mesh.shape_faces_y)
-                is_t = np.zeros(mesh.shape_faces_y, dtype=bool, order="F")
-                is_t[:, -1] = True
-                is_t = is_t.reshape(-1, order="F")[is_b]
-                not_top = np.zeros(boundary_faces.shape[0], dtype=bool)
-                not_top[-len(is_t) :] = ~is_t
+                not_top = ~self.surface_faces
 
             # use the exponentialy scaled modified bessel function of second kind,
             # (the division will cancel out the scaling)
@@ -589,12 +616,11 @@ class Simulation2DNodal(BaseDCSimulation2D):
     fieldsPair_fwd = Fields3DNodal
     _gradT = None
 
-    def __init__(self, mesh, survey=None, bc_type="Robin", surface_faces=None, **kwargs):
+    def __init__(self, mesh, survey=None, bc_type="Robin", **kwargs):
         super().__init__(mesh=mesh, survey=survey, **kwargs)
         self.solver_opts["is_symmetric"] = True
         self.solver_opts["is_positive_definite"] = True
         self.bc_type = bc_type
-        self.surface_faces = surface_faces
 
     @property
     def bc_type(self):
@@ -729,13 +755,13 @@ class Simulation2DNodal(BaseDCSimulation2D):
                 # determine faces that are on the sides and bottom of the mesh...
                 if mesh._meshType.lower() == "tree":
                     not_top = boundary_faces[:, -1] != top_v
-                elif mesh._meshType.lower() in ['tensor', 'curv']:
+                elif mesh._meshType.lower() in ["tensor", "curv"]:
                     # mesh faces are ordered, faces_x, faces_y, faces_z so...
                     is_b = make_boundary_bool(mesh.shape_faces_y)
                     is_t = np.zeros(mesh.shape_faces_y, dtype=bool, order="F")
                     is_t[:, -1] = True
                     is_t = is_t.reshape(-1, order="F")[is_b]
-                    not_top = np.zeros(boundary_faces.shape[0], dtype=bool)
+                    not_top = np.ones(boundary_faces.shape[0], dtype=bool)
                     not_top[-len(is_t) :] = ~is_t
             else:
                 not_top = ~self.surface_faces

--- a/SimPEG/electromagnetics/static/resistivity/simulation_2d.py
+++ b/SimPEG/electromagnetics/static/resistivity/simulation_2d.py
@@ -583,7 +583,7 @@ class Simulation2DCellCentered(BaseDCSimulation2D):
                 # determine faces that are on the sides and bottom of the mesh...
                 if mesh._meshType.lower() == "tree":
                     not_top = boundary_faces[:, -1] != top_v
-                else:
+                elif mesh._meshType.lower() in ["tensor", "curv"]:
                     # mesh faces are ordered, faces_x, faces_y, faces_z so...
                     is_b = make_boundary_bool(mesh.shape_faces_y)
                     is_t = np.zeros(mesh.shape_faces_y, dtype=bool, order="F")
@@ -591,6 +591,11 @@ class Simulation2DCellCentered(BaseDCSimulation2D):
                     is_t = is_t.reshape(-1, order="F")[is_b]
                     not_top = np.ones(boundary_faces.shape[0], dtype=bool)
                     not_top[-len(is_t) :] = ~is_t
+                else:
+                    raise NotImplementedError(
+                        f"Unable to infer surface boundaries for {type(mesh)}, please "
+                        f"set the `surface_faces` property."
+                    )
             else:
                 not_top = ~self.surface_faces
 
@@ -763,6 +768,11 @@ class Simulation2DNodal(BaseDCSimulation2D):
                     is_t = is_t.reshape(-1, order="F")[is_b]
                     not_top = np.ones(boundary_faces.shape[0], dtype=bool)
                     not_top[-len(is_t) :] = ~is_t
+                else:
+                    raise NotImplementedError(
+                        f"Unable to infer surface boundaries for {type(mesh)}, please "
+                        f"set the `surface_faces` property."
+                    )
             else:
                 not_top = ~self.surface_faces
 

--- a/tests/em/static/test_DC_Boundaries.py
+++ b/tests/em/static/test_DC_Boundaries.py
@@ -1,19 +1,35 @@
 import numpy as np
 import pytest
 import discretize
+from discretize.utils import example_simplex_mesh
 
 import SimPEG.electromagnetics.static.resistivity as dc
+
+
+tens_2d = discretize.TensorMesh([8, 9])
+tens_3d = discretize.TensorMesh([8, 9, 10])
+tree_2d = discretize.TreeMesh([16, 16])
+tree_2d.refine(4)
+tree_3d = discretize.TreeMesh([16, 16, 16])
+tree_3d.refine(4)
+
+simp_2d = discretize.SimplexMesh(*example_simplex_mesh((5, 6)))
+simp_3d = discretize.SimplexMesh(*example_simplex_mesh((4, 5, 6)))
 
 
 @pytest.mark.parametrize(
     "mesh,sim_class,tx_loc",
     [
-        (discretize.TensorMesh([8, 9, 10]), dc.Simulation3DNodal, [0.5, 0.5, 1]),
-        (discretize.TensorMesh([8, 9, 10]), dc.Simulation3DCellCentered, [0.5, 0.5, 1]),
-        (discretize.TensorMesh([8, 9]), dc.Simulation3DNodal, [0.5, 1]),
-        (discretize.TensorMesh([8, 9]), dc.Simulation3DCellCentered, [0.5, 1]),
-        (discretize.TensorMesh([8, 9]), dc.Simulation2DNodal, [0.5, 1]),
-        (discretize.TensorMesh([8, 9]), dc.Simulation2DCellCentered, [0.5, 1]),
+        (tens_3d, dc.Simulation3DNodal, [0.5, 0.5, 1]),
+        (tens_3d, dc.Simulation3DCellCentered, [0.5, 0.5, 1]),
+        (tens_2d, dc.Simulation3DNodal, [0.5, 1]),
+        (tens_2d, dc.Simulation3DCellCentered, [0.5, 1]),
+        (tens_2d, dc.Simulation2DNodal, [0.5, 1]),
+        (tens_2d, dc.Simulation2DCellCentered, [0.5, 1]),
+        (tree_2d, dc.Simulation2DNodal, [0.5, 1]),
+        (tree_2d, dc.Simulation2DCellCentered, [0.5, 1]),
+        (tree_3d, dc.Simulation3DNodal, [0.5, 0.5, 1]),
+        (tree_3d, dc.Simulation3DCellCentered, [0.5, 0.5, 1]),
     ],
 )
 def test_custom_surface(mesh, sim_class, tx_loc):
@@ -31,7 +47,23 @@ def test_custom_surface(mesh, sim_class, tx_loc):
     f1 = sim1.fields()
     f2 = sim2.fields()
 
-    print(bf[sim1.surface_faces])
-    print(bf[sim2.surface_faces])
-
     np.testing.assert_equal(f1[src, "phiSolution"], f2[src, "phiSolution"])
+
+
+@pytest.mark.parametrize(
+    "mesh,sim_class,tx_loc",
+    [
+        (simp_3d, dc.Simulation3DNodal, [0.5, 0.5, 1]),
+        (simp_3d, dc.Simulation3DCellCentered, [0.5, 0.5, 1]),
+        (simp_2d, dc.Simulation2DNodal, [0.5, 1]),
+        (simp_2d, dc.Simulation2DCellCentered, [0.5, 1]),
+    ],
+)
+def test_not_implemented(mesh, sim_class, tx_loc):
+    src = dc.sources.Pole([], location=tx_loc)
+    survey = dc.Survey([src])
+    sigma = np.full(mesh.n_cells, 0.1)
+
+    with pytest.raises(NotImplementedError):
+        sim = sim_class(mesh, survey, sigma=sigma)
+        sim.fields()

--- a/tests/em/static/test_DC_Boundaries.py
+++ b/tests/em/static/test_DC_Boundaries.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pytest
+import discretize
+
+import SimPEG.electromagnetics.static.resistivity as dc
+
+
+@pytest.mark.parametrize(
+    "mesh,sim_class,tx_loc",
+    [
+        (discretize.TensorMesh([8, 9, 10]), dc.Simulation3DNodal, [0.5, 0.5, 1]),
+        (discretize.TensorMesh([8, 9, 10]), dc.Simulation3DCellCentered, [0.5, 0.5, 1]),
+        (discretize.TensorMesh([8, 9]), dc.Simulation3DNodal, [0.5, 1]),
+        (discretize.TensorMesh([8, 9]), dc.Simulation3DCellCentered, [0.5, 1]),
+        (discretize.TensorMesh([8, 9]), dc.Simulation2DNodal, [0.5, 1]),
+        (discretize.TensorMesh([8, 9]), dc.Simulation2DCellCentered, [0.5, 1]),
+    ],
+)
+def test_custom_surface(mesh, sim_class, tx_loc):
+    bf = mesh.boundary_faces
+    surface_boundary_faces = bf[:, -1] == bf[:, -1].max()
+
+    src = dc.sources.Pole([], location=tx_loc)
+    survey = dc.Survey([src])
+
+    sigma = np.full(mesh.n_cells, 0.1)
+
+    sim1 = sim_class(mesh, survey, sigma=sigma)
+    sim2 = sim_class(mesh, survey, surface_faces=surface_boundary_faces, sigma=sigma)
+
+    f1 = sim1.fields()
+    f2 = sim2.fields()
+
+    print(bf[sim1.surface_faces])
+    print(bf[sim2.surface_faces])
+
+    np.testing.assert_equal(f1[src, "phiSolution"], f2[src, "phiSolution"])


### PR DESCRIPTION
Adds an option for the user to explicitly specify which boundary faces are considered to be surface boundaries (that will get a Neumann boundary).

Also fixes a small bug identified by the new tests regarding which boundaries were considered to be Robin boundaries for Tensor and Curvilinear meshes in the previous logic.