### PR TITLE
Make units of gravity simulations more explicit

### DIFF
--- a/SimPEG/potential_fields/gravity/receivers.py
+++ b/SimPEG/potential_fields/gravity/receivers.py
@@ -11,6 +11,10 @@ class Point(survey.BaseRx):
 
     .. important::
 
+        Density model is assumed to be in g/cc.
+
+    .. important::
+
         Acceleration components ("gx", "gy", "gz") are returned in mgal
         (:math:`10^{-5} m/s^2`).
 

--- a/SimPEG/potential_fields/gravity/receivers.py
+++ b/SimPEG/potential_fields/gravity/receivers.py
@@ -42,6 +42,10 @@ class Point(survey.BaseRx):
         - "gyz"  --> z-derivative of the y-component (and visa versa)
         - "gzz"  --> z-derivative of the z-component
         - "guv"  --> UV component
+
+    See also
+    --------
+    SimPEG.potential_fields.gravity.Simulation3DIntegral
     """
 
     def __init__(self, locations, components="gz", **kwargs):

--- a/SimPEG/potential_fields/gravity/receivers.py
+++ b/SimPEG/potential_fields/gravity/receivers.py
@@ -9,6 +9,16 @@ class Point(survey.BaseRx):
     field that are simulated at each location. The length of the resulting data
     vector is *n_loc X n_comp*, and is organized by location then component.
 
+    .. important::
+
+        Acceleration components ("gx", "gy", "gz") are returned in mgal
+        (:math:`10^{-5} m/s^2`).
+
+    .. important::
+
+        Gradient components ("gxx", "gyy", "gzz", "gxy", "gxz", "gyz") are
+        returned in Eotvos (:math:`10^{-9} s^{-2}`).
+
     Parameters
     ----------
     locations: (n_loc, 3) numpy.ndarray

--- a/SimPEG/potential_fields/gravity/simulation.py
+++ b/SimPEG/potential_fields/gravity/simulation.py
@@ -14,6 +14,19 @@ class Simulation3DIntegral(BasePFSimulation):
     """
     Gravity simulation in integral form.
 
+    .. important::
+
+        Density model is assumed to be in g/cc.
+
+    .. important::
+
+        Acceleration components ("gx", "gy", "gz") are returned in mgal
+        (:math:`10^{-5} m/s^2`).
+
+    .. important::
+
+        Gradient components ("gxx", "gyy", "gzz", "gxy", "gxz", "gyz") are
+        returned in Eotvos (:math:`10^{-9} s^{-2}`).
     """
 
     rho, rhoMap, rhoDeriv = props.Invertible("Density")

--- a/tutorials/03-gravity/plot_1b_gravity_gradiometry.py
+++ b/tutorials/03-gravity/plot_1b_gravity_gradiometry.py
@@ -265,6 +265,6 @@ norm = mpl.colors.Normalize(vmin=-v_max, vmax=v_max)
 cbar = mpl.colorbar.ColorbarBase(
     ax4, norm=norm, orientation="vertical", cmap=mpl.cm.bwr
 )
-cbar.set_label("$mgal/m$", rotation=270, labelpad=15, size=12)
+cbar.set_label("Eotvos", rotation=270, labelpad=15, size=12)
 
 plt.show()


### PR DESCRIPTION
#### Summary

Add admonitions to the `Point` receiver for gravity simulations. Fix unit in the plot legend of one of the examples.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Added relevant method tags (i.e. `GRAV`, `EM`, etc.)
* [ ] Marked as ready for review (ff this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information

The error in the example was caught by @johnweis0480. We concluded that returned gravity units should be explicitly mentioned in the documentation.