### PR TITLE
Update DC1D for flexibility and speed

### DIFF
--- a/SimPEG/electromagnetics/static/resistivity/receivers.py
+++ b/SimPEG/electromagnetics/static/resistivity/receivers.py
@@ -35,6 +35,7 @@ class BaseRx(BaseSimPEGRx):
         self.orientation = orientation
         self.data_type = data_type
         self.projField = projField
+        self._geometric_factor = {}
 
     @property
     def orientation(self):
@@ -52,8 +53,6 @@ class BaseRx(BaseSimPEGRx):
         if var is not None:
             var = validate_string("orientation", var, ("x", "y", "z"))
         self._orientation = var
-
-    _geometric_factor = {}
 
     # @property
     # def projField(self):

--- a/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
+++ b/SimPEG/electromagnetics/static/resistivity/simulation_1d.py
@@ -1,16 +1,111 @@
 import numpy as np
 
-from ....utils import mkvc
 from ....simulation import BaseSimulation
 from .... import props
 
 from .survey import Survey
 
-from empymod.transform import dlf
 from empymod.transform import get_dlf_points
-from empymod.utils import check_hankel
-from ..utils import static_utils
+from empymod import filters
 from ....utils import validate_type, validate_string
+from scipy.interpolate import InterpolatedUnivariateSpline as iuSpline
+
+
+HANKEL_FILTERS = [
+    "kong_61_2007",
+    "kong_241_2007",
+    "key_101_2009",
+    "key_201_2009",
+    "key_401_2009",
+    "anderson_801_1982",
+    "key_51_2012",
+    "key_101_2012",
+    "key_201_2012",
+    "wer_201_2018",
+]
+
+
+def _phi_tilde(rho, thicknesses, lambdas):
+    """Calculate potential in the hankel domain.
+
+    Parameters
+    ----------
+    rho : (n_layer) np.ndarray
+        Resistivity array (ohm m)
+    thicknesses : (n_layer - 1) np.ndarray
+        Array of layer thicknesses defined from the top down (m).
+    lambdas : (n_lambda) np.ndarray
+        Wavenumbers.
+
+    Returns
+    -------
+    (n_lambda) np.ndarray
+        Potential in wavenumber domain at sampled locations
+    """
+    n_layer = len(rho)
+    tanh = np.tanh(lambdas[None, :] * thicknesses[:, None])
+    t = rho[-1] * np.ones_like(lambdas)
+    for i in range(n_layer - 2, -1, -1):
+        t = (t + rho[i] * tanh[i]) / (1.0 + t * tanh[i] / rho[i])
+    return t
+
+
+def _dphi_tilde(rho, thicknesses, lambdas):
+    """Calculate derivative of potential in the hankel domain.
+
+    Parameters
+    ----------
+    rho : (n_layer) np.ndarray
+        Resistivity array (ohm m)
+    thicknesses : (n_layer - 1) np.ndarray
+        Array of layer thicknesses defined from the top down (m).
+    lambdas : (n_lambda) np.ndarray
+        Wavenumbers.
+
+    Returns
+    -------
+    J_rho : (n_lambda, n_layer) np.ndarray
+        Jacobian matrix of first derivatives of lambda w.r.t. resistivity.
+    J_h : (n_lambda, n_layer-1) np.ndarray
+        Jacobian matrix of first derivatives of lambda w.r.t. thicknesses.
+    """
+    n_layer = len(rho)
+    ts = np.empty((n_layer, len(lambdas)))
+    tanh = np.tanh(lambdas[None, :] * thicknesses[:, None])
+    tops = np.empty((n_layer, len(lambdas)))
+    bots = np.empty((n_layer, len(lambdas)))
+    ts[-1] = rho[-1]
+    for i in range(n_layer - 2, -1, -1):
+        ts[i] = ts[i + 1]
+        tops[i] = ts[i + 1] + rho[i] * tanh[i]
+        bots[i] = 1 + ts[i + 1] * tanh[i] / rho[i]
+        ts[i] = tops[i] / bots[i]
+    # return ts[0]
+    # ts0 = 1.0
+    g_ti = np.ones(len(lambdas))
+    J_rho = np.empty((n_layer, len(lambdas)))
+    J_h = np.empty((n_layer - 1, len(lambdas)))
+    for i in range(n_layer - 1):
+        # ts[i] = tops[i] / bots[i]
+        g_tops = g_ti / bots[i]
+        g_bots = -ts[i] / bots[i] * g_ti
+        # bots[i] = 1 + ts[i+1] * tanh[i] / rho0
+        g_tip1 = tanh[i] / rho[i] * g_bots
+        g_tanh = ts[i + 1] / rho[i] * g_bots
+        g_rho0 = -ts[i + 1] * tanh[i] / (rho[i] ** 2) * g_bots
+        # tops[i] = ts[i+1] + rho0 * tanh[i]
+        g_tip1 += g_tops
+        g_tanh += rho[i] * g_tops
+        g_rho0 += tanh[i] * g_tops
+        # tanh = tanh(thick * lambd)
+        g_thick = (1 - tanh[i] ** 2) * lambdas * g_tanh
+
+        J_rho[i] = g_rho0
+        J_h[i] = g_thick
+
+        g_ti = g_tip1
+    J_rho[-1] = g_ti
+    return J_rho.T, J_h.T
 
 
 class Simulation1DLayers(BaseSimulation):
