### PR TITLE
Fix IP simulation / inversion with SimPEG.dask

### DIFF
--- a/SimPEG/dask/electromagnetics/static/induced_polarization/simulation.py
+++ b/SimPEG/dask/electromagnetics/static/induced_polarization/simulation.py
@@ -1,8 +1,8 @@
+import dask.array as da
+
 from .....electromagnetics.static.induced_polarization.simulation import (
     BaseIPSimulation as Sim,
 )
-
-import dask.array as da
 
 
 def dask_getJtJdiag(self, m, W=None, f=None):
@@ -13,9 +13,9 @@ def dask_getJtJdiag(self, m, W=None, f=None):
         J = self.getJ(m, f=f)
         # Need to check if multiplying weights makes sense
         if W is None:
-            W = self._scale
+            W = self.scale
         else:
-            W = self._scale * W.diagonal()
+            W = self.scale * W.diagonal()
         w = da.from_array(W)[:, None]
         self._gtgdiag = da.sum((w * J) ** 2, axis=0).compute()
 

--- a/SimPEG/dask/electromagnetics/static/induced_polarization/simulation.py
+++ b/SimPEG/dask/electromagnetics/static/induced_polarization/simulation.py
@@ -16,7 +16,7 @@ def dask_getJtJdiag(self, m, W=None, f=None):
             W = self._scale
         else:
             W = self._scale * W.diagonal()
-        self._gtgdiag = da.einsum("i,ij,ij->j", W**2.0, J, axis=0).compute()
+        self._gtgdiag = da.einsum("i,ij,ij->j", W**2, J, J).compute()
 
     return self._gtgdiag
 

--- a/SimPEG/dask/electromagnetics/static/induced_polarization/simulation.py
+++ b/SimPEG/dask/electromagnetics/static/induced_polarization/simulation.py
@@ -13,11 +13,10 @@ def dask_getJtJdiag(self, m, W=None, f=None):
         J = self.getJ(m, f=f)
         # Need to check if multiplying weights makes sense
         if W is None:
-            W = self.scale
+            W = self._scale
         else:
-            W = self.scale * W.diagonal()
-        w = da.from_array(W)[:, None]
-        self._gtgdiag = da.sum((w * J) ** 2, axis=0).compute()
+            W = self._scale * W.diagonal()
+        self._gtgdiag = da.einsum("i,ij,ij->j", W**2.0, J, axis=0).compute()
 
     return self._gtgdiag
 

--- a/SimPEG/dask/electromagnetics/static/induced_polarization/simulation.py
+++ b/SimPEG/dask/electromagnetics/static/induced_polarization/simulation.py
@@ -1,8 +1,6 @@
-from .....electromagnetics.static.induced_polarization.simulation import (
-    BaseIPSimulation as Sim,
-)
-
 import dask.array as da
+
+from .....electromagnetics.static.induced_polarization.simulation import BaseIPSimulation as Sim
 
 
 def dask_getJtJdiag(self, m, W=None, f=None):
@@ -10,13 +8,14 @@ def dask_getJtJdiag(self, m, W=None, f=None):
     Return the diagonal of JtJ
     """
     if getattr(self, "_gtgdiag", None) is None:
+        J = self.getJ(m, f=f)
         # Need to check if multiplying weights makes sense
         if W is None:
             W = self._scale
         else:
             W = self._scale * W.diagonal()
         w = da.from_array(W)[:, None]
-        self._gtgdiag = da.sum((w * self.getJ(m, f=f)) ** 2, axis=0).compute()
+        self._gtgdiag = da.sum((w * J) ** 2, axis=0).compute()
 
     return self._gtgdiag
 

--- a/SimPEG/electromagnetics/static/induced_polarization/simulation.py
+++ b/SimPEG/electromagnetics/static/induced_polarization/simulation.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 import numpy as np
 import scipy.sparse as sp
 
@@ -39,24 +41,22 @@ class BaseIPSimulation(BasePDESimulation):
     def rhoDeriv(self):
         return sp.diags(self.rho) @ self.etaDeriv
 
-    @property
-    def scale(self):
-        if getattr(self, "_scale", None) is None:
-            scale = Data(self.survey, np.ones(self.survey.nD))
-            if self._f is None:
-                # re-uses the DC simulation's fields method
-                self._f = super().fields(None)
-            try:
-                f = self.fields_to_space(self._f)
-            except AttributeError:
-                f = self._f
-            # loop through receievers to check if they need to set the _dc_voltage
-            for src in self.survey.source_list:
-                for rx in src.receiver_list:
-                    if rx.data_type == "apparent_chargeability":
-                        scale[src, rx] = 1.0 / rx.eval(src, self.mesh, f)
-            self._scale = scale.dobs
-        return self._scale
+    @cached_property
+    def _scale(self):
+        scale = Data(self.survey, np.ones(self.survey.nD))
+        if self._f is None:
+            # re-uses the DC simulation's fields method
+            self._f = super().fields(None)
+        try:
+            f = self.fields_to_space(self._f)
+        except AttributeError:
+            f = self._f
+        # loop through receivers to check if they need to set the _dc_voltage
+        for src in self.survey.source_list:
+            for rx in src.receiver_list:
+                if rx.data_type == "apparent_chargeability":
+                    scale[src, rx] = 1.0 / rx.eval(src, self.mesh, f)
+        return scale.dobs
 
     eta, etaMap, etaDeriv = props.Invertible("Electrical Chargeability (V/V)")
 
@@ -112,22 +112,22 @@ class BaseIPSimulation(BasePDESimulation):
         if getattr(self, "_gtgdiag", None) is None:
             J = self.getJ(m, f=f)
             if W is None:
-                W = self.scale**2
+                W = self._scale**2
             else:
-                W = (self.scale * W.diagonal()) ** 2
+                W = (self._scale * W.diagonal()) ** 2
 
             self._gtgdiag = np.einsum("i,ij,ij->j", W, J, J)
 
         return self._gtgdiag
 
     def Jvec(self, m, v, f=None):
-        return self.scale * super().Jvec(m, v, f)
+        return self._scale * super().Jvec(m, v, f)
 
     def forward(self, m, f=None):
         return np.asarray(self.Jvec(m, m, f=f))
 
     def Jtvec(self, m, v, f=None):
-        return super().Jtvec(m, v * self.scale, f)
+        return super().Jtvec(m, v * self._scale, f)
 
     @property
     def deleteTheseOnModelUpdate(self):

--- a/SimPEG/electromagnetics/static/induced_polarization/simulation.py
+++ b/SimPEG/electromagnetics/static/induced_polarization/simulation.py
@@ -87,6 +87,9 @@ class BaseIPSimulation(BasePDESimulation):
     def fields(self, m):
         if self.verbose:
             print(">> Compute DC fields")
+        if self._f is None:
+            # re-uses the DC simulation's fields method
+            self._f = super().fields(None)
 
         self._pred = self.forward(m, f=self._f)
 

--- a/SimPEG/electromagnetics/static/induced_polarization/simulation.py
+++ b/SimPEG/electromagnetics/static/induced_polarization/simulation.py
@@ -83,7 +83,6 @@ class BaseIPSimulation(BasePDESimulation):
 
     _Jmatrix = None
     _pred = None
-    _scale = None
 
     def fields(self, m):
         if self.verbose:

--- a/tests/dask/test_IP_jvecjtvecadj_dask.py
+++ b/tests/dask/test_IP_jvecjtvecadj_dask.py
@@ -7,7 +7,16 @@ import discretize as ds
 import numpy as np
 
 import SimPEG.dask  # noqa: F401
-from SimPEG import data_misfit, inverse_problem, inversion, maps, optimization, regularization, tests, utils
+from SimPEG import (
+    data_misfit,
+    inverse_problem,
+    inversion,
+    maps,
+    optimization,
+    regularization,
+    tests,
+    utils,
+)
 from SimPEG.electromagnetics import induced_polarization as ip
 from SimPEG.electromagnetics import resistivity as dc
 from SimPEG.utils.io_utils.io_utils_electromagnetics import read_dcip2d_ubc
@@ -70,7 +79,10 @@ class IPProblemTests2DN(unittest.TestCase):
         conductivity_model = background_conductivity * np.ones(nC)
 
         simulation = ip.simulation.Simulation2DNodal(
-            mesh=mesh, survey=ip_data.survey, sigma=conductivity_model, etaMap=active_map
+            mesh=mesh,
+            survey=ip_data.survey,
+            sigma=conductivity_model,
+            etaMap=active_map,
         )
         mSynth = np.ones(mesh.nC) * 0.1
         # test without calling make_synthetic_data first to simulate real data case
@@ -78,7 +90,9 @@ class IPProblemTests2DN(unittest.TestCase):
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=simulation)
         reg = regularization.WeightedLeastSquares(mesh)
-        opt = optimization.InexactGaussNewton(maxIterLS=5, maxIter=1, tolF=1e-6, tolX=1e-6, tolG=1e-6, maxIterCG=5)
+        opt = optimization.InexactGaussNewton(
+            maxIterLS=5, maxIter=1, tolF=1e-6, tolX=1e-6, tolG=1e-6, maxIterCG=5
+        )
         invProb = inverse_problem.BaseInvProblem(dmis, reg, opt, beta=1e4)
         inv = inversion.BaseInversion(invProb)
 
@@ -111,7 +125,9 @@ class IPProblemTests2DN(unittest.TestCase):
         self.assertTrue(passed)
 
     def test_dataObj(self):
-        passed = tests.check_derivative(lambda m: [self.dmis(m), self.dmis.deriv(m)], self.m0, plotIt=False, num=3)
+        passed = tests.check_derivative(
+            lambda m: [self.dmis(m), self.dmis.deriv(m)], self.m0, plotIt=False, num=3
+        )
         self.assertTrue(passed)
 
 

--- a/tests/dask/test_IP_jvecjtvecadj_dask.py
+++ b/tests/dask/test_IP_jvecjtvecadj_dask.py
@@ -25,6 +25,12 @@ np.random.seed(30)
 
 
 class IPProblemTests2DN(unittest.TestCase):
+    """
+    This test builds upon the 2D files used in the IP2D tutorial, with a much smaller mesh.
+
+    It tests IP 2D with dask without calling `make_synthetic_data` first to simulate a real data case.
+    """
+
     def setUp(self):
         # storage bucket where we have the data
         data_source = "https://storage.googleapis.com/simpeg/doc-assets/dcip2d.tar.gz"

--- a/tests/dask/test_IP_jvecjtvecadj_dask.py
+++ b/tests/dask/test_IP_jvecjtvecadj_dask.py
@@ -84,7 +84,7 @@ class IPProblemTests2DN(unittest.TestCase):
             sigma=conductivity_model,
             etaMap=active_map,
         )
-        mSynth = np.ones(mesh.nC) * 0.1
+        mSynth = np.ones(nC) * 0.1
         # test without calling make_synthetic_data first to simulate real data case
         dobs = read_dcip2d_ubc(ip_data_filename, "apparent_chargeability", "general")
         # Now set up the problem to do some minimization
@@ -116,8 +116,9 @@ class IPProblemTests2DN(unittest.TestCase):
 
     def test_adjoint(self):
         # Adjoint Test
-        v = np.random.rand(self.mesh.nC)
+        v = np.random.rand(len(self.m0))
         w = np.random.rand(self.survey.nD)
+        # J = self.p.getJ(self.m0)
         wtJv = w.dot(self.p.Jvec(self.m0, v))
         vtJtw = v.dot(self.p.Jtvec(self.m0, w))
         passed = np.abs(wtJv - vtJtw) < 1e-10

--- a/tests/dask/test_IP_jvecjtvecadj_dask.py
+++ b/tests/dask/test_IP_jvecjtvecadj_dask.py
@@ -1,21 +1,118 @@
+import os
+import shutil
+import tarfile
 import unittest
-import discretize
+
+import discretize as ds
 import numpy as np
 
 import SimPEG.dask  # noqa: F401
-from SimPEG import maps
-from SimPEG import data_misfit
-from SimPEG import regularization
-from SimPEG import optimization
-from SimPEG import inversion
-from SimPEG import inverse_problem
-from SimPEG import tests
-
-from SimPEG.electromagnetics import resistivity as dc
+from SimPEG import data_misfit, inverse_problem, inversion, maps, optimization, regularization, tests, utils
 from SimPEG.electromagnetics import induced_polarization as ip
-import shutil
+from SimPEG.electromagnetics import resistivity as dc
+from SimPEG.utils.io_utils.io_utils_electromagnetics import read_dcip2d_ubc
 
 np.random.seed(30)
+
+
+class IPProblemTests2DN(unittest.TestCase):
+    def setUp(self):
+        # storage bucket where we have the data
+        data_source = "https://storage.googleapis.com/simpeg/doc-assets/dcip2d.tar.gz"
+
+        # download the data
+        downloaded_data = utils.download(data_source, overwrite=True)
+
+        # unzip the tarfile
+        tar = tarfile.open(downloaded_data, "r")
+        tar.extractall()
+        tar.close()
+
+        # path to the directory containing our data
+        dir_path = downloaded_data.split(".")[0] + os.path.sep
+
+        # files to work with
+        topo_filename = dir_path + "topo_xyz.txt"
+        dc_data_filename = dir_path + "dc_data.obs"
+        ip_data_filename = dir_path + "ip_data.obs"
+
+        # Load topo
+        topo_xyz = np.loadtxt(str(topo_filename))
+        # define the 2D topography along the survey line.
+        topo_2d = np.unique(topo_xyz[:, [0, 2]], axis=0)
+        # Load datas
+        dc_data = read_dcip2d_ubc(dc_data_filename, "volt", "general")
+        ip_data = read_dcip2d_ubc(ip_data_filename, "apparent_chargeability", "general")
+        # assign uncertainties
+        dc_data.standard_deviation = 0.05 * np.abs(dc_data.dobs)
+        ip_data.standard_deviation = 5e-3 * np.ones_like(ip_data.dobs)
+        # mesh
+        cs = 10.0
+        mesh = ds.TensorMesh(
+            [
+                [(cs, 20, -1.3), (cs, 20, 1.3)],
+                [(cs, 20, -1.3), (cs, 20, 1.3)],
+            ],
+            "CN",
+        )
+        # Find cells that lie below surface topography
+        ind_active = ds.utils.active_from_xyz(mesh, topo_2d)
+        # Shift electrodes to the surface of discretized topography
+        dc_data.survey.drape_electrodes_on_topography(mesh, ind_active, option="top")
+        ip_data.survey.drape_electrodes_on_topography(mesh, ind_active, option="top")
+
+        # Define conductivity model in S/m (or resistivity model in Ohm m)
+        air_conductivity = 1e-8
+        background_conductivity = 1e-2
+        active_map = maps.InjectActiveCells(mesh, ind_active, air_conductivity)
+        nC = int(ind_active.sum())
+        # Define model
+        conductivity_model = background_conductivity * np.ones(nC)
+
+        simulation = ip.simulation.Simulation2DNodal(
+            mesh=mesh, survey=ip_data.survey, sigma=conductivity_model, etaMap=active_map
+        )
+        mSynth = np.ones(mesh.nC) * 0.1
+        # test without calling make_synthetic_data first to simulate real data case
+        dobs = read_dcip2d_ubc(ip_data_filename, "apparent_chargeability", "general")
+        # Now set up the problem to do some minimization
+        dmis = data_misfit.L2DataMisfit(data=dobs, simulation=simulation)
+        reg = regularization.WeightedLeastSquares(mesh)
+        opt = optimization.InexactGaussNewton(maxIterLS=5, maxIter=1, tolF=1e-6, tolX=1e-6, tolG=1e-6, maxIterCG=5)
+        invProb = inverse_problem.BaseInvProblem(dmis, reg, opt, beta=1e4)
+        inv = inversion.BaseInversion(invProb)
+
+        self.inv = inv
+        self.reg = reg
+        self.p = simulation
+        self.mesh = mesh
+        self.m0 = mSynth
+        self.survey = ip_data.survey
+        self.dmis = dmis
+        self.conductivity_model = conductivity_model
+
+    def test_misfit(self):
+        passed = tests.check_derivative(
+            lambda m: [self.p.dpred(m), lambda mx: self.p.Jvec(self.m0, mx)],
+            self.m0,
+            plotIt=False,
+            num=3,
+        )
+        self.assertTrue(passed)
+
+    def test_adjoint(self):
+        # Adjoint Test
+        v = np.random.rand(self.mesh.nC)
+        w = np.random.rand(self.survey.nD)
+        wtJv = w.dot(self.p.Jvec(self.m0, v))
+        vtJtw = v.dot(self.p.Jtvec(self.m0, w))
+        passed = np.abs(wtJv - vtJtw) < 1e-10
+        print("Adjoint Test", np.abs(wtJv - vtJtw), passed)
+        self.assertTrue(passed)
+
+    def test_dataObj(self):
+        passed = tests.check_derivative(lambda m: [self.dmis(m), self.dmis.deriv(m)], self.m0, plotIt=False, num=3)
+        self.assertTrue(passed)
 
 
 class IPProblemTestsCC(unittest.TestCase):
@@ -26,7 +123,7 @@ class IPProblemTestsCC(unittest.TestCase):
         surveySize = nElecs * aSpacing - aSpacing
         cs = surveySize / nElecs / 4
 
-        mesh = discretize.TensorMesh(
+        mesh = ds.TensorMesh(
             [
                 [(cs, 10, -1.3), (cs, surveySize / cs), (cs, 10, 1.3)],
                 [(cs, 3, -1.3), (cs, 3, 1.3)],
@@ -96,7 +193,7 @@ class IPProblemTestsN(unittest.TestCase):
         surveySize = nElecs * aSpacing - aSpacing
         cs = surveySize / nElecs / 4
 
-        mesh = discretize.TensorMesh(
+        mesh = ds.TensorMesh(
             [
                 [(cs, 10, -1.3), (cs, surveySize / cs), (cs, 10, 1.3)],
                 [(cs, 3, -1.3), (cs, 3, 1.3)],
@@ -165,7 +262,7 @@ class IPProblemTestsCC_storeJ(unittest.TestCase):
         surveySize = nElecs * aSpacing - aSpacing
         cs = surveySize / nElecs / 4
 
-        mesh = discretize.TensorMesh(
+        mesh = ds.TensorMesh(
             [
                 [(cs, 10, -1.3), (cs, surveySize / cs), (cs, 10, 1.3)],
                 [(cs, 3, -1.3), (cs, 3, 1.3)],
@@ -245,7 +342,7 @@ class IPProblemTestsN_storeJ(unittest.TestCase):
         surveySize = nElecs * aSpacing - aSpacing
         cs = surveySize / nElecs / 4
 
-        mesh = discretize.TensorMesh(
+        mesh = ds.TensorMesh(
             [
                 [(cs, 10, -1.3), (cs, surveySize / cs), (cs, 10, 1.3)],
                 [(cs, 3, -1.3), (cs, 3, 1.3)],


### PR DESCRIPTION
#### Summary
`fields` needs to be called first to set `_scale` for IP simulation. It is the case without dask by calling `getJ` at the beginning of the `getJtJdiag` function, but not with the dask function `dask_getJtJdiag`.

#### PR Checklist
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/basic/practices.html#style).
* [x] Added relevant method tags (i.e. `GRAV`, `EM`, etc.) (cannot do it as not a team member)
* [x] Marked as ready for review (ff this is was a draft PR), and converted 
      to a Pull Request 
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review. (cannot do it as not a team member)

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
You can test it by adding `from SimPEG import dask` to the IP tutorial: https://docs.simpeg.xyz/content/tutorials/06-ip/plot_inv_2_dcip2d.html
