### PR TITLE
Always calculate gzz if needed

### DIFF
--- a/SimPEG/potential_fields/gravity/simulation.py
+++ b/SimPEG/potential_fields/gravity/simulation.py
@@ -144,14 +144,17 @@ class Simulation3DIntegral(BasePFSimulation):
                 # (NN - EE) / 2
         inside_adjust = False
         if "gzz" in components:
-            if "gxx" not in node_evals or "gyy" not in node_evals:
-                node_evals["gzz"] = prism_fzz(dx, dy, dz)
-            else:
-                inside_adjust = True
-                # The below need to be adjusted for observation points within a cell.
-                # because `gxx + gyy + gzz = -4 * pi * G * rho`
-                # gzz = - gxx - gyy - 4 * np.pi * G * rho[in_cell]
-                node_evals["gzz"] = -node_evals["gxx"] - node_evals["gyy"]
+            node_evals["gzz"] = prism_fzz(dx, dy, dz)
+            # The below should be uncommented when we are able to give the index of a
+            # containing cell.
+            # if "gxx" not in node_evals or "gyy" not in node_evals:
+            #     node_evals["gzz"] = prism_fzz(dx, dy, dz)
+            # else:
+            #     inside_adjust = True
+            #     # The below need to be adjusted for observation points within a cell.
+            #     # because `gxx + gyy + gzz = -4 * pi * G * rho`
+            #     # gzz = - gxx - gyy - 4 * np.pi * G * rho[in_cell]
+            #     node_evals["gzz"] = -node_evals["gxx"] - node_evals["gyy"]
 
         rows = {}
         for component in set(components):

--- a/SimPEG/potential_fields/magnetics/simulation.py
+++ b/SimPEG/potential_fields/magnetics/simulation.py
@@ -269,10 +269,15 @@ class Simulation3DIntegral(BasePFSimulation):
                 node_evals["gxz"] = prism_fzy(dy, dz, dx)
             if "gyz" not in node_evals:
                 node_evals["gyz"] = prism_fzy(dx, dy, dz)
-            if "gxx" not in node_evals or "gyy" not in node_evals:
-                node_evals["gzz"] = prism_fzz(dx, dy, dz)
-            else:
-                node_evals["gzz"] = -node_evals["gxx"] - node_evals["gyy"]
+            node_evals["gzz"] = prism_fzz(dx, dy, dz)
+            # the below will be uncommented when we give the containing cell index
+            # for interior observations.
+            # if "gxx" not in node_evals or "gyy" not in node_evals:
+            #     node_evals["gzz"] = prism_fzz(dx, dy, dz)
+            # else:
+            #     # This is the one that would need to be adjusted if the observation is
+            #     # inside an active cell.
+            #     node_evals["gzz"] = -node_evals["gxx"] - node_evals["gyy"]
 
         if "bxx" in components:
             node_evals["gxxx"] = prism_fzzz(dy, dz, dx)


### PR DESCRIPTION
Instead of using gzz = -gxx - gyy, which needs to be adjusted if inside a cell.

<!-- 
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing.html#pull-request

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
Always calculates the gzz component of the potential field tensors using the kernel functions, instead of making the gzz = -gxx - gyy simplification.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Added relevant method tags (i.e. `GRAV`, `EM`, etc.)
* [ ] Marked as ready for review (ff this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.


#### What does this implement/fix?
The previous method of calculating gzz from gxx and gyy is invalid when the observation point is internal to a cell. In these cases it needs to be adjusted by:

gzz = -gxx - gyy - 4 * pi

#### Additional information
Best practice will be to implement `point2index` for each discretize mesh, which will be queried at the start to determine for each observation which (if any) cell they are located in, then use that information to make the correction listed above. In the mean time, we should at least be correct for now (even if it slows down slightly (is about 1.2 x the calculation time from before.)


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->