### PR TITLE
Fix B028 flake error: non-explicit stacklevel

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -36,8 +36,6 @@ exclude-from-doctest =
 ignore =
     # assertRaises(Exception): should be considered evil
     B017,
-    # No explicit stacklevel argument found.
-    B028,
     # Missing docstring in public module
     D100,
     # Missing docstring in public class

--- a/SimPEG/data.py
+++ b/SimPEG/data.py
@@ -76,7 +76,8 @@ class Data:
             if relative_error is not None or noise_floor is not None:
                 warnings.warn(
                     "Setting the standard_deviation overwrites the "
-                    "relative_error and noise_floor"
+                    "relative_error and noise_floor",
+                    stacklevel=2,
                 )
             self.standard_deviation = standard_deviation
 

--- a/SimPEG/directives/directives.py
+++ b/SimPEG/directives/directives.py
@@ -110,7 +110,8 @@ class InversionDirective:
             warnings.warn(
                 "InversionDirective {0!s} has switched to a new inversion.".format(
                     self.__class__.__name__
-                )
+                ),
+                stacklevel=2,
             )
         self._inversion = i
 
@@ -308,7 +309,10 @@ class DirectiveList(object):
             return
         if getattr(self, "_inversion", None) is not None:
             warnings.warn(
-                "{0!s} has switched to a new inversion.".format(self.__class__.__name__)
+                "{0!s} has switched to a new inversion.".format(
+                    self.__class__.__name__
+                ),
+                stacklevel=2,
             )
         for d in self.dList:
             d.inversion = i
@@ -1297,7 +1301,8 @@ class MultiTargetMisfits(InversionDirective):
             ]
             if smallness[smallness[:, 2] == 1][:, :2].size == 0:
                 warnings.warn(
-                    "There is no PGI regularization. Smallness target is turned off (TriggerSmall flag)"
+                    "There is no PGI regularization. Smallness target is turned off (TriggerSmall flag)",
+                    stacklevel=2,
                 )
                 self.smallness = -1
                 self.pgi_smallness = None
@@ -1340,7 +1345,8 @@ class MultiTargetMisfits(InversionDirective):
             if smallness[smallness[:, 1] == 1][:, :1].size == 0:
                 if self.TriggerSmall:
                     warnings.warn(
-                        "There is no PGI regularization. Smallness target is turned off (TriggerSmall flag)."
+                        "There is no PGI regularization. Smallness target is turned off (TriggerSmall flag).",
+                        stacklevel=2,
                     )
                     self.TriggerSmall = False
                 self.smallness = -1
@@ -2248,7 +2254,8 @@ class Update_IRLS(InversionDirective):
             warnings.warn(
                 "Without a Linear preconditioner, convergence may be slow. "
                 "Consider adding `Directives.UpdatePreconditioner` to your "
-                "directives list"
+                "directives list",
+                stacklevel=2,
             )
         return True
 
@@ -2531,21 +2538,24 @@ class UpdateSensitivityWeights(InversionDirective):
         if "everyIter" in kwargs.keys():
             warnings.warn(
                 "'everyIter' property is deprecated and will be removed in SimPEG 0.20.0."
-                "Please use 'every_iteration'."
+                "Please use 'every_iteration'.",
+                stacklevel=2,
             )
             every_iteration = kwargs.pop("everyIter")
 
         if "threshold" in kwargs.keys():
             warnings.warn(
                 "'threshold' property is deprecated and will be removed in SimPEG 0.20.0."
-                "Please use 'threshold_value'."
+                "Please use 'threshold_value'.",
+                stacklevel=2,
             )
             threshold_value = kwargs.pop("threshold")
 
         if "normalization" in kwargs.keys():
             warnings.warn(
                 "'normalization' property is deprecated and will be removed in SimPEG 0.20.0."
-                "Please define normalization using 'normalization_method'."
+                "Please define normalization using 'normalization_method'.",
+                stacklevel=2,
             )
             normalization_method = kwargs.pop("normalization")
             if normalization_method is True:
@@ -2661,7 +2671,8 @@ class UpdateSensitivityWeights(InversionDirective):
         elif isinstance(value, bool):
             warnings.warn(
                 "Boolean type for 'normalization_method' is deprecated and will be removed in 0.20.0."
-                "Please use None, 'maximum' or 'minimum'."
+                "Please use None, 'maximum' or 'minimum'.",
+                stacklevel=2,
             )
             if value:
                 self._normalization_method = "maximum"

