### PR TITLE
Replace deprecated numpy type aliases with builtin types

### DIFF
--- a/SimPEG/electromagnetics/viscous_remanent_magnetization/sources.py
+++ b/SimPEG/electromagnetics/viscous_remanent_magnetization/sources.py
@@ -168,7 +168,7 @@ class MagDipole(BaseSrcVRM):
 
         """
 
-        refFlag = np.zeros(np.shape(xyzc)[0], dtype=np.int)
+        refFlag = np.zeros(np.shape(xyzc)[0], dtype=int)
 
         r = np.sqrt(
             (xyzc[:, 0] - self.location[0]) ** 2
@@ -330,7 +330,7 @@ class CircLoop(BaseSrcVRM):
 
         """
 
-        refFlag = np.zeros(np.shape(xyzc)[0], dtype=np.int)
+        refFlag = np.zeros(np.shape(xyzc)[0], dtype=int)
 
         r0 = self.location
         a = self.radius
@@ -523,12 +523,12 @@ class LineCurrent(BaseSrcVRM):
 
         """
 
-        ref_flag = np.zeros(np.shape(xyzc)[0], dtype=np.int)
+        ref_flag = np.zeros(np.shape(xyzc)[0], dtype=int)
 
         nSeg = np.shape(self.location)[0] - 1
 
         for tt in range(0, nSeg):
-            ref_flag_tt = np.zeros(np.shape(xyzc)[0], dtype=np.int)
+            ref_flag_tt = np.zeros(np.shape(xyzc)[0], dtype=int)
             tx0 = self.location[tt, :]
             tx1 = self.location[tt + 1, :]
             a = (tx1[0] - tx0[0]) ** 2 + (tx1[1] - tx0[1]) ** 2 + (tx1[2] - tx0[2]) ** 2
@@ -546,7 +546,7 @@ class LineCurrent(BaseSrcVRM):
                     + (tx0[2] - xyzc[:, 2]) ** 2
                     - d**2
                 )
-                e = np.array(b**2 - 4 * a * c, dtype=np.complex)
+                e = np.array(b**2 - 4 * a * c, dtype=complex)
 
                 q_pos = (-b + np.sqrt(e)) / (2 * a)
                 q_neg = (-b - np.sqrt(e)) / (2 * a)

--- a/SimPEG/flow/richards/survey.py
+++ b/SimPEG/flow/richards/survey.py
@@ -81,14 +81,12 @@ class Survey(BaseSurvey):
         numpy.ndarray
             Adjoint derivative with respect to model times a vector
         """
-        dd_du = []
-        dd_dm = []
+        dd_du = 0
+        dd_dm = 0
         cnt = 0
-        for ii, rx in enumerate(self.receiver_list):
+        for rx in self.receiver_list:
             du, dm = rx.deriv(f, simulation, v=v[cnt : cnt + rx.nD], adjoint=True)
-            if not isinstance(du, Zero):
-                dd_du.append(du)
-            if not isinstance(dm, Zero):
-                dd_dm.append(dm)
+            dd_du = dd_du + du
+            dd_dm = dd_dm + dm
             cnt += rx.nD
-        return np.sum(dd_du, axis=0), np.sum(dd_dm, axis=0)
+        return dd_du, dd_dm

--- a/SimPEG/flow/richards/survey.py
+++ b/SimPEG/flow/richards/survey.py
@@ -3,6 +3,7 @@ import numpy as np
 
 from ...survey import BaseSurvey, BaseRx
 from ...utils import validate_list_of_types
+from discretize.utils import Zero
 
 
 class Survey(BaseSurvey):
