### PR TITLE
Generalize __add__  for any ComboObjectiveFunction

### DIFF
--- a/SimPEG/objective_function.py
+++ b/SimPEG/objective_function.py
@@ -132,7 +132,7 @@ class BaseObjectiveFunction(BaseSimPEG):
             num=num,
             expectedOrder=expectedOrder,
             plotIt=plotIt,
-            **kwargs
+            **kwargs,
         )
 
     def test(self, x=None, num=4, plotIt=False, **kwargs):
@@ -146,32 +146,26 @@ class BaseObjectiveFunction(BaseSimPEG):
 
     __numpy_ufunc__ = True
 
-    def __add__(self, objfct2):
-        if isinstance(objfct2, Zero):
+    def __add__(self, other):
+        if isinstance(other, Zero):
             return self
-
-        if not isinstance(objfct2, BaseObjectiveFunction):
-            raise Exception(
-                "Cannot add type {} to an objective function. Only "
-                "ObjectiveFunctions can be added together".format(
-                    objfct2.__class__.__name__
-                )
+        if not isinstance(other, BaseObjectiveFunction):
+            raise TypeError(
+                f"Cannot add type '{other.__class__.__name__}' to an objective "
+                "function. Only ObjectiveFunctions can be added together."
             )
-
-        if (
-            self.__class__.__name__ != "ComboObjectiveFunction"
-        ):  # not isinstance(self, ComboObjectiveFunction):
-            self = 1 * self
-
-        if (
-            objfct2.__class__.__name__ != "ComboObjectiveFunction"
-        ):  # not isinstance(objfct2, ComboObjectiveFunction):
-            objfct2 = 1 * objfct2
-
-        objfctlist = self.objfcts + objfct2.objfcts
-        multipliers = self.multipliers + objfct2.multipliers
-
-        return ComboObjectiveFunction(objfcts=objfctlist, multipliers=multipliers)
+        objective_functions, multipliers = [], []
+        for instance in (self, other):
+            if isinstance(instance, ComboObjectiveFunction) and instance._unpack_on_add:
+                objective_functions += instance.objfcts
+                multipliers += instance.multipliers
+            else:
+                objective_functions.append(instance)
+                multipliers.append(1)
+        combo = ComboObjectiveFunction(
+            objfcts=objective_functions, multipliers=multipliers
+        )
+        return combo
 
     def __radd__(self, objfct2):
         return self + objfct2
@@ -183,47 +177,91 @@ class BaseObjectiveFunction(BaseSimPEG):
         return self * multiplier
 
     def __div__(self, denominator):
-        return self.__mul__(1.0 / denominator)
+        return self * (1.0 / denominator)
 
     def __truediv__(self, denominator):
-        return self.__mul__(1.0 / denominator)
+        return self * (1.0 / denominator)
 
     def __rdiv__(self, denominator):
-        return self.__mul__(1.0 / denominator)
+        return self * (1.0 / denominator)
 
 
 class ComboObjectiveFunction(BaseObjectiveFunction):
     """
-    A composite objective function that consists of multiple objective
-    functions. Objective functions are stored in a list, and multipliers
-    are stored in a parallel list.
+    Composite for multiple objective functions
 
-    .. code::python
+    A composite class for multiple objective functions. Each objective function
+    is accompanied by a multiplier. Both objective functions and multipliers
+    are stored in a list.
 
-        import SimPEG.ObjectiveFunction
-        phi1 = ObjectiveFunction.L2ObjectiveFunction(nP=10)
-        phi2 = ObjectiveFunction.L2ObjectiveFunction(nP=10)
+    Parameters
+    ----------
+    objfcts : list or None, optional
+        List containing the objective functions that will live inside the
+        composite class. If ``None``, an empty list will be created.
+    multipliers : list or None, optional
+        List containing the multipliers for its respective objective function
+        in ``objfcts``.  If ``None``, a list full of ones with the same length
+        as ``objfcts`` will be created.
+    unpack_on_add : bool, optional
+        Weather to unpack the multiple objective functions when adding them to
+        another objective function, or to add them as a whole.
 
-        phi = 2*phi1 + 3*phi2
+    Examples
+    --------
+    Build a simple combo objective function:
 
-    is equivalent to
+    >>> objective_fun_a = L2ObjectiveFunction(nP=3)
+    >>> objective_fun_b = L2ObjectiveFunction(nP=3)
+    >>> combo = ComboObjectiveFunction([objective_fun_a, objective_fun_b], [1, 0.5])
+    >>> print(len(combo))
+    2
+    >>> print(combo.multipliers)
+    [1, 0.5]
 
-        .. code::python
+    Combo objective functions are also created after adding two objective functions:
 
-            import SimPEG.ObjectiveFunction
-            phi1 = ObjectiveFunction.L2ObjectiveFunction(nP=10)
-            phi2 = ObjectiveFunction.L2ObjectiveFunction(nP=10)
+    >>> combo = 2 * objective_fun_a + 3.5 * objective_fun_b
+    >>> print(len(combo))
+    2
+    >>> print(combo.multipliers)
+    [2, 3.5]
 
-            phi = ObjectiveFunction.ComboObjectiveFunction(
-                [phi1, phi2], [2, 3]
-            )
+    We could add two combo objective functions as well:
+
+    >>> objective_fun_c = L2ObjectiveFunction(nP=3)
+    >>> objective_fun_d = L2ObjectiveFunction(nP=3)
+    >>> combo_1 = 4.3 * objective_fun_a + 3 * objective_fun_b
+    >>> combo_2 = 1.5 * objective_fun_c + 0.5 * objective_fun_d
+    >>> combo = combo_1 + combo_2
+    >>> print(len(combo))
+    4
+    >>> print(combo.multipliers)
+    [4.3, 3, 1.5, 0.5]
+
+    We can choose to not unpack the objective functions when creating the
+    combo. For example:
+
+    >>> objective_fun_a = L2ObjectiveFunction(nP=3)
+    >>> objective_fun_b = L2ObjectiveFunction(nP=3)
+    >>> objective_fun_c = L2ObjectiveFunction(nP=3)
+    >>>
+    >>> # Create a ComboObjectiveFunction that won't unpack
+    >>> combo_1 = ComboObjectiveFunction(
+    ...     objfcts=[objective_fun_a, objective_fun_b],
+    ...     multipliers=[0.1, 1.2],
+    ...     unpack_on_add=False,
+    ... )
+    >>> combo_2 = combo_1 + objective_fun_c
+    >>> print(len(combo_2))
+    2
 
     """
 
     _multiplier_types = (float, None, Zero, np.float64, int, np.integer)  # Directive
     _multipliers = None
 
-    def __init__(self, objfcts=None, multipliers=None, **kwargs):
+    def __init__(self, objfcts=None, multipliers=None, unpack_on_add=True, **kwargs):
         if objfcts is None:
             objfcts = []
         if multipliers is None:
@@ -269,6 +307,7 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
 
         self.objfcts = objfcts
         self._multipliers = multipliers
+        self._unpack_on_add = unpack_on_add
 
         super(ComboObjectiveFunction, self).__init__(**kwargs)
 

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -781,7 +781,7 @@ class WeightedLeastSquares(ComboObjectiveFunction):
                 )
         else:
             objfcts = kwargs.pop("objfcts")
-        super().__init__(objfcts=objfcts, **kwargs)
+        super().__init__(objfcts=objfcts, unpack_on_add=False, **kwargs)
         self.mapping = mapping
         self.reference_model = reference_model
         self.reference_model_in_smooth = reference_model_in_smooth

--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -748,7 +748,7 @@ class PGI(ComboObjectiveFunction):
                 )
             ]
 
-        super().__init__(objfcts=objfcts)
+        super().__init__(objfcts=objfcts, unpack_on_add=False)
         self.reference_model_in_smooth = reference_model_in_smooth
         self.alpha_pgi = alpha_pgi
 

--- a/tests/base/test_objective_function.py
+++ b/tests/base/test_objective_function.py
@@ -354,6 +354,17 @@ class TestOperationsComboObjectiveFunctions:
             combo_1 = combo_2.objfcts[1]
             assert combo_1.multipliers == [2, 3]
 
+    def test_add_multiple_terms(self, unpack_on_add):
+        """Test addition of multiple BaseObjectiveFunctions"""
+        n_params = 10
+        phi1 = objective_function.L2ObjectiveFunction(nP=n_params)
+        phi2 = objective_function.L2ObjectiveFunction(nP=n_params)
+        phi3 = objective_function.L2ObjectiveFunction(nP=n_params)
+        combo = 1.1 * phi1 + 1.2 * phi2 + 1.3 * phi3
+        assert len(combo) == 3
+        assert combo.multipliers == [1.1, 1.2, 1.3]
+        assert combo.objfcts == [phi1, phi2, phi3]
+
     @pytest.mark.parametrize("unpack_on_add", (True, False))
     def test_add_and_mul(self, unpack_on_add):
         """Test ComboObjectiveFunction addition with multiplication"""

--- a/tests/base/test_objective_function.py
+++ b/tests/base/test_objective_function.py
@@ -367,7 +367,12 @@ class TestOperationsComboObjectiveFunctions:
 
     @pytest.mark.parametrize("unpack_on_add", (True, False))
     def test_add_and_mul(self, unpack_on_add):
-        """Test ComboObjectiveFunction addition with multiplication"""
+        """
+        Test ComboObjectiveFunction addition with multiplication
+
+        After multiplying a Combo with a scalar, the `__mul__` method creates
+        another Combo for it.
+        """
         n_params = 10
         phi1 = objective_function.L2ObjectiveFunction(nP=n_params)
         phi2 = objective_function.L2ObjectiveFunction(nP=n_params)
@@ -376,16 +381,9 @@ class TestOperationsComboObjectiveFunctions:
             [phi1, phi2], [2, 3], unpack_on_add=unpack_on_add
         )
         combo_2 = 5 * phi3 + 1.2 * combo_1
-        if unpack_on_add:
-            assert len(combo_2) == 3
-            assert combo_2.multipliers == [5, 1.2 * 2, 1.2 * 3]
-            assert combo_2.objfcts == [phi3, phi1, phi2]
-        else:
-            assert len(combo_2) == 2
-            assert combo_2.multipliers == [5, 1]
-            assert combo_2.objfcts == [phi3, combo_1]
-            combo_1 = combo_2.objfcts[1]
-            assert combo_1.multipliers == [1.2 * 2, 1.2 * 3]
+        assert len(combo_2) == 2
+        assert combo_2.multipliers == [5, 1.2]
+        assert combo_2.objfcts == [phi3, combo_1]
 
 
 if __name__ == "__main__":

--- a/tests/base/test_objective_function.py
+++ b/tests/base/test_objective_function.py
@@ -354,7 +354,7 @@ class TestOperationsComboObjectiveFunctions:
             combo_1 = combo_2.objfcts[1]
             assert combo_1.multipliers == [2, 3]
 
-    def test_add_multiple_terms(self, unpack_on_add):
+    def test_add_multiple_terms(self):
         """Test addition of multiple BaseObjectiveFunctions"""
         n_params = 10
         phi1 = objective_function.L2ObjectiveFunction(nP=n_params)


### PR DESCRIPTION
#### Summary

Rewrite the `__add__` method of `BaseObjectiveFunction` so by default it performs the same task for any `ComboObjectiveFunction` or any of its child classes. Add a new `unpack_on_add` attribute to `ComboObjectiveFunction` to decide weather to unpack its objective functions after an addition, or if it should be added as a whole. Set `unpack_on_add=True` by default on `ComboObjectiveFunction`, but set it to `False` for regularization classes, like `WeightedLeastSquares` and `PGI`. Add tests for the new changes.


#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/basic/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/basic/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/basic/practices.html#documentation).
* [ ] Added relevant method tags (i.e. `GRAV`, `EM`, etc.)
* [ ] Marked as ready for review (ff this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?

Fixes an unexpected behaviour when subclassing `ComboObjectiveFunction`: by default its `__add__` method would have worked differently than it does for the parent, adding the instance as a whole during the addition. Instead, the `ComboObjectiveFunction` gets unpacked, and every objective function in its `objfcts` attribute is directly included in the addition.


#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