--- a/SimPEG/electromagnetics/frequency_domain/receivers.py
+++ b/SimPEG/electromagnetics/frequency_domain/receivers.py
@@ -38,7 +38,8 @@ class BaseRx(survey.BaseRx):
             warnings.warn(
                 "'projComp' overrides the 'orientation' property which automatically"
                 " handles the projection from the mesh the receivers!!! "
-                "'projComp' is deprecated and will be removed in SimPEG 0.19.0."
+                "'projComp' is deprecated and will be removed in SimPEG 0.19.0.",
+                stacklevel=2,
             )
             self.projComp = proj
 

--- a/SimPEG/electromagnetics/frequency_domain/sources.py
+++ b/SimPEG/electromagnetics/frequency_domain/sources.py
@@ -841,7 +841,8 @@ class CircularLoop(MagDipole):
         if value is not None:
             warnings.warn(
                 "Moment is not set as a property. I is the product"
-                "of the loop radius and transmitter current"
+                "of the loop radius and transmitter current",
+                stacklevel=2,
             )
         pass
 

--- a/SimPEG/electromagnetics/static/resistivity/IODC.py
+++ b/SimPEG/electromagnetics/static/resistivity/IODC.py
@@ -95,7 +95,10 @@ class IO:
         self.pad_rate_z = pad_rate_z
         self.ncell_per_dipole = ncell_per_dipole
         self.corezlength = corezlength
-        warnings.warn("code under construction - API might change in the future")
+        warnings.warn(
+            "code under construction - API might change in the future",
+            stacklevel=2,
+        )
 
     @property
     def survey_layout(self):
@@ -959,6 +962,7 @@ class IO:
                         "Because the x coordinates of some topo and electrodes are the same,"
                         " we excluded electrodes with the same coordinates.",
                         RuntimeWarning,
+                        stacklevel=2,
                     )
                 locs_tmp = np.vstack((topo, self.electrode_locations[~mask, :]))
                 row_idx = np.lexsort((locs_tmp[:, 0],))
@@ -973,6 +977,7 @@ class IO:
                         "Because the x and y coordinates of some topo and electrodes are the same,"
                         " we excluded electrodes with the same coordinates.",
                         RuntimeWarning,
+                        stacklevel=2,
                     )
                 locs_tmp = np.vstack((topo, self.electrode_locations[~mask, :]))
                 row_idx = np.lexsort((locs_tmp[:, 1], locs_tmp[:, 0]))

--- a/SimPEG/electromagnetics/static/resistivity/simulation_2d.py
+++ b/SimPEG/electromagnetics/static/resistivity/simulation_2d.py
@@ -99,7 +99,8 @@ class BaseDCSimulation2D(BaseElectricalPDESimulation):
             if not out["success"]:
                 warnings.warn(
                     "Falling back to trapezoidal for integration. "
-                    "You may need to change nky."
+                    "You may need to change nky.",
+                    stacklevel=2,
                 )
                 do_trap = True
         if do_trap:

--- a/SimPEG/electromagnetics/static/utils/static_utils.py
+++ b/SimPEG/electromagnetics/static/utils/static_utils.py
@@ -204,6 +204,7 @@ def pseudo_locations(survey, wenner_tolerance=0.1, **kwargs):
             "The keyword arguments of this function have been deprecated."
             " All of the necessary information is now in the DC survey class",
             DeprecationWarning,
+            stacklevel=2,
         )
 
     # Pre-allocate
