### PR TITLE
Do not store real lambdas as complex

### DIFF
--- a/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
+++ b/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
@@ -7,11 +7,8 @@ from .... import props
 from .survey import Survey
 
 from empymod.transform import dlf
-
-try:
-    from empymod.transform import get_spline_values as get_dlf_points
-except ImportError:
-    from empymod.transform import get_dlf_points
+from empymod import filters
+from empymod.transform import get_dlf_points
 from empymod.utils import check_hankel
 from ..utils import static_utils
 from ....utils import validate_type, validate_string

--- a/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
+++ b/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
@@ -7,7 +7,6 @@ from .... import props
 from .survey import Survey
 
 from empymod.transform import dlf
-from empymod import filters
 from empymod.transform import get_dlf_points
 from empymod.utils import check_hankel
 from ..utils import static_utils

--- a/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
+++ b/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
@@ -303,23 +303,10 @@ class Simulation1DLayers(BaseSimulation):
         """
         # TODO: only works isotropic sigma
         if getattr(self, "_lambd", None) is None:
-            self._lambd = np.empty(
-                [self.offset.size, self._fhtfilt.base.size], order="F", dtype=complex
-            )
-            self.lambd[:, :], _ = get_dlf_points(
+            self._lambd, _ = get_dlf_points(
                 self._fhtfilt, self.offset, self.hankel_pts_per_dec
             )
         return self._lambd
-
-    # @property
-    # def t(self):
-    #     """
-    #         thickness of the layer
-    #     """
-    #     # TODO: only works isotropic sigma
-    #     if getattr(self, '_t', None) is None:
-    #         self._t = self.mesh.h[0][:-1]
-    #     return self._t
 
     @property
     def n_layer(self):

--- a/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
+++ b/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
@@ -189,7 +189,8 @@ class Simulation1DLayers(BaseSimulation):
 
         # Assume dipole-dipole
         V = voltage.reshape((self.survey.nD, 4), order="F")
-        data = V[:, 0] + V[:, 1] - (V[:, 2] + V[:, 3])
+        # vs are AM, AN, BM, BN
+        data = (V[:, 0] - V[:, 1]) - (V[:, 2] - V[:, 3])
 
         if self.data_type == "apparent_resistivity":
             data /= self.geometric_factor

--- a/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
+++ b/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
@@ -291,7 +291,7 @@ class Simulation1DLayers(BaseSimulation):
             r_AM = self.electrode_separations["AM"]
             r_AN = self.electrode_separations["AN"]
             r_BM = self.electrode_separations["BM"]
-            r_BN = self.electrode_separations["BM"]
+            r_BN = self.electrode_separations["BN"]
             self._offset = np.r_[r_AM, r_AN, r_BM, r_BN]
         return self._offset
 
@@ -328,7 +328,7 @@ class Simulation1DLayers(BaseSimulation):
             r_AM = self.electrode_separations["AM"]
             r_AN = self.electrode_separations["AN"]
             r_BM = self.electrode_separations["BM"]
-            r_BN = self.electrode_separations["BM"]
+            r_BN = self.electrode_separations["BN"]
             self._geometric_factor = (1 / r_AM - 1 / r_BM - 1 / r_AN + 1 / r_BN) / (
                 2 * np.pi
             )


### PR DESCRIPTION
Storing reals as complex lead to a tanh overflow... also save a lot of time not computing tanh on complex values.


At some point in the future, the 1D DC resistivity simulator should be brought up to the same level as the 1D em functionality.