### PR TITLE
unpack the data misfits for plotting tikhonov curves

### DIFF
--- a/SimPEG/directives/directives.py
+++ b/SimPEG/directives/directives.py
@@ -1765,7 +1765,9 @@ class SaveOutputEveryIteration(SaveEveryIteration):
         plot_small=False,
         plot_smooth=False,
     ):
-        self.target_misfit = self.invProb.dmisfit.simulation.survey.nD / 2.0
+        self.target_misfit = (
+            np.sum([dmis.nD for dmis in self.invProb.dmisfit.objfcts]) / 2.0
+        )
         self.i_target = None
 
         if self.invProb.phi_d < self.target_misfit:


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing.html#pull-request

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
Small pr to fix a bug in the plotting of tikhonov curves. Since we turn the data misfit into a combo objective function, we need to unpack it to get the number of data  

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Added relevant method tags (i.e. `GRAV`, `EM`, etc.)
* [x] Marked as ready for review (ff this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.
