### PR TITLE
Patch/identity map init

### DIFF
--- a/SimPEG/maps.py
+++ b/SimPEG/maps.py
@@ -58,24 +58,25 @@ class IdentityMap:
     mesh : discretize.BaseMesh
         The number of parameters accepted by the mapping is set to equal the number
         of mesh cells.
-    nP : int
+    nP : int, or '*'
         Set the number of parameters accepted by the mapping directly. Used if the
         number of parameters is known. Used generally when the number of parameters
         is not equal to the number of cells in a mesh.
     """
 
     def __init__(self, mesh=None, nP=None, **kwargs):
-        if nP is not None:
-            if isinstance(nP, str):
-                assert nP == "*", "nP must be an integer or '*', not {}".format(nP)
-            assert isinstance(
-                nP, (int, np.integer)
-            ), "Number of parameters must be an integer. Not `{}`.".format(type(nP))
-            nP = int(nP)
-        elif mesh is not None:
-            nP = mesh.nC
+        if (isinstance(nP, str) and nP == "*") or nP is None:
+            if mesh is not None:
+                nP = mesh.n_cells
+            else:
+                nP = "*"
         else:
-            nP = "*"
+            try:
+                nP = int(nP)
+            except (TypeError, ValueError) as err:
+                raise TypeError(
+                    f"Unrecognized input of {repr(nP)} for number of parameters, must be an integer or '*'."
+                ) from err
         self.mesh = mesh
         self._nP = nP
 

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -77,6 +77,27 @@ MAPS_TO_EXCLUDE_3D = [
 ] + REMOVED_IGNORE
 
 
+def test_IdentityMap_init():
+    m = maps.IdentityMap()
+    assert m.nP == "*"
+
+    m = maps.IdentityMap(nP="*")
+    assert m.nP == "*"
+
+    m = maps.IdentityMap(nP=3)
+    assert m.nP == 3
+
+    mesh = discretize.TensorMesh([3])
+    m = maps.IdentityMap(mesh)
+    assert m.nP == 3
+
+    m = maps.IdentityMap(mesh, nP="*")
+    assert m.nP == 3
+
+    with pytest.raises(TypeError):
+        maps.IdentityMap(nP="x")
+
+
 class MapTests(unittest.TestCase):
     def setUp(self):
         maps2test2D = [M for M in dir(maps) if M not in MAPS_TO_EXCLUDE_2D]


### PR DESCRIPTION
Fix initializing `IdentityMap` with `nP = '*'` (which should be valid)