### PR TITLE
Add more hints about pre-commit in documentation

### DIFF
--- a/docs/content/basic/contributing/code-style.rst
+++ b/docs/content/basic/contributing/code-style.rst
@@ -10,12 +10,12 @@ ensure it complies with Black code style. flake8_ performs style checks, raises
 warnings on code that could lead towards bugs, performs checks on consistent
 documentation formatting, and identifies poor coding practices.
 
-.. important::
+.. hint::
 
-   If you :ref:`configure-pre-commit`, pre-commit_ will automatically run
-   Black and flake8 on every commit.
+   If you :ref:`configure pre-commit <configure-pre-commit>`, it will
+   automatically run Black and flake8 on every commit.
 
-Alternatively, one could run them manually at anytime.
+One can manually run Black_ and flake8_ anytime.
 Run ``black`` on SimPEG directories that contain Python source files:
 
 .. code::
@@ -27,6 +27,15 @@ Run ``flake8`` on the whole project with:
 .. code::
 
    flake8
+
+.. important::
+
+   Following code style rules can be challenging for new contributors. These
+   rules are meant to ease the development process, not to generate an obstacle
+   to contribute. Please, don't hesistate to **ask for help** if your
+   contribution raises some flake8 errors. And **feel free to push** code that
+   **don't follow our code style 100%** in :ref:`pull-requests`. Other
+   developers will be there to help you solve them.
 
 .. note::
 

--- a/docs/content/basic/contributing/setting-up-environment.rst
+++ b/docs/content/basic/contributing/setting-up-environment.rst
@@ -101,8 +101,8 @@ You are now set up to SimPEG!
 
 .. _configure-pre-commit:
 
-Configure pre-commit
---------------------
+Configure pre-commit (optional)
+-------------------------------
 
 We recommend using pre-commit_ to ensure that your new code follows the code
 style of SimPEG. pre-commit will run Black_ and flake8_ before any commit you
@@ -111,6 +111,29 @@ make. To configure it, you need to navigate to your cloned SimPEG repo and run:
 .. code::
 
    pre-commit install
+
+.. note::
+
+   Using ``pre-commit`` is recommended, but not necessary. You can still
+   manually run Black_ and flake8_. See our :ref:`code-style` page for more
+   details.
+
+If for some reason you want to stop using ``pre-commit`` on SimPEG, you can
+permanently configure it to stop running automatically with:
+
+.. code::
+
+   pre-commit uninstall
+
+Alternatively, you can temporarily bypass ``pre-commit`` when committing some changes by running:
+
+.. code::
+
+   git commit --no-verify
+
+This is specially useful if the checks run by ``pre-commit`` are failing, but
+you want to commit them nonetheless.
+
 
 .. _pre-commit: https://pre-commit.com/
 .. _Black: https://black.readthedocs.io


### PR DESCRIPTION
#### Summary

Mark configuring pre-commit as an optional step, and add instructions on how to permanently disable it or bypass it for a single commit. Add admonition clarifying that contributors are allowed to push changes that fail to follow our code style and they can ask for help.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/basic/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/basic/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/basic/practices.html#documentation).
* [ ] Added relevant method tags (i.e. `GRAV`, `EM`, etc.)
* [ ] Marked as ready for review (ff this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information

Try to account for some concerns raised on SimPEG meeting of 2023-06-20.