@@ -562,7 +563,9 @@ def plot_pseudosection(
         if kwarg in kwargs:
             raise TypeError(r"The {kwarg} keyword has been removed.")
     if len(kwargs) > 0:
-        warnings.warn("plot_pseudosection unused kwargs: {list(kwargs.keys())}")
+        warnings.warn(
+            f"plot_pseudosection unused kwargs: {list(kwargs.keys())}", stacklevel=2
+        )
 
     if plot_type.lower() not in ["pcolor", "contourf", "scatter"]:
         raise ValueError(
@@ -1061,7 +1064,8 @@ def generate_survey_from_abmn_locations(
         warnings.warn(
             "Ordering of ABMN locations changed when generating survey. "
             "Associated data vectors will need sorting. Set output_sorting to "
-            "True for sorting indices."
+            "True for sorting indices.",
+            stacklevel=2,
         )
 
     if output_sorting:

--- a/SimPEG/electromagnetics/time_domain/receivers.py
+++ b/SimPEG/electromagnetics/time_domain/receivers.py
@@ -32,7 +32,8 @@ class BaseRx(BaseTimeRx):
             warnings.warn(
                 "'projComp' overrides the 'orientation' property which automatically"
                 " handles the projection from the mesh the receivers!!! "
-                "'projComp' is deprecated and will be removed in SimPEG 0.19.0."
+                "'projComp' is deprecated and will be removed in SimPEG 0.19.0.",
+                stacklevel=2,
             )
             self.projComp = proj
 

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -1633,7 +1633,8 @@ class CircularLoop(MagDipole):
         if value is not None:
             warnings.warn(
                 "Moment is not set as a property. I is the product"
-                "of the loop radius and transmitter current"
+                "of the loop radius and transmitter current",
+                stacklevel=2,
             )
         pass
 

--- a/SimPEG/electromagnetics/utils/current_utils.py
+++ b/SimPEG/electromagnetics/utils/current_utils.py
@@ -318,7 +318,9 @@ def _poly_line_source_tree(mesh, locs):
         srcCellIds = mesh.get_cells_along_line(A, B)
         levels = mesh.cell_levels_by_index(srcCellIds)
         if isinstance(levels, np.ndarray) and np.any(levels != levels[0]):
-            warnings.warn("Warning! Line path crosses a cell level change.")
+            warnings.warn(
+                "Warning! Line path crosses a cell level change.", stacklevel=2
+            )
 
         # Starts at point A!
         p0 = A

--- a/SimPEG/maps.py
+++ b/SimPEG/maps.py
@@ -1775,7 +1775,7 @@ class SelfConsistentEffectiveMedium(IdentityMap):
         """
 
         if not (np.all(0 <= phi1) and np.all(phi1 <= 1)):
-            warnings.warn("there are phis outside bounds of 0 and 1")
+            warnings.warn("there are phis outside bounds of 0 and 1", stacklevel=2)
             phi1 = np.median(np.c_[phi1 * 0, phi1, phi1 * 0 + 1.0])
 
         phi0 = 1.0 - phi1
@@ -1812,7 +1812,7 @@ class SelfConsistentEffectiveMedium(IdentityMap):
 
             sige1 = sige2
         # TODO: make this a proper warning, and output relevant info (sigma0, sigma1, phi, sigstart, and relerr)
-        warnings.warn("Maximum number of iterations reached")
+        warnings.warn("Maximum number of iterations reached", stacklevel=2)
 
         return sige2
 

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -232,6 +232,7 @@ class BaseRegularization(BaseObjectiveFunction):
             "cell_weights are deprecated please access weights using the `set_weights`,"
             " `get_weights`, and `remove_weights` functionality. This will be removed in 0.19.0",
             FutureWarning,
+            stacklevel=2,
         )
         return np.prod(list(self._weights.values()), axis=0)
 
@@ -241,6 +242,7 @@ class BaseRegularization(BaseObjectiveFunction):
             "cell_weights are deprecated please access weights using the `set_weights`,"
             " `get_weights`, and `remove_weights` functionality. This will be removed in 0.19.0",
             FutureWarning,
+            stacklevel=2,
         )
         self.set_weights(cell_weights=value)
 
@@ -831,6 +833,7 @@ class WeightedLeastSquares(ComboObjectiveFunction):
             "cell_weights are deprecated please access weights using the `set_weights`,"
             " `get_weights`, and `remove_weights` functionality. This will be removed in 0.19.0",
             FutureWarning,
+            stacklevel=2,
         )
         self.set_weights(cell_weights=value)
 

--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -74,7 +74,9 @@ class PGIsmallness(Smallness):
 
         if "mapping" in kwargs:
             warnings.warn(
-                f"Property 'mapping' of class {type(self)} cannot be set. Defaults to IdentityMap."
+                f"Property 'mapping' of class {type(self)} cannot be set. "
+                "Defaults to IdentityMap.",
+                stacklevel=2,
             )
             kwargs.pop("mapping")
 

--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -499,7 +499,7 @@ class LinearSimulation(BaseSimulation):
         if getattr(self, "_G", None) is not None:
             return self._G
         else:
-            warnings.warn("G has not been implemented for the simulation")
+            warnings.warn("G has not been implemented for the simulation", stacklevel=2)
         return None
 
     @G.setter

--- a/SimPEG/survey.py
+++ b/SimPEG/survey.py
@@ -40,7 +40,8 @@ class BaseRx:
         if projGLoc is not None:
             warnings.warn(
                 "'projGLoc' is no longer of property of the receiver class. It is set automatically "
-                "based on the receiver and simulation class. Will be remove in SimPEG 0.18.0"
+                "based on the receiver and simulation class. Will be remove in SimPEG 0.18.0",
+                stacklevel=2,
             )
         # ideally there shouldn't be any kwargs left to hit, but this will throw an
         # error if kwargs hasn't been emptied properly. This also will allow proper

--- a/SimPEG/utils/code_utils.py
+++ b/SimPEG/utils/code_utils.py
@@ -546,11 +546,11 @@ def deprecate_class(
 
         def __init__(self, *args, **kwargs):
             if future_warn:
-                warnings.warn(message, FutureWarning)
+                warnings.warn(message, FutureWarning, stacklevel=2)
             elif error:
                 raise NotImplementedError(message)
             else:
-                warnings.warn(message, DeprecationWarning)
+                warnings.warn(message, DeprecationWarning, stacklevel=2)
             self._old__init__(*args, **kwargs)
 
         cls.__init__ = __init__
@@ -589,11 +589,11 @@ def deprecate_module(
         message += " It will be removed in a future version of SimPEG."
     message += " Please update your code accordingly."
     if future_warn:
-        warnings.warn(message, FutureWarning)
+        warnings.warn(message, FutureWarning, stacklevel=2)
     elif error:
         raise NotImplementedError(message)
     else:
-        warnings.warn(message, DeprecationWarning)
+        warnings.warn(message, DeprecationWarning, stacklevel=2)
 
 
 def deprecate_property(
@@ -639,20 +639,20 @@ def deprecate_property(
 
     def get_dep(self):
         if future_warn:
-            warnings.warn(message, FutureWarning)
+            warnings.warn(message, FutureWarning, stacklevel=2)
         elif error:
             raise NotImplementedError(message)
         else:
-            warnings.warn(message, DeprecationWarning)
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
         return prop.fget(self)
 
     def set_dep(self, other):
         if future_warn:
-            warnings.warn(message, FutureWarning)
+            warnings.warn(message, FutureWarning, stacklevel=2)
         elif error:
             raise NotImplementedError(message)
         else:
-            warnings.warn(message, DeprecationWarning)
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
         prop.fset(self, other)
 
     doc = f"`{old_name}` has been deprecated. See `{new_name}` for documentation"
@@ -698,11 +698,11 @@ def deprecate_method(
 
     def new_method(*args, **kwargs):
         if future_warn:
-            warnings.warn(message, FutureWarning)
+            warnings.warn(message, FutureWarning, stacklevel=2)
         elif error:
             raise NotImplementedError(message)
         else:
-            warnings.warn(message, DeprecationWarning)
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
         return method(*args, **kwargs)
 
     doc = f"`{old_name}` has been deprecated. See `{new_name}` for documentation"
@@ -752,11 +752,11 @@ def deprecate_function(
 
     def dep_function(*args, **kwargs):
         if future_warn:
-            warnings.warn(message, FutureWarning)
+            warnings.warn(message, FutureWarning, stacklevel=2)
         elif error:
             raise NotImplementedError(message)
         else:
-            warnings.warn(message, DeprecationWarning)
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
         return new_function(*args, **kwargs)
 
     doc = f"""

--- a/SimPEG/utils/io_utils/io_utils_electromagnetics.py
+++ b/SimPEG/utils/io_utils/io_utils_electromagnetics.py
@@ -148,7 +148,8 @@ def read_dcip_xyz(
         warnings.warn(
             "Loaded data are in surface format. Elevations automatically set to 9999 m. "
             "Use the project_to_discretized_topography method of the survey to project "
-            "electrode locations to the discretized surface."
+            "electrode locations to the discretized surface.",
+            stacklevel=2,
         )
     else:
         locations_a = data_array[:, a_cols]
@@ -315,7 +316,8 @@ def read_dcip2d_ubc(file_name, data_type, format_type):
         warnings.warn(
             "Loaded data did not have elevations. Elevations automatically set to 9999 m. "
             "Use the project_to_discretized_topography method of the survey to project "
-            "electrode locations to the discretized surface."
+            "electrode locations to the discretized surface.",
+            stacklevel=2,
         )
 
     else:
@@ -410,7 +412,8 @@ def read_dcip2d_ubc(file_name, data_type, format_type):
             warnings.warn(
                 "Loaded data were in surface format. Elevations automatically set to 9999 m. "
                 "Use the project_to_discretized_topography method of the survey to project "
-                "electrode locations to the discretized surface."
+                "electrode locations to the discretized surface.",
+                stacklevel=2,
             )
 
     return data_out
@@ -569,7 +572,8 @@ def read_dcip3d_ubc(file_name, data_type):
         warnings.warn(
             "Loaded data were in surface format. Elevations automatically set to 9999 m. "
             "Use the project_to_discretized_topography method of the survey to project "
-            "electrode locations to the discretized surface."
+            "electrode locations to the discretized surface.",
+            stacklevel=2,
         )
 
     return data_out

--- a/SimPEG/utils/model_utils.py
+++ b/SimPEG/utils/model_utils.py
@@ -39,6 +39,7 @@ def surface2ind_topo(mesh, topo, gridLoc="CC", method="nearest", fill_value=np.n
         "The surface2ind_topo function has been deprecated, please import "
         "discretize.utils.active_from_xyz. This will be removed in SimPEG 0.20.0",
         FutureWarning,
+        stacklevel=2,
     )
 
     active_cells = active_from_xyz(mesh, topo, gridLoc, method)
@@ -164,6 +165,7 @@ def depth_weighting(
             "The indActive keyword argument has been deprecated, please use active_cells. "
             "This will be removed in SimPEG 0.19.0",
             FutureWarning,
+            stacklevel=2,
         )
         active_cells = kwargs["indActive"]
 

--- a/SimPEG/utils/pgi_utils.py
+++ b/SimPEG/utils/pgi_utils.py
@@ -1171,6 +1171,7 @@ class GaussianMixtureWithPrior(WeightedGaussianMixture):
                 "or increase max_iter, tol "
                 "or check for degenerate data." % (init + 1),
                 ConvergenceWarning,
+                stacklevel=2,
             )
 
         self._set_parameters(best_params)

--- a/SimPEG/utils/plot_utils.py
+++ b/SimPEG/utils/plot_utils.py
@@ -368,6 +368,7 @@ def plotLayer(
     warnings.warn(
         "plotLayer has been deprecated, please use plot_1d_layer_model",
         DeprecationWarning,
+        stacklevel=2,
     )
     thicknesses = np.diff(LocSigZ)
     z0 = LocSigZ[0]

--- a/SimPEG/utils/solver_utils.py
+++ b/SimPEG/utils/solver_utils.py
@@ -15,7 +15,7 @@ def _checkAccuracy(A, b, X, accuracyTol):
             nrm, accuracyTol
         )
         print(msg)
-        warnings.warn(msg, RuntimeWarning)
+        warnings.warn(msg, RuntimeWarning, stacklevel=2)
 
 
 def SolverWrapD(fun, factorize=True, checkAccuracy=True, accuracyTol=1e-6, name=None):
@@ -87,7 +87,8 @@ def SolverWrapD(fun, factorize=True, checkAccuracy=True, accuracyTol=1e-6, name=
                     culled_args[item] = kwargs[item]
                 else:
                     warnings.warn(
-                        f"{item} is not a valid keyword for {fun.__name__} and will be ignored"
+                        f"{item} is not a valid keyword for {fun.__name__} and will be ignored",
+                        stacklevel=2,
                     )
             kwargs = culled_args
 
@@ -204,7 +205,8 @@ def SolverWrapI(fun, checkAccuracy=True, accuracyTol=1e-5, name=None):
                     culled_args[item] = kwargs[item]
                 else:
                     warnings.warn(
-                        f"{item} is not a valid keyword for {fun.__name__} and will be ignored"
+                        f"{item} is not a valid keyword for {fun.__name__} and will be ignored",
+                        stacklevel=2,
                     )
             kwargs = culled_args
 
@@ -289,7 +291,9 @@ class SolverDiag(object):
         self.A = A
         self._diagonal = A.diagonal()
         for kwarg in kwargs:
-            warnings.warn(f"{kwarg} is not recognized and will be ignored")
+            warnings.warn(
+                f"{kwarg} is not recognized and will be ignored", stacklevel=2
+            )
 
     def __mul__(self, rhs):
         n = self.A.shape[0]


### PR DESCRIPTION
#### Summary

Remove B028 from the list of ignored rules in `.flake`. Explicitly set
stacklevel on `warning.warn` calls.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Added relevant method tags (i.e. `GRAV`, `EM`, etc.)
* [ ] Marked as ready for review (ff this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
