### PR TITLE
Meta/meta patches

### DIFF
--- a/SimPEG/meta/simulation.py
+++ b/SimPEG/meta/simulation.py
@@ -95,6 +95,7 @@ class MetaSimulation(BaseSimulation):
         )
         self.simulations = simulations
         self.mappings = mappings
+        self.model = None
         # give myself a BaseSurvey that has the number of data equal
         # to the sum of the sims' data.
         survey = BaseSurvey([])
@@ -182,7 +183,10 @@ class MetaSimulation(BaseSimulation):
         # Only send the model to the internal simulations if it was updated.
         if not self._repeat_sim and updated:
             for mapping, sim in zip(self.mappings, self.simulations):
-                sim.model = mapping * self._model
+                if value is not None:
+                    sim.model = mapping * self._model
+                else:
+                    sim.model = value
 
     def fields(self, m):
         """Create fields for every simulation.
@@ -199,7 +203,7 @@ class MetaSimulation(BaseSimulation):
         # The above should pass the model to all the internal simulations.
         f = []
         for mapping, sim in zip(self.mappings, self.simulations):
-            if self._repeat_sim:
+            if self._repeat_sim and self.model is not None:
                 sim.model = mapping * self.model
             f.append(sim.fields(m=sim.model))
         return f
@@ -338,6 +342,7 @@ class SumMetaSimulation(MetaSimulation):
         )
         self.simulations = simulations
         self.mappings = mappings
+        self.model = None
         # give myself a BaseSurvey
         survey = BaseSurvey([])
         survey._vnD = [
@@ -426,6 +431,7 @@ class RepeatedSimulation(MetaSimulation):
         )
         self.simulation = simulation
         self.mappings = mappings
+        self.model = None
         survey = BaseSurvey([])
         vnD = len(self.mappings) * [self.simulation.survey.nD]
         survey._vnD = vnD

--- a/SimPEG/meta/simulation.py
+++ b/SimPEG/meta/simulation.py
@@ -205,7 +205,7 @@ class MetaSimulation(BaseSimulation):
         for mapping, sim in zip(self.mappings, self.simulations):
             if self._repeat_sim and self.model is not None:
                 sim.model = mapping * self.model
-            f.append(sim.fields(m=sim.model))
+            f.append(sim.fields(sim.model))
         return f
 
     def dpred(self, m=None, f=None):

--- a/tests/meta/test_meta_sim.py
+++ b/tests/meta/test_meta_sim.py
@@ -362,3 +362,56 @@ def test_repeat_errors():
     mappings[0] = maps.Projection(mesh.n_cells, [0, 1, 3, 5, 10])
     with pytest.raises(ValueError):
         RepeatedSimulation(sim, mappings)
+
+
+def test_cache_clear_on_model_clear():
+    mesh = TensorMesh([16, 16, 16], origin="CCN")
+
+    rx_locs = np.mgrid[-0.25:0.25:5j, -0.25:0.25:5j, 0:1:1j]
+    rx_locs = rx_locs.reshape(3, -1).T
+    rxs = dc.receivers.Pole(rx_locs)
+    source_locs = np.mgrid[-0.5:0.5:10j, 0:1:1j, 0:1:1j].reshape(3, -1).T
+    src_list = [
+        dc.sources.Pole(
+            [
+                rxs,
+            ],
+            location=loc,
+        )
+        for loc in source_locs
+    ]
+
+    m_test = np.arange(mesh.n_cells) / mesh.n_cells + 0.1
+
+    # split by chunks of sources
+    chunk_size = 3
+    sims = []
+    mappings = []
+    for i in range(0, len(src_list) + 1, chunk_size):
+        end = min(i + chunk_size, len(src_list))
+        if i == end:
+            break
+        survey_chunk = dc.Survey(src_list[i:end])
+        sims.append(
+            dc.Simulation3DNodal(mesh, survey=survey_chunk, sigmaMap=maps.IdentityMap())
+        )
+        mappings.append(maps.IdentityMap())
+
+    multi_sim = MetaSimulation(sims, mappings)
+
+    assert multi_sim.model is None
+    for sim in multi_sim.simulations:
+        assert sim.model is None
+
+    # create fields to do some caching operations
+    multi_sim.fields(m_test)
+    assert multi_sim.model is not None
+    for sim in multi_sim.simulations:
+        assert sim._Me_Sigma is not None
+
+    # then set to None to make sure that works (and it clears things)
+    multi_sim.model = None
+    assert multi_sim.model is None
+    for sim in multi_sim.simulations:
+        assert sim.model is None
+        assert not hasattr(sim, "_Me_Sigma")


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/basic/contributing.html#pull-request

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
A few small fixes for the `MetaSimulation`

#### PR Checklist
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/basic/practices.html#style).
* [x] Added [tests](https://docs.simpeg.xyz/content/basic/practices.html#testing) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/basic/practices.html#documentation).
* [x] Added relevant method tags (i.e. `GRAV`, `EM`, etc.)
* [x] Marked as ready for review (ff this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### What does this implement/fix?
There were a few small bugs with the `MetaSimulation` that were identified in use. One is that setting a `meta_sim.model = None` should work (and also it should get initialized with a model equal to `None`). The second is changing the call to internal `fields` to not be a keyword argument. Every call to fields expects the model to be the first argument, but not all of them called it `m` (only the integral magnetic simulation did not).

<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->