### PR TITLE
Fix flake8 `B015` errors: solve unused comparisons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ STYLE_CHECK_FILES = SimPEG examples tutorials tests
 # included in the list so we keep ignoring them while running the
 # flake-permissive target.
 FLAKE8_IGNORE = "E121,E123,E126,E226,E24,E704,W503,W504,\
-	B015,\
 	B017,\
 	B028,\
 	D100,\

--- a/SimPEG/electromagnetics/static/resistivity/simulation.py
+++ b/SimPEG/electromagnetics/static/resistivity/simulation.py
@@ -489,7 +489,7 @@ class Simulation3DNodal(BaseDCSimulation):
         if mesh._meshType == "TREE":
             mesh.nodal_gradient
         elif mesh._meshType == "CYL":
-            bc_type == "Neumann"
+            bc_type = "Neumann"
         self.bc_type = bc_type
         self.setBC()
 

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -560,7 +560,7 @@ class TestWires(unittest.TestCase):
 
         named_model = wires * model
 
-        named_model.sigma == model[: mesh.shape_cells[2]]
+        assert named_model.sigma == model[: mesh.shape_cells[2]]
         assert named_model.mu_casing == 10
 
 


### PR DESCRIPTION
Fix flake8 `B015` error that highlights unused comparisons. Remove `B015` from the list of ignored warnings in `Makefile`.
