### PR TITLE
update JTV to work for an arbitrary number of models

### DIFF
--- a/SimPEG/regularization/jtv.py
+++ b/SimPEG/regularization/jtv.py
@@ -70,7 +70,6 @@ class JointTotalVariation(BaseSimilarityMeasure):
         float
             The computed value of the joint total variation term.
         """
-        m1, m2 = self.wire_map * model
         W = self.W
         G = self._G
         v2 = self.regularization_mesh.vol**2

--- a/SimPEG/regularization/jtv.py
+++ b/SimPEG/regularization/jtv.py
@@ -45,15 +45,15 @@ class JointTotalVariation(BaseSimilarityMeasure):
 
     @wire_map.setter
     def wire_map(self, wires):
-        n = None
+        n = self.regularization_mesh.nC
         maps = wires.maps
         for _, mapping in maps:
             map_n = mapping.shape[0]
-            if n is not None and n != map_n:
+            if n != map_n:
                 raise ValueError(
-                    f"All mapping outputs must be the same size! Got {n} and {map_n}"
+                    f"All mapping outputs must match the number of cells in "
+                    f"the regularization mesh! Got {n} and {map_n}"
                 )
-            n = map_n
         self._wire_map = wires
 
     def __call__(self, model):

--- a/tests/base/test_jtv.py
+++ b/tests/base/test_jtv.py
@@ -25,7 +25,7 @@ class JTVTensor2D(unittest.TestCase):
         actv = np.ones(len(mesh), dtype=bool)
 
         # maps
-        wires = maps.Wires(("m1", mesh.nC), ("m2", mesh.nC))
+        wires = maps.Wires(("m1", mesh.nC), ("m2", mesh.nC), ("m3", mesh.nC))
 
         jtv = regularization.JointTotalVariation(
             mesh,
@@ -35,7 +35,7 @@ class JTVTensor2D(unittest.TestCase):
 
         self.mesh = mesh
         self.jtv = jtv
-        self.x0 = np.random.rand(len(mesh) * 2)
+        self.x0 = np.random.rand(len(mesh) * len(wires.maps))
 
     def test_order_full_hessian(self):
         """

--- a/tests/base/test_jtv.py
+++ b/tests/base/test_jtv.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 
 import numpy as np
 
@@ -199,6 +200,29 @@ class JTVTree3D(unittest.TestCase):
         W = jtv.deriv2(m)
         Wv = jtv.deriv2(m, v)
         np.testing.assert_allclose(Wv, W @ v)
+
+
+def test_bad_wires():
+    dh = 1.0
+    nx = 12
+    ny = 12
+
+    hx = [(dh, nx)]
+    hy = [(dh, ny)]
+    mesh = TensorMesh([hx, hy], "CN")
+
+    # reg
+    actv = np.ones(len(mesh), dtype=bool)
+
+    # maps
+    wires = maps.Wires(("m1", mesh.nC), ("m2", mesh.nC - 2), ("m3", mesh.nC - 3))
+
+    with pytest.raises(ValueError):
+        regularization.JointTotalVariation(
+            mesh,
+            wire_map=wires,
+            indActive=actv,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updating the `JointTotalVariation` to work for more than 2 models as the formulation is generalizable to the number of physical property models.

- [ ] add more tests