### PR TITLE
Fix W291 and W293 flake errors: white spaces

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -118,10 +118,6 @@ ignore =
     RST307,
     # Previously unseen severe error, not yet assigned a unique code.
     RST499,
-    # trailing whitespace
-    W291,
-    # blank line contains whitespace
-    W293,
 
 
 # Configure flake8-rst-docstrings

--- a/tutorials/08-tdem/plot_fwd_1_em1dtm_waveforms.py
+++ b/tutorials/08-tdem/plot_fwd_1_em1dtm_waveforms.py
@@ -6,7 +6,7 @@ For time-domain electromagnetic problems, the response depends strongly on the
 souce waveforms. In this tutorial, we construct a set of waveforms of different
 types and simulate the response for a halfspace. Many types of waveforms can
 be constructed within *SimPEG.electromagnetics.time_domain_1d*. These include:
-    
+
     - the unit step off waveform
     - a set of basic waveforms: rectangular, triangular, quarter sine, etc...
     - a set of system-specific waveforms: SkyTEM, VTEM, GeoTEM, etc...

--- a/tutorials/08-tdem/plot_fwd_2_tem_cyl.py
+++ b/tutorials/08-tdem/plot_fwd_2_tem_cyl.py
@@ -3,7 +3,7 @@
 ==================================================================
 
 Here we use the module *SimPEG.electromagnetics.time_domain* to simulate the
-transient response for borehole survey using a cylindrical mesh and a 
+transient response for borehole survey using a cylindrical mesh and a
 radially symmetric conductivity. For this tutorial, we focus on the following:
 
     - How to define the transmitters and receivers


### PR DESCRIPTION
#### Summary

Remove `W291` and `W293` from list of ignored rules in `.flake8`. Remove
trailing whitespaces and whitespaces in empty lines.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Added relevant method tags (i.e. `GRAV`, `EM`, etc.)
* [ ] Marked as ready for review (ff this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
