### PR TITLE
Add issue forms for github

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,8 +44,8 @@ body:
   attributes:
     label: "Runtime information:"
     description: >
-      Please include the output from SimPEG.Report() to describe your system for us.
-      Output from `from SimPEG import Report; print(Report())`
+      Please include the output from `SimPEG.Report()` to describe your system for us.
+      Paste the output from `from SimPEG import Report; print(Report())` below.
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Report a bug in SimPEG.
+title: "BUG: <Please write a comprehensive title after the 'BUG: ' prefix>"
+labels: [Bug]
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      Thanks for your use of SimPEG and for taking the time to report a bug! Please
+      first double check that there is not already a bug report on this issue by
+      searching through the existing bugs.
+
+- type: textarea
+  attributes:
+    label: "Describe the issue:"
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Reproducable code example:"
+    description: >
+      Please submit a small, but complete, code sample that reproduces the
+      bug or missing functionality. It should be able to be copy-pasted
+      into a Python interpreter and ran as-is.
+    placeholder: |
+      import SimPEG
+      << your code here >>
+    render: python
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Error message:"
+    description: >
+      Please include full error message, if any.
+    placeholder: |
+      << Full traceback starting from `Traceback: ...` >>
+    render: shell
+
+- type: textarea
+  attributes:
+    label: "Runtime information:"
+    description: >
+      Please include the output from SimPEG.Report() to describe your system for us.
+      Output from `from SimPEG import Report; print(Report())`
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Context for the issue:"
+    description: |
+      If you would like to give a little context for the issue, let us know and
+      it will help us to prioritize the issue.
+    placeholder: |
+      << your explanation here >>
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Question/Help/Support
+    url: https://simpeg.discourse.group/
+    about: "If you have a question on how to use SimPEG, please submit them to our discourse page."
+  - name: Development-related matters
+    url: https://slack.simpeg.xyz/
+    about: "If you would like to discuss SimPEG, any geophysics related problems, or need help from the SimPEG team, get in touch with us on slack."

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,20 @@
+name: Documentation
+description: Report an issue related to SimPEG's documentation.
+title: "DOC: <Please write a comprehensive title after the 'DOC: ' prefix>"
+labels: [Documentation]
+
+body:
+- type: textarea
+  attributes:
+    label: "Issue with current documentation:"
+    description: >
+      Please make sure to leave a reference to the document/code you're
+      referring to.
+
+- type: textarea
+  attributes:
+    label: "Idea or request for content:"
+    description: >
+      We would like to note that the SimPEG documentation is a work in progress.
+      But if there is a specific function you need documentation for, it might
+      help us to prioritize adding it.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -6,7 +6,7 @@ body:
 - type: markdown
   attributes:
     value: >
-      If you'd like to request a new feature in SimPEG, or suggested changed the
+      If you'd like to request a new feature in SimPEG, or suggest changes in the
       functionality of certain functions, we recommend getting in touch with the
       developers on [slack](https://slack.simpeg.xyz), in addition to opening an
       issue or pull request here.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,21 @@
+name: Feature request
+description: If you have a feature request, or an enhancement suggestion let us know.
+title: "ENH: <Please write a comprehensive title after the 'ENH: ' prefix>"
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      If you'd like to request a new feature in SimPEG, or suggested changed the
+      functionality of certain functions, we recommend getting in touch with the
+      developers on [slack](https://slack.simpeg.xyz), in addition to opening an
+      issue or pull request here.
+      You can also check out our
+      [Contributor Guide](https://docs.simpeg.xyz/content/basic/contributing.html)
+      if you need more information.
+
+- type: textarea
+  attributes:
+    label: "Proposed new feature or change:"
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/post-install.yml
+++ b/.github/ISSUE_TEMPLATE/post-install.yml
@@ -10,6 +10,8 @@ body:
     description: >
       Please describe the installation method (e.g. building from source,
       Anaconda, pip), your OS and SimPEG, NumPy, Scipy, and Python version information.
+    placeholder: |
+      If running in a conda environment you could paste the output of `conda list env` here.
   validations:
     required: true
 

--- a/.github/ISSUE_TEMPLATE/post-install.yml
+++ b/.github/ISSUE_TEMPLATE/post-install.yml
@@ -1,0 +1,28 @@
+name: Post-install/importing issue
+description: Report an issue if you have trouble importing SimPEG after installation.
+title: "<Please write a comprehensive title here>"
+labels: [Installation]
+
+body:
+- type: textarea
+  attributes:
+    label: "Steps to reproduce:"
+    description: >
+      Please describe the installation method (e.g. building from source,
+      Anaconda, pip), your OS and SimPEG, NumPy, Scipy, and Python version information.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: "Error message:"
+    description: >
+      Please include full error message, if any.
+    placeholder: |
+      << Full traceback starting from `Traceback: ...` >>
+    render: shell
+
+- type: textarea
+  attributes:
+    label: "Additional information:"
+    description: Please add any additional information that could help us diagnose the problem better.

--- a/.github/ISSUE_TEMPLATE/post-install.yml
+++ b/.github/ISSUE_TEMPLATE/post-install.yml
@@ -11,7 +11,7 @@ body:
       Please describe the installation method (e.g. building from source,
       Anaconda, pip), your OS and SimPEG, NumPy, Scipy, and Python version information.
     placeholder: |
-      If running in a conda environment you could paste the output of `conda list env` here.
+      If running in a conda environment you could paste the output of `conda list` here.
   validations:
     required: true
 


### PR DESCRIPTION
This adds Issue templates using fillable forms. It is modeled after the forms numpy uses for their issues.

These are (mostly complete) starting points, if there's anything else I missed though let me know.

For approximate look at what the forms will look like, check them out here: https://github.com/jcapriot/simpeg/tree/issue_forms/.github/ISSUE_TEMPLATE