@@ -35,13 +130,23 @@ class Simulation1DLayers(BaseSimulation):
         rhoMap=None,
         thicknesses=None,
         thicknessesMap=None,
-        storeJ=False,
-        data_type="volt",
-        hankel_pts_per_dec=None,
-        hankel_filter="key_51_2012",
+        hankel_filter="key_201_2012",
         fix_Jmatrix=False,
         **kwargs,
     ):
+        if kwargs.pop("storeJ", None) is not None:
+            raise TypeError(
+                "storeJ is no longer settable by the user for this simulation."
+            )
+        if kwargs.pop("hankel_pts_per_dec", None) is not None:
+            raise TypeError(
+                "hankel_pts_per_dec is no longer settable by the user for this simulation."
+            )
+        if kwargs.pop("data_type", None) is not None:
+            raise TypeError(
+                "data_type can no longer be set on the simulation, it must be set on each"
+                "receiver."
+            )
         super().__init__(survey=survey, **kwargs)
         self.sigma = sigma
         self.rho = rho
@@ -49,22 +154,10 @@ class Simulation1DLayers(BaseSimulation):
         self.sigmaMap = sigmaMap
         self.rhoMap = rhoMap
         self.thicknessesMap = thicknessesMap
-        self.storeJ = storeJ
-        self.data_type = data_type
         self.fix_Jmatrix = fix_Jmatrix
-        try:
-            ht, htarg = check_hankel("fht", [hankel_filter, hankel_pts_per_dec], 1)
-            self._fhtfilt = htarg[0]  # Store filter
-            self._hankel_pts_per_dec = htarg[1]  # Store pts_per_dec
-        except ValueError:
-            arg = {}
-            arg["dlf"] = hankel_filter
-            if hankel_pts_per_dec is not None:
-                arg["pts_per_dec"] = hankel_pts_per_dec
-            ht, htarg = check_hankel("dlf", arg, 1)
-            self._fhtfilt = htarg["dlf"]  # Store filter
-            self._hankel_pts_per_dec = htarg["pts_per_dec"]  # Store pts_per_dec
-        self._hankel_filter = self._fhtfilt.name
+        self.hankel_filter = hankel_filter  # Store filter
+        self._coefficients_set = False
+        self._storeJ = True
 
     @property
     def survey(self):
@@ -94,10 +187,6 @@ class Simulation1DLayers(BaseSimulation):
         """
         return self._storeJ
 
-    @storeJ.setter
-    def storeJ(self, value):
-        self._storeJ = validate_type("storeJ", value, bool)
-
     @property
     def hankel_filter(self):
         """The hankel filter key.
@@ -108,15 +197,14 @@ class Simulation1DLayers(BaseSimulation):
         """
         return self._hankel_filter
 
-    @property
-    def hankel_pts_per_dec(self):
-        """Number of hankel transform points per decade.
-
-        Returns
-        -------
-        int
-        """
-        return self._hankel_pts_per_dec
+    @hankel_filter.setter
+    def hankel_filter(self, value):
+        self._hankel_filter = validate_string(
+            "hankel_filter",
+            value,
+            HANKEL_FILTERS,
+        )
+        self._fhtfilt = getattr(filters, self._hankel_filter)()
 
     @property
     def fix_Jmatrix(self):
@@ -132,69 +220,81 @@ class Simulation1DLayers(BaseSimulation):
     def fix_Jmatrix(self, value):
         self._fix_Jmatrix = validate_type("fix_Jmatrix", value, bool)
 
-    @property
-    def data_type(self):
-        """The type of data observered by the receivers.
+    def _compute_hankel_coefficients(self):
+        if self._coefficients_set:
+            return
+        survey = self.survey
 
-        Returns
-        -------
-        {"volt", "apparent_resistivity"}
-        """
-        return self._data_type
+        r_min = np.infty
+        r_max = -np.infty
 
-    @data_type.setter
-    def data_type(self, value):
-        self._data_type = validate_string(
-            "data_type", value, ["volt", "apparent_resistivity"]
+        for src in survey.source_list:
+            src_loc = src.location
+            for rx in src.receiver_list:
+                rx_loc = rx.locations
+                if not isinstance(rx_loc, list):
+                    # is a pole receiver
+                    rx_loc = [rx_loc]
+                for loc in rx_loc:
+                    off = np.linalg.norm(src_loc[:, None, :] - loc[None, :, :], axis=-1)
+                    r_min = min(off.min(), r_min)
+                    r_max = max(off.max(), r_max)
+        self.survey.set_geometric_factor()
+
+        lambdas, r_spline_points = get_dlf_points(
+            self._fhtfilt, np.r_[r_min, r_max], -1
         )
+        lambdas = lambdas.reshape(-1)
+        n_lambda = len(lambdas)
+        n_r = len(r_spline_points)
+
+        n_base = len(self._fhtfilt.base)
+        A_dht = np.zeros((n_r, n_lambda))
+        for i in range(n_r):
+            A_dht[i, i : i + n_base] = self._fhtfilt.j0
+        A_dht = A_dht[::-1]  # shuffle these back
+
+        # A_dht goes from wavenumber to space at r_spline_points
+        # Then need to spline it from r_spline to all offsets
+        # Calculate the interpolating spline basis functions for each spline point
+        splines = []
+        for i in range(n_r):
+            e = np.zeros(n_r)
+            e[i] = 1.0
+            sp = iuSpline(np.log(r_spline_points[::-1]), e, k=5)
+            splines.append(sp)
+        # As will go from wavenumber to space domain
+        As = []
+        for src in survey.source_list:
+            src_loc = src.location
+            for rx in src.receiver_list:
+                rx_loc = rx.locations
+                A = np.zeros((rx.nD, n_r))
+                for current, tx_elec_loc in zip(src.current, src_loc):
+                    if not isinstance(rx_loc, list):
+                        # is a pole receiver
+                        m_off = np.linalg.norm(tx_elec_loc - rx_loc, axis=-1)
+                        n_off = None
+                    else:
+                        m_off = np.linalg.norm(tx_elec_loc - rx_loc[0], axis=-1)
+                        n_off = np.linalg.norm(tx_elec_loc - rx_loc[1], axis=-1)
+                    # This receiver has a bunch of data...
+                    # this A is the linear operation going from the splined offsets to the data offset
+                    for i in range(n_r):
+                        A[:, i] += current * splines[i](np.log(m_off)) / m_off
+                        if n_off is not None:
+                            A[:, i] -= current * splines[i](np.log(n_off)) / n_off
+                if rx.data_type == "apparent_resistivity":
+                    A /= rx.geometric_factor[src]
+                As.append(A @ A_dht / (2 * np.pi))
+        self._coefficients_set = True
+        self._As = np.vstack(As)
+        self._lambdas = lambdas
 
     def fields(self, m):
-        if m is not None:
-            self.model = m
-
-        if self.verbose:
-            print(">> Compute fields")
-
-        # TODO: this for loop can slow down the speed, cythonize below for loop
-        T1 = self.rho[self.n_layer - 1] * np.ones_like(self.lambd)
-        for ii in range(self.n_layer - 1, 0, -1):
-            rho0 = self.rho[ii - 1]
-            t0 = self.thicknesses[ii - 1]
-            T0 = (T1 + rho0 * np.tanh(self.lambd * t0)) / (
-                1.0 + (T1 * np.tanh(self.lambd * t0) / rho0)
-            )
-            T1 = T0
-        PJ = (T0, None, None)
-        try:
-            voltage = dlf(
-                PJ,
-                self.lambd,
-                self.offset,
-                self._fhtfilt,
-                self.hankel_pts_per_dec,
-                factAng=None,
-                ab=33,
-            ).real / (2 * np.pi)
-        except TypeError:
-            voltage = dlf(
-                PJ,
-                self.lambd,
-                self.offset,
-                self._fhtfilt,
-                self.hankel_pts_per_dec,
-                ang_fact=None,
-                ab=33,
-            ).real / (2 * np.pi)
-
-        # Assume dipole-dipole
-        V = voltage.reshape((self.survey.nD, 4), order="F")
-        # vs are AM, AN, BM, BN
-        data = (V[:, 0] - V[:, 1]) - (V[:, 2] - V[:, 3])
-
-        if self.data_type == "apparent_resistivity":
-            data /= self.geometric_factor
-
-        return data
+        self.model = m
+        self._compute_hankel_coefficients()
+        return _phi_tilde(self.rho, self.thicknesses, self._lambdas)
 
     def dpred(self, m=None, f=None):
         """