@@ -80,12 +81,14 @@ class Survey(BaseSurvey):
         numpy.ndarray
             Adjoint derivative with respect to model times a vector
         """
-        dd_du = list(range(len(self.receiver_list)))
-        dd_dm = list(range(len(self.receiver_list)))
+        dd_du = []
+        dd_dm = []
         cnt = 0
         for ii, rx in enumerate(self.receiver_list):
-            dd_du[ii], dd_dm[ii] = rx.deriv(
-                f, simulation, v=v[cnt : cnt + rx.nD], adjoint=True
-            )
+            du, dm = rx.deriv(f, simulation, v=v[cnt : cnt + rx.nD], adjoint=True)
+            if not isinstance(du, Zero):
+                dd_du.append(du)
+            if not isinstance(dm, Zero):
+                dd_dm.append(dm)
             cnt += rx.nD
         return np.sum(dd_du, axis=0), np.sum(dd_dm, axis=0)

--- a/SimPEG/flow/richards/survey.py
+++ b/SimPEG/flow/richards/survey.py
@@ -3,7 +3,6 @@ import numpy as np
 
 from ...survey import BaseSurvey, BaseRx
 from ...utils import validate_list_of_types
-from discretize.utils import Zero
 
 
 class Survey(BaseSurvey):

--- a/SimPEG/utils/drivers/gravity_driver.py
+++ b/SimPEG/utils/drivers/gravity_driver.py
@@ -110,7 +110,7 @@ class GravityDriver_Inv(object):
         l_input = re.split(r"[!\s]", line)
         if l_input[0] == "VALUE":
             val = np.array(l_input[1:5])
-            alphas = val.astype(np.float)
+            alphas = val.astype(float)
 
         elif l_input[0] == "DEFAULT":
             alphas = np.ones(4)
@@ -120,7 +120,7 @@ class GravityDriver_Inv(object):
         l_input = re.split(r"[!\s]", line)
         if l_input[0] == "VALUE":
             val = np.array(l_input[1:3])
-            bounds = val.astype(np.float)
+            bounds = val.astype(float)
 
         elif l_input[0] == "FILE":
             bounds = l_input[1].rstrip()
@@ -133,7 +133,7 @@ class GravityDriver_Inv(object):
         l_input = re.split(r"[!\s]", line)
         if l_input[0] == "VALUE":
             val = np.array(l_input[1:6])
-            lpnorms = val.astype(np.float)
+            lpnorms = val.astype(float)
 
         elif l_input[0] == "FILE":
             lpnorms = l_input[1].rstrip()
@@ -143,7 +143,7 @@ class GravityDriver_Inv(object):
         l_input = re.split(r"[!\s]", line)
         if l_input[0] == "VALUE":
             val = np.array(l_input[1:3])
-            eps = val.astype(np.float)
+            eps = val.astype(float)
 
         elif l_input[0] == "DEFAULT":
             eps = None

--- a/SimPEG/utils/drivers/magnetics_driver.py
+++ b/SimPEG/utils/drivers/magnetics_driver.py
@@ -119,7 +119,7 @@ class MagneticsDriver_Inv(object):
         l_input = re.split(r"[!\s]", line)
         if l_input[0] == "VALUE":
             val = np.array(l_input[1:5])
-            alphas = val.astype(np.float)
+            alphas = val.astype(float)
 
         elif l_input[0] == "DEFAULT":
             alphas = np.ones(4)
@@ -129,7 +129,7 @@ class MagneticsDriver_Inv(object):
         l_input = re.split(r"[!\s]", line)
         if l_input[0] == "VALUE":
             val = np.array(l_input[1:3])
-            bounds = val.astype(np.float)
+            bounds = val.astype(float)
 
         elif l_input[0] == "FILE":
             bounds = l_input[1].rstrip()
@@ -142,7 +142,7 @@ class MagneticsDriver_Inv(object):
         l_input = re.split(r"[!\s]", line)
         if l_input[0] == "VALUE":
             val = np.array(l_input[1:6])
-            lpnorms = val.astype(np.float)
+            lpnorms = val.astype(float)
 
         elif l_input[0] == "FILE":
             lpnorms = l_input[1].rstrip()
@@ -152,7 +152,7 @@ class MagneticsDriver_Inv(object):
         l_input = re.split(r"[!\s]", line)
         if l_input[0] == "VALUE":
             val = np.array(l_input[1:3])
-            eps = val.astype(np.float)
+            eps = val.astype(float)
 
         elif l_input[0] == "DEFAULT":
             eps = None

--- a/SimPEG/utils/io_utils/io_utils_general.py
+++ b/SimPEG/utils/io_utils/io_utils_general.py
@@ -35,7 +35,7 @@ def read_GOCAD_ts(tsfile):
     while re.match("VRTX", line):
         l_input = re.split(r"[\s*]", line)
         temp = np.array(l_input[2:5])
-        vrtx.append(temp.astype(np.float))
+        vrtx.append(temp.astype(float))
 
         # Read next line
         line = fid.readline()
@@ -53,7 +53,7 @@ def read_GOCAD_ts(tsfile):
     while re.match("TRGL", line):
         l_input = re.split(r"[\s*]", line)
         temp = np.array(l_input[1:4])
-        trgl.append(temp.astype(np.int))
+        trgl.append(temp.astype(int))
 
         # Read next line
         line = fid.readline()

--- a/examples/20-published/plot_heagyetal2017_casing.py
+++ b/examples/20-published/plot_heagyetal2017_casing.py
@@ -184,7 +184,7 @@ class PrimSecCasingExample(object):
 
             # cell size, number of core cells, number of padding cells in the
             # x-direction
-            ncz = np.int(np.ceil(np.diff(self.casing_z)[0] / csz)) + 10
+            ncz = int(np.ceil(np.diff(self.casing_z)[0] / csz)) + 10
             npadzu, npadzd = 43, 43
 
             # vector of cell widths in the z-direction

--- a/examples/20-published/plot_schenkel_morrison_casing.py
+++ b/examples/20-published/plot_schenkel_morrison_casing.py
@@ -105,7 +105,7 @@ def run(plotIt=True):
     nza = 10
     # cell size, number of core cells, number of padding cells in the
     # x-direction
-    ncz, npadzu, npadzd = np.int(np.ceil(np.diff(casing_z)[0] / csz)) + 10, 68, 68
+    ncz, npadzu, npadzd = int(np.ceil(np.diff(casing_z)[0] / csz)) + 10, 68, 68
     # vector of cell widths in the z-direction
     hz = utils.unpack_widths([(csz, npadzd, -1.3), (csz, ncz), (csz, npadzu, 1.3)])
 

--- a/tests/em/nsem/inversion/test_BC_Sims.py
+++ b/tests/em/nsem/inversion/test_BC_Sims.py
@@ -163,7 +163,7 @@ def create_simulation_2d(sim_type, deriv_type, mesh_type, fixed_boundary=False):
             right = np.where(b_e[:, 0] == mesh.nodes_x[-1])
             h_bc = {}
             for src in survey_1d.source_list:
-                h_bc_freq = np.zeros(mesh.boundary_edges.shape[0], dtype=np.complex)
+                h_bc_freq = np.zeros(mesh.boundary_edges.shape[0], dtype=complex)
                 h_bc_freq[top] = 1.0
                 h_bc_freq[right] = f_right[src, "h"][:, 0]
                 h_bc_freq[left] = f_left[src, "h"][:, 0]
@@ -214,7 +214,7 @@ def create_simulation_2d(sim_type, deriv_type, mesh_type, fixed_boundary=False):
             right = np.where(b_e[:, 0] == mesh.nodes_x[-1])
             e_bc = {}
             for src in survey_1d.source_list:
-                e_bc_freq = np.zeros(mesh.boundary_edges.shape[0], dtype=np.complex)
+                e_bc_freq = np.zeros(mesh.boundary_edges.shape[0], dtype=complex)
                 e_bc_freq[top] = 1.0
                 e_bc_freq[right] = f_right[src, "e"][:, 0]
                 e_bc_freq[left] = f_left[src, "e"][:, 0]


### PR DESCRIPTION
#### Summary
Hi! According to numpy/numpy#14882, **_np.{builtin}_**(np.float, np.str, etc.), which were aliases to python builtin types, was deprecated, and has been removed in numpy 1.24.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/basic/practices.html#style).
* [x] Added [tests](https://docs.simpeg.xyz/content/basic/practices.html#testing) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/basic/practices.html#documentation).
* [x] Added relevant method tags (i.e. `GRAV`, `EM`, etc.)
* [ ] Marked as ready for review (ff this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue

#### What does this implement/fix?
It replaces numpy's type aliases np.{builtin} with corresponding builtin types according to [this note](https://github.com/numpy/numpy/blob/da1621637b7c59c155ec29466fb5f810ebd902ac/doc/release/upcoming_changes/14882.deprecation.rst). It may be better to consider using more precise ones like **np.int64** or **np.complex64**, but it deserves another pr I guess.

Changes are done with regular expressions.
```regex
np\.(bool|int|float|complex|object|str)(?!\d|_|e) -> $1
np\.long(?!\d|_|e) -> int
np\.unicode(?!\d|_|e) -> str
```

#### Additional information