### PR TITLE
Change default n_processes for potential fields

### DIFF
--- a/SimPEG/potential_fields/base.py
+++ b/SimPEG/potential_fields/base.py
@@ -42,11 +42,28 @@ class BasePFSimulation(LinearSimulation):
 
         - 'ram': sensitivities are stored in the computer's RAM
         - 'disk': sensitivities are written to a directory
-        - 'forward_only': you intend only do perform a forward simulation and sensitivities do no need to be stored
+        - 'forward_only': you intend only do perform a forward simulation and sensitivities do not need to be stored
 
     n_processes : None or int, optional
         The number of processes to use in the internal multiprocessing pool for forward
-        modeling.
+        modeling. The default value of 1 will not use multiprocessing. Any other setting
+        will. `None` implies setting by the number of cpus.
+
+    Notes
+    -----
+    If using multiprocessing by setting `n_processes` to a value other than 1, you must
+    be aware of the method your operating system uses to spawn the subprocesses. On
+    Windows the default method starts new processes that all import the main script.
+    Therefor you must protect the calls to this class by testing if you are in
+    the main process with:
+
+    >>> from SimPEG.potential_fields import gravity
+    >>> if __name__ == '__main__':
+    ...     # Do your processing here
+    ...     sim = gravity.Simulation3DIntegral(n_processes=4, ...)
+    ...     sim.dpred(m)
+
+    This usually does not affect jupyter notebook environments.
     """
 
     def __init__(
@@ -54,7 +71,7 @@ class BasePFSimulation(LinearSimulation):
         mesh,
         ind_active=None,
         store_sensitivities="ram",
-        n_processes=None,
+        n_processes=1,
         **kwargs,
     ):
         # If deprecated property set with kwargs

--- a/tests/pf/test_forward_Grav_Linear.py
+++ b/tests/pf/test_forward_Grav_Linear.py
@@ -66,7 +66,6 @@ def test_ana_grav_forward(tmp_path):
         ind_active=active_cells,
         store_sensitivities="disk",
         sensitivity_path=str(tmp_path) + os.sep,
-        n_processes=1,
     )
 
     data = sim.dpred(model_reduced)
@@ -149,6 +148,7 @@ def test_ana_gg_forward():
         rhoMap=idenMap,
         ind_active=active_cells,
         store_sensitivities="forward_only",
+        n_processes=None,
     )
 
     data = sim.dpred(model_reduced)

--- a/tests/pf/test_forward_Mag_Linear.py
+++ b/tests/pf/test_forward_Mag_Linear.py
@@ -71,6 +71,7 @@ def test_ana_mag_forward():
         chiMap=idenMap,
         ind_active=active_cells,
         store_sensitivities="forward_only",
+        n_processes=None,
     )
 
     data = sim.dpred(model_reduced)
@@ -164,6 +165,7 @@ def test_ana_mag_grad_forward():
         chiMap=idenMap,
         ind_active=active_cells,
         store_sensitivities="forward_only",
+        n_processes=None,
     )
 
     data = sim.dpred(model_reduced)
@@ -256,6 +258,7 @@ def test_ana_mag_vec_forward():
         ind_active=active_cells,
         store_sensitivities="forward_only",
         model_type="vector",
+        n_processes=None,
     )
 
     data = sim.dpred(model_reduced).reshape(-1, 4)
@@ -342,6 +345,7 @@ def test_ana_mag_amp_forward():
         store_sensitivities="forward_only",
         model_type="vector",
         is_amplitude_data=True,
+        n_processes=None,
     )
 
     data = sim.dpred(model_reduced)

--- a/tests/pf/test_grav_inversion_linear.py
+++ b/tests/pf/test_grav_inversion_linear.py
@@ -79,6 +79,7 @@ class GravInvLinProblemTest(unittest.TestCase):
             rhoMap=idenMap,
             ind_active=actv,
             store_sensitivities="ram",
+            n_processes=None,
         )
 
         # Compute linear forward operator and compute some data

--- a/tests/pf/test_mag_inversion_linear.py
+++ b/tests/pf/test_mag_inversion_linear.py
@@ -82,6 +82,7 @@ class MagInvLinProblemTest(unittest.TestCase):
             chiMap=idenMap,
             ind_active=actv,
             store_sensitivities="disk",
+            n_processes=None,
         )
         self.sim = sim
 

--- a/tests/pf/test_mag_inversion_linear_Octree.py
+++ b/tests/pf/test_mag_inversion_linear_Octree.py
@@ -102,6 +102,7 @@ class MagInvLinProblemTest(unittest.TestCase):
             chiMap=idenMap,
             ind_active=actv,
             store_sensitivities="ram",
+            n_processes=None,
         )
         self.sim = sim
         data = sim.make_synthetic_data(


### PR DESCRIPTION
Change default to not use multiprocessing. Was causing too many issues on unsuspecting Windows users.

Also added a note on using the class with n_processes not equal to 1 to warn the users about how to use it when multiprocessing is enabled.