### PR TITLE
Move flake8 ignored rules to `.flake8` and rename Makefile targets

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,8 @@
 # ----------------
 [flake8]
 extend-ignore =
+    # Default ignores by flake (added here for when ignore gets overwritten)
+    E121,E123,E126,E226,E24,E704,W503,W504,
     # Too many leading '#' for block comment
     E266,
     # Line too long (82 > 79 characters)
@@ -26,6 +28,112 @@ per-file-ignores =
 exclude-from-doctest =
     # Don't check style in docstring of test functions
     tests
+# Define flake rules that will be ignored for now. Every time a new warning is
+# solved througout the entire project, it should be removed to this list.
+ignore =
+    # assertRaises(Exception): should be considered evil
+	B017,
+    # No explicit stacklevel argument found.
+	B028,
+    # Missing docstring in public module
+	D100,
+    # Missing docstring in public class
+	D101,
+    # Missing docstring in public method
+	D102,
+    # Missing docstring in public function
+	D103,
+    # Missing docstring in public package
+	D104,
+    # Missing docstring in magic method
+	D105,
+    # Missing docstring in __init__
+	D107,
+    # One-line docstring should fit on one line with quotes
+	D200,
+    # No blank lines allowed before function docstring
+	D201,
+    # No blank lines allowed after function docstring
+	D202,
+    # 1 blank line required between summary line and description
+	D205,
+    # Docstring is over-indented
+	D208,
+    # Multi-line docstring closing quotes should be on a separate line
+	D209,
+    # No whitespaces allowed surrounding docstring text
+	D210,
+    # No blank lines allowed before class docstring
+	D211,
+    # Use """triple double quotes"""
+	D300,
+    # First line should end with a period
+	D400,
+    # First line should be in imperative mood; try rephrasing
+    D401,
+    # First line should not be the function's "signature"
+	D402,
+    # First word of the first line should be properly capitalized
+	D403,
+    # No blank lines allowed between a section header and its content
+	D412,
+    # Section has no content
+	D414,
+    # Docstring is empty
+	D419,
+    # module level import not at top of file
+	E402,
+    # comparison to None should be ‘if cond is None:’
+	E711,
+    # do not assign a lambda expression, use a def
+	E731,
+    # 'from %s import *' used; unable to detect undefined names
+	F403,
+    # %r may be undefined, or defined from star imports: %s
+	F405,
+    # '...'.format(...) has unused named argument(s): %s
+	F522,
+    # '...'.format(...) has unused arguments at position(s): %s
+	F523,
+    # '...'.format(...) is missing argument(s) for placeholder(s): %s
+	F524,
+    # f-string is missing placeholders
+	F541,
+    # redefinition of unused %r from line %r
+	F811,
+    # undefined name %r
+	F821,
+    # Block quote ends without a blank line; unexpected unindent.
+	RST201,
+    # Definition list ends without a blank line; unexpected unindent.
+	RST203,
+    # Field list ends without a blank line; unexpected unindent.
+	RST206,
+    # Inline strong start-string without end-string.
+	RST210,
+    # Title underline too short.
+	RST212,
+    # Inline emphasis start-string without end-string.
+	RST213,
+    # Inline interpreted text or phrase reference start-string without end-string.
+	RST215,
+    # Inline substitution_reference start-string without end-string.
+	RST219,
+    # Unexpected indentation.
+	RST301,
+    # Unknown directive type "*".
+	RST303,
+    # Unknown interpreted text role "*".
+	RST304,
+    # Error in "*" directive:
+	RST307,
+    # Previously unseen severe error, not yet assigned a unique code.
+	RST499,
+    # trailing whitespace
+	W291,
+    # blank line contains whitespace
+	W293,
+
 
 # Configure flake8-rst-docstrings
 # -------------------------------

--- a/Makefile
+++ b/Makefile
@@ -1,69 +1,15 @@
 STYLE_CHECK_FILES = SimPEG examples tutorials tests
 
-# Define flake8 warnings that shouldn't be catched for now.
-# Every time a new warning is solved througout the entire project, it should be
-# removed to this list.
-# This list is only meant to be used in the flake-permissive target and it's
-# a temprary solution until every flake8 warning is solved in SimPEG.
-# The first set of rules (up to W504) are the default ignored ones by flake8.
-# Since we are using the --ignore option we are overriding them. They are
-# included in the list so we keep ignoring them while running the
-# flake-permissive target.
-FLAKE8_IGNORE = "E121,E123,E126,E226,E24,E704,W503,W504,\
-	B017,\
-	B028,\
-	D100,\
-	D101,\
-	D102,\
-	D103,\
-	D104,\
-	D105,\
-	D107,\
-	D200,\
-	D201,\
-	D202,\
-	D205,\
-	D208,\
-	D209,\
-	D210,\
-	D211,\
-	D300,\
-	D400,\
-	D401,\
-	D402,\
-	D403,\
-	D412,\
-	D414,\
-	D419,\
-	E402,\
-	E711,\
-	E731,\
-	F403,\
-	F405,\
-	F522,\
-	F523,\
-	F524,\
-	F541,\
-	F811,\
-	F821,\
-	RST201,\
-	RST203,\
-	RST206,\
-	RST210,\
-	RST212,\
-	RST213,\
-	RST215,\
-	RST219,\
-	RST301,\
-	RST303,\
-	RST304,\
-	RST307,\
-	RST499,\
-	W291,\
-	W293,\
-"
+.PHONY: help build coverage lint graphs tests docs check black flake
 
-.PHONY: build coverage lint graphs tests docs check black flake
+help:
+	@echo "Commands:"
+	@echo ""
+	@echo "  check       run code style and quality checks (black and flake8)"
+	@echo "  black       checks code style with black"
+	@echo "  flake       checks code style with flake8"
+	@echo "  flake-full  checks code style with flake8 (full set of rules)"
+	@echo ""
 
 build:
 	python setup.py build_ext --inplace
@@ -98,6 +44,6 @@ flake:
 	flake8 --version
 	flake8 ${FLAKE8_OPTS} ${STYLE_CHECK_FILES}
 
-flake-permissive:
+flake-all:
 	flake8 --version
-	flake8 ${FLAKE8_OPTS} --ignore ${FLAKE8_IGNORE} ${STYLE_CHECK_FILES}
+	flake8 ${FLAKE8_OPTS} --ignore "" ${STYLE_CHECK_FILES}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ stages:
         - script: |
             pip install -r requirements_style.txt
           displayName: "Install dependencies to run the checks"
-        - script: make flake-permissive
+        - script: make flake
           displayName: "Run flake8"
 
     - job:


### PR DESCRIPTION
#### Summary

Moves the flake rules we are currently ignoring to the .flake8
configuration file. Rename the Makefile targets: `make flake` runs
flake8 with ignores set in `.flake8`, while `make flake-full` runs
flake8 with the full set of rules (without ignoring the ones we aren't
following at the moment). Add a `help` target to the `Makefile` that
prints out description of the available targets.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/basic/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/basic/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/basic/practices.html#documentation).
* [ ] Added relevant method tags (i.e. `GRAV`, `EM`, etc.)
* [ ] Marked as ready for review (ff this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Additional information

This PR was triggered by ideas discussed in the SimPEG meeting of 2023-06-14.