@@ -203,39 +303,33 @@ class Simulation1DLayers(BaseSimulation):
         :rtype: numpy.ndarray
         :return: data
         """
-
         if self.verbose:
             print("Calculating predicted data")
 
+        self._compute_hankel_coefficients()
         if f is None:
             if m is None:
                 m = self.model
             f = self.fields(m)
-
-        return f
+        return self._As @ f
 
     def getJ(self, m, f=None, factor=1e-2):
         """
         Generate Full sensitivity matrix using central difference
         """
+        self.model = m
         if getattr(self, "_Jmatrix", None) is None:
+            self._compute_hankel_coefficients()
             if self.verbose:
                 print("Calculating J and storing")
-            self.model = m
 
-            # TODO: this makes code quite slow derive analytic sensitivity
-            N = self.survey.nD
-            M = self.model.size
-            Jmatrix = np.zeros((N, M), dtype=float, order="F")
-            for ii in range(M):
-                m0 = m.copy()
-                dm = m[ii] * factor
-                m0[ii] = m[ii] - dm * 0.5
-                m1 = m.copy()
-                m1[ii] = m[ii] + dm * 0.5
-                d0 = self.fields(m0)
-                d1 = self.fields(m1)
-                Jmatrix[:, ii] = (d1 - d0) / (dm)
+            J_rho, J_h = _dphi_tilde(self.rho, self.thicknesses, self._lambdas)
+
+            Jmatrix = 0
+            if self.rhoMap is not None:
+                Jmatrix += (self._As @ J_rho) @ self.rhoDeriv
+            if self.thicknessesMap is not None:
+                Jmatrix += (self._As @ J_h) @ self.thicknessesDeriv
             self._Jmatrix = Jmatrix
         return self._Jmatrix
 
@@ -243,90 +337,17 @@ class Simulation1DLayers(BaseSimulation):
         """
         Compute sensitivity matrix (J) and vector (v) product.
         """
-
-        J = self.getJ(m, f=f)
-        Jv = mkvc(np.dot(J, v))
-
-        return mkvc(Jv)
+        return self.getJ(m, f=f) @ v
 
     def Jtvec(self, m, v, f=None):
         """
         Compute adjoint sensitivity matrix (J^T) and vector (v) product.
         """
-
-        J = self.getJ(m, f=f)
-        Jtv = mkvc(np.dot(J.T, v))
-
-        return Jtv
+        return self.getJ(m, f=f).T @ v
 
     @property
     def deleteTheseOnModelUpdate(self):
-        toDelete = super().deleteTheseOnModelUpdate
-        if self.fix_Jmatrix:
-            return toDelete
-        return toDelete + ["_Jmatrix"]
-
-    @property
-    def electrode_separations(self):
-        """
-        Electrode separations
-        """
-        # TODO: only works isotropic sigma
-        if getattr(self, "_electrode_separations", None) is None:
-            self._electrode_separations = static_utils.electrode_separations(
-                self.survey
-            )
-        return self._electrode_separations
-
-    @property
-    def offset(self):
-        """
-        Offset between a current electrode and a potential electrode
-        """
-        # TODO: only works isotropic sigma
-        if getattr(self, "_offset", None) is None:
-            r_AM = self.electrode_separations["AM"]
-            r_AN = self.electrode_separations["AN"]
-            r_BM = self.electrode_separations["BM"]
-            r_BN = self.electrode_separations["BN"]
-            self._offset = np.r_[r_AM, r_AN, r_BM, r_BN]
-        return self._offset
-
-    @property
-    def lambd(self):
-        """
-        Spatial frequency in Hankel domain
-        np.sqrt(kx*2 + ky**2) = lamda
-        """
-        # TODO: only works isotropic sigma
-        if getattr(self, "_lambd", None) is None:
-            self._lambd, _ = get_dlf_points(
-                self._fhtfilt, self.offset, self.hankel_pts_per_dec
-            )
-        return self._lambd
-
-    @property
-    def n_layer(self):
-        """
-        number of layers
-        """
-        # TODO: only works isotropic sigma
-        if getattr(self, "_n_layer", None) is None:
-            self._n_layer = self.thicknesses.size + 1
-        return self._n_layer
-
-    @property
-    def geometric_factor(self):
-        """
-        number of layers
-        """
-        # TODO: only works isotropic sigma
-        if getattr(self, "_geometric_factor", None) is None:
-            r_AM = self.electrode_separations["AM"]
-            r_AN = self.electrode_separations["AN"]
-            r_BM = self.electrode_separations["BM"]
-            r_BN = self.electrode_separations["BN"]
-            self._geometric_factor = (1 / r_AM - 1 / r_BM - 1 / r_AN + 1 / r_BN) / (
-                2 * np.pi
-            )
-        return self._geometric_factor
+        to_delete = super().deleteTheseOnModelUpdate
+        if not self.fix_Jmatrix:
+            to_delete = to_delete + ["_Jmatrix"]
+        return to_delete

--- a/tests/em/static/test_DC_1D_jvecjtvecadj.py
+++ b/tests/em/static/test_DC_1D_jvecjtvecadj.py
@@ -1,109 +1,251 @@
-import unittest
+from discretize.tests import check_derivative, assert_isadjoint
 import numpy as np
-from discretize import TensorMesh
+import pytest
 from SimPEG import (
     maps,
-    data_misfit,
-    regularization,
-    inversion,
-    optimization,
-    inverse_problem,
-    tests,
 )
-from SimPEG.utils import mkvc
 from SimPEG.electromagnetics import resistivity as dc
-
-np.random.seed(40)
 
 TOL = 1e-5
 FLR = 1e-20  # "zero", so if residual below this --> pass regardless of order
 
 
-class DC1DSimulation(unittest.TestCase):
-    def setUp(self):
-        ntx = 31
-        xtemp_txP = np.logspace(1, 3, ntx)
-        xtemp_txN = -xtemp_txP
-        ytemp_tx = np.zeros(ntx)
-        xtemp_rxP = -5
-        xtemp_rxN = 5
-        ytemp_rx = 0.0
-        abhalf = abs(xtemp_txP - xtemp_txN) * 0.5
-        a = xtemp_rxN - xtemp_rxP
-        b = ((xtemp_txN - xtemp_txP) - a) * 0.5
+def get_survey(data_type, rx_type, tx_type):
+    n_spacings = np.logspace(0, 2, 3)
+    y = np.zeros_like(n_spacings)
+    z = np.full_like(n_spacings, -1.0)
+    a_locations = np.column_stack((-1.5 * n_spacings, y, z))
+    b_locations = np.column_stack((1.5 * n_spacings, y, z))
+    m_locations = np.column_stack((-0.5 * n_spacings, y, z))
+    n_locations = np.column_stack((0.5 * n_spacings, y, z))
 
-        # We generate tx and rx lists:
-        srclist = []
-        for i in range(ntx):
-            rx = dc.receivers.Dipole(
-                np.r_[xtemp_rxP, ytemp_rx, -12.5], np.r_[xtemp_rxN, ytemp_rx, -12.5]
-            )
-            locA = np.r_[xtemp_txP[i], ytemp_tx[i], -12.5]
-            locB = np.r_[xtemp_txN[i], ytemp_tx[i], -12.5]
-            src = dc.sources.Dipole([rx], locA, locB)
-            srclist.append(src)
-        survey = dc.survey.Survey(srclist)
+    # some dipole receivers (with and without app_res))
+    sources = []
+    if data_type == "both":
+        data_type = ["volt", "apparent_resistivity"]
+    else:
+        data_type = [data_type]
+    if rx_type == "both":
+        rx_type = ["p", "d"]
+    else:
+        rx_type = [rx_type]
+    if tx_type == "both":
+        tx_type = ["p", "d"]
+    else:
+        tx_type = [tx_type]
+    for a, b, m, n in zip(a_locations, b_locations, m_locations, n_locations):
+        rx = []
+        for dtype in data_type:
+            for rxt in rx_type:
+                if rxt == "p":
+                    rx.append(dc.receivers.Pole(m, data_type=dtype))
+                else:
+                    rx.append(dc.receivers.Dipole(locations=[m, n], data_type=dtype))
 
-        rho = np.r_[10, 10, 10]
-        dummy_hz = 100.0
-        hz = np.r_[10, 10, dummy_hz]
-        mesh = TensorMesh([hz])
+        for txt in tx_type:
+            if txt == "p":
+                sources.append(dc.sources.Pole(rx, a))
+            else:
+                sources.append(dc.sources.Dipole(rx, location=[a, b]))
+    return dc.Survey(sources)
 
-        simulation = dc.simulation_1d.Simulation1DLayers(
+
+@pytest.mark.parametrize("rx_type", ["p", "d", "both"])
+@pytest.mark.parametrize("tx_type", ["p", "d", "both"])
+@pytest.mark.parametrize("data_type", ["volt", "apparent_resistivity", "both"])
+def test_forward_accuracy(data_type, rx_type, tx_type):
+    sigma = 1.0
+    cond = [sigma, sigma, sigma]
+    thick = [10, 20]
+    survey = get_survey(data_type, rx_type, tx_type)
+    simulation = dc.Simulation1DLayers(
+        survey=survey,
+        sigma=cond,
+        thicknesses=thick,
+    )
+    d = simulation.dpred()
+
+    # apparent resistivity should be close to the true resistivity of this half space
+    if data_type == "app_res":
+        np.testing.assert_allclose(d, 1.0 / sigma, rtol=1e-6)
+    if data_type == "volt":
+        geom = dc.utils.geometric_factor(survey)
+        np.testing.assert_allclose(d / geom, 1.0 / sigma, rtol=1e-6)
+    if data_type == "both":
+        n_r = 2 if rx_type == "both" else 1
+        d = d.reshape(-1, n_r)
+        geom = dc.utils.geometric_factor(survey).reshape(-1, n_r)[::2]
+        # double check the app_res calc was applied correctly
+        d_volts = d[::2]
+        d_app = d[1::2]
+        np.testing.assert_allclose(d_volts / geom, d_app)
+
+        # double check the accuracy
+        np.testing.assert_allclose(d_app, 1.0 / sigma, rtol=1e-6)
+
+
+@pytest.mark.parametrize("deriv_type", ("sigma", "h", "both"))
+def test_derivative(deriv_type):
+    n_layer = 4
+    np.random.seed(40)
+    log_cond = np.random.rand(n_layer)
+    log_thick = np.random.rand(n_layer - 1)
+
+    if deriv_type != "h":
+        sigma_map = maps.ExpMap()
+        model = log_cond
+        sigma = None
+    else:
+        sigma = np.exp(log_cond)
+        sigma_map = None
+    if deriv_type != "sigma":
+        h_map = maps.ExpMap()
+        model = log_thick
+        h = None
+    else:
+        h_map = None
+        h = np.exp(log_thick)
+    if deriv_type == "both":
+        wire = maps.Wires(("sigma", n_layer), ("thick", n_layer - 1))
+        sigma_map = sigma_map * wire.sigma
+        h_map = h_map * wire.thick
+        model = np.r_[log_cond, log_thick]
+    # already tested that the forward operation works for all combinations of src/rx/data_type
+    # the way this simulation is set up, only need to test the derivative with
+    # a single combination.
+    survey = get_survey("volt", "d", "d")
+    simulation = dc.Simulation1DLayers(
+        survey=survey,
+        sigma=sigma,
+        sigmaMap=sigma_map,
+        thicknesses=h,
+        thicknessesMap=h_map,
+    )
+
+    def sim_1d_func(m):
+        d = simulation.dpred(m)
+
+        def J(v):
+            return simulation.Jvec(m, v)
+
+        return d, J
+
+    assert check_derivative(sim_1d_func, model, plotIt=False, num=4)
+
+
+@pytest.mark.parametrize("deriv_type", ("sigma", "h", "both"))
+def test_adjoint(deriv_type):
+    n_layer = 4
+    np.random.seed(40)
+    log_cond = np.random.rand(n_layer)
+    log_thick = np.random.rand(n_layer - 1)
+
+    if deriv_type != "h":
+        sigma_map = maps.ExpMap()
+        model = log_cond
+        sigma = None
+    else:
+        sigma = np.exp(log_cond)
+        sigma_map = None
+    if deriv_type != "sigma":
+        h_map = maps.ExpMap()
+        model = log_thick
+        h = None
+    else:
+        h_map = None
+        h = np.exp(log_thick)
+    if deriv_type == "both":
+        wire = maps.Wires(("sigma", n_layer), ("thick", n_layer - 1))
+        sigma_map = sigma_map * wire.sigma
+        h_map = h_map * wire.thick
+        model = np.r_[log_cond, log_thick]
+    # already tested that the forward operation works for all combinations of src/rx/data_type
+    # the way this simulation is set up, only need to test the derivative with
+    # a single combination.
+    survey = get_survey("volt", "d", "d")
+    simulation = dc.Simulation1DLayers(
+        survey=survey,
+        sigma=sigma,
+        sigmaMap=sigma_map,
+        thicknesses=h,
+        thicknessesMap=h_map,
+    )
+
+    def J(v):
+        return simulation.Jvec(model, v)
+
+    def JT(v):
+        return simulation.Jtvec(model, v)
+
+    assert_isadjoint(J, JT, len(model), survey.nD)
+
+
+def test_errors():
+    sigma = 1.0
+    cond = [sigma, sigma, sigma]
+    thick = [10, 20]
+    survey = get_survey("apparent_resistivity", "d", "d")
+
+    with pytest.raises(TypeError):
+        simulation = dc.Simulation1DLayers(
             survey=survey,
-            rhoMap=maps.ExpMap(mesh),
-            thicknesses=hz[:-1],
-            data_type="apparent_resistivity",
+            sigma=cond,
+            thicknesses=thick,
+            storeJ=False,
         )
-        simulation.dpred(np.log(rho))
-
-        mSynth = np.log(rho)
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
-
-        # Now set up the problem to do some minimization
-        dmis = data_misfit.L2DataMisfit(simulation=simulation, data=dobs)
-        reg = regularization.WeightedLeastSquares(mesh)
-        opt = optimization.InexactGaussNewton(
-            maxIterLS=20, maxIter=10, tolF=1e-6, tolX=1e-6, tolG=1e-6, maxIterCG=6
+    with pytest.raises(TypeError):
+        simulation = dc.Simulation1DLayers(
+            survey=survey,
+            sigma=cond,
+            thicknesses=thick,
+            hankel_pts_per_dec=2,
         )
-        invProb = inverse_problem.BaseInvProblem(dmis, reg, opt, beta=0.0)
-        inv = inversion.BaseInversion(invProb)
-
-        self.inv = inv
-        self.reg = reg
-        self.p = simulation
-        self.mesh = mesh
-        self.m0 = mSynth
-        self.survey = survey
-        self.dmis = dmis
-        self.dobs = dobs
-
-    def test_misfit(self):
-        passed = tests.check_derivative(
-            lambda m: [self.p.dpred(m), lambda mx: self.p.Jvec(self.m0, mx)],
-            self.m0,
-            plotIt=False,
-            num=3,
+    with pytest.raises(TypeError):
+        simulation = dc.Simulation1DLayers(
+            survey=survey,
+            sigma=cond,
+            thicknesses=thick,
+            data_type="volt",
         )
-        self.assertTrue(passed)
 
-    def test_adjoint(self):
-        # Adjoint Test
-        # u = np.random.rand(self.mesh.nC*self.survey.nSrc)
-        v = np.random.rand(self.mesh.nC)
-        w = np.random.rand(mkvc(self.dobs).shape[0])
-        wtJv = w.dot(self.p.Jvec(self.m0, v))
-        vtJtw = v.dot(self.p.Jtvec(self.m0, w))
-        passed = np.abs(wtJv - vtJtw) < 1e-8
-        print("Adjoint Test", np.abs(wtJv - vtJtw), passed)
-        self.assertTrue(passed)
-
-    def test_dataObj(self):
-        passed = tests.check_derivative(
-            lambda m: [self.dmis(m), self.dmis.deriv(m)], self.m0, plotIt=False, num=3
-        )
-        self.assertTrue(passed)
+    simulation = dc.Simulation1DLayers(
+        sigma=cond,
+        thicknesses=thick,
+    )
+    with pytest.raises(AttributeError):
+        _ = simulation.survey
+    simulation.survey = survey
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_functionality():
+    n_layer = 4
+    np.random.seed(40)
+    log_cond = np.random.rand(n_layer)
+    thick = np.random.rand(n_layer - 1)
+
+    sigma_map = maps.ExpMap()
+    model = log_cond
+
+    survey = get_survey("volt", "d", "d")
+    simulation = dc.Simulation1DLayers(
+        survey=survey,
+        sigmaMap=sigma_map,
+        thicknesses=thick,
+    )
+
+    # test dpred with and without fields passed
+    f = simulation.fields(model)
+    d1 = simulation.dpred(model, f)
+    d2 = simulation.dpred()
+    np.testing.assert_allclose(d1, d2)
+
+    # test clearing J on model update if fix_J is False
+    simulation.fix_Jmatrix = False
+    J1 = simulation.getJ(model)
+    J2 = simulation.getJ(model + 2)
+    assert J1 is not J2
+
+    simulation.fix_Jmatrix = True
+    J1 = simulation.getJ(model)
+    J2 = simulation.getJ(model + 2)
+    assert J1 is J2

--- a/tutorials/05-dcr/plot_fwd_1_dcr_sounding.py
+++ b/tutorials/05-dcr/plot_fwd_1_dcr_sounding.py
@@ -71,7 +71,9 @@ for ii in range(0, len(electrode_separations)):
     N_location = np.r_[0.5 * a, 0.0, 0.0]
 
     # Create receivers list. Define as pole or dipole.
-    receiver_list = dc.receivers.Dipole(M_location, N_location)
+    receiver_list = dc.receivers.Dipole(
+        M_location, N_location, data_type="apparent_resistivity"
+    )
     receiver_list = [receiver_list]
 
     # Define the source properties and associated receivers
@@ -125,7 +127,6 @@ simulation = dc.simulation_1d.Simulation1DLayers(
     survey=survey,
     rhoMap=model_map,
     thicknesses=layer_thicknesses,
-    data_type="apparent_resistivity",
 )
 
 # Predict data for a given model

--- a/tutorials/05-dcr/plot_inv_1_dcr_sounding.py
+++ b/tutorials/05-dcr/plot_inv_1_dcr_sounding.py
@@ -105,7 +105,13 @@ for ii in range(0, n_sources):
     # MN electrode locations for receivers. Each is an (N, 3) numpy array
     M_locations = M_electrodes[k[ii] : k[ii + 1], :]
     N_locations = N_electrodes[k[ii] : k[ii + 1], :]
-    receiver_list = [dc.receivers.Dipole(M_locations, N_locations)]
+    receiver_list = [
+        dc.receivers.Dipole(
+            M_locations,
+            N_locations,
+            data_type="apparent_resistivity",
+        )
+    ]
 
     # AB electrode locations for source. Each is a (1, 3) numpy array
     A_location = A_electrodes[k[ii], :]
@@ -199,7 +205,6 @@ simulation = dc.simulation_1d.Simulation1DLayers(
     survey=survey,
     rhoMap=model_map,
     thicknesses=layer_thicknesses,
-    data_type="apparent_resistivity",
 )
 
 

--- a/tutorials/05-dcr/plot_inv_1_dcr_sounding_irls.py
+++ b/tutorials/05-dcr/plot_inv_1_dcr_sounding_irls.py
@@ -105,7 +105,13 @@ for ii in range(0, n_sources):
     # MN electrode locations for receivers. Each is an (N, 3) numpy array
     M_locations = M_electrodes[k[ii] : k[ii + 1], :]
     N_locations = N_electrodes[k[ii] : k[ii + 1], :]
-    receiver_list = [dc.receivers.Dipole(M_locations, N_locations)]
+    receiver_list = [
+        dc.receivers.Dipole(
+            M_locations,
+            N_locations,
+            data_type="apparent_resistivity",
+        )
+    ]
 
     # AB electrode locations for source. Each is a (1, 3) numpy array
     A_location = A_electrodes[k[ii], :]
@@ -199,7 +205,6 @@ simulation = dc.simulation_1d.Simulation1DLayers(
     survey=survey,
     rhoMap=model_map,
     thicknesses=layer_thicknesses,
-    data_type="apparent_resistivity",
 )
 
 

--- a/tutorials/05-dcr/plot_inv_1_dcr_sounding_parametric.py
+++ b/tutorials/05-dcr/plot_inv_1_dcr_sounding_parametric.py
@@ -106,7 +106,13 @@ for ii in range(0, n_sources):
     # MN electrode locations for receivers. Each is an (N, 3) numpy array
     M_locations = M_electrodes[k[ii] : k[ii + 1], :]
     N_locations = N_electrodes[k[ii] : k[ii + 1], :]
-    receiver_list = [dc.receivers.Dipole(M_locations, N_locations)]
+    receiver_list = [
+        dc.receivers.Dipole(
+            M_locations,
+            N_locations,
+            data_type="apparent_resistivity",
+        )
+    ]
 
     # AB electrode locations for source. Each is a (1, 3) numpy array
     A_location = A_electrodes[k[ii], :]
@@ -196,7 +202,6 @@ simulation = dc.simulation_1d.Simulation1DLayers(
     survey=survey,
     rhoMap=resistivity_map,
     thicknessesMap=layer_map,
-    data_type="apparent_resistivity",
 )
 
 #######################################################################
@@ -248,9 +253,6 @@ inv_prob = inverse_problem.BaseInvProblem(dmis, reg, opt)
 # criteria for the inversion and saving inversion results at each iteration.
 #
 
-# Apply and update sensitivity weighting as the model updates
-update_sensitivity_weights = directives.UpdateSensitivityWeights()
-
 # Defining a starting value for the trade-off parameter (beta) between the data
 # misfit and the regularization.
 starting_beta = directives.BetaEstimate_ByEig(beta0_ratio=1e1)
@@ -268,7 +270,6 @@ target_misfit = directives.TargetMisfit(chifact=0.1)
 
 # The directives are defined in a list
 directives_list = [
-    update_sensitivity_weights,
     starting_beta,
     beta_schedule,
     target_misfit,


### PR DESCRIPTION
Took the time this morning to just update the DC1D to be more flexible for receivers and sources.
It now supports `Pole` and `Dipole` receivers, `Pole`, `Dipole`, `Multipole` sources, and arbitrary combinations of these.

It also overhauled the class to use faster forward and jacobian kernels, while making use of the splined output for the hankel transform, resulting in far fewer calls to those faster kernel functions.

It's calling structure has been overhauled to match the 2D and 3D simulations, (i.e. no setting `data_type` on the simulation, it should be set on the receivers).

There was also a small bug setting repeated geometric factors on receivers that was caught here too.