### PR TITLE
Set storage type of pf sensitivity matrix

### DIFF
--- a/SimPEG/dask/potential_fields/base.py
+++ b/SimPEG/dask/potential_fields/base.py
@@ -16,7 +16,7 @@ def dask_linear_operator(self):
     rows = [
         array.from_delayed(
             row(receiver_location, components),
-            dtype=np.float32,
+            dtype=self.sensitivity_dtype,
             shape=(len(components),) if forward_only else (len(components), n_cells),
         )
         for receiver_location, components in self.survey._location_component_iterator()

--- a/SimPEG/potential_fields/base.py
+++ b/SimPEG/potential_fields/base.py
@@ -166,7 +166,7 @@ class BasePFSimulation(LinearSimulation):
         numpy.float32 or numpy.float64
             The dtype used to store the sensitivity matrix
         """
-        if self.forward_only:
+        if self.store_sensitivities == "forward_only":
             return np.float64
         return self._sensitivity_dtype
 

--- a/SimPEG/potential_fields/base.py
+++ b/SimPEG/potential_fields/base.py
@@ -239,7 +239,7 @@ class BasePFSimulation(LinearSimulation):
                 rows = self.evaluate_integral(*args)
                 n_c = rows.shape[0]
                 id1 = id0 + n_c
-                kernel[id0:id1] = rows.astype(dtype)
+                kernel[id0:id1] = rows.astype(dtype, copy=False)
                 id0 = id1
         else:
             # multiprocessed
@@ -250,7 +250,7 @@ class BasePFSimulation(LinearSimulation):
                 ):
                     n_c = rows.shape[0]
                     id1 = id0 + n_c
-                    kernel[id0:id1] = rows.astype(dtype)
+                    kernel[id0:id1] = rows.astype(dtype, copy=False)
                     id0 = id1
 
         # if self.store_sensitivities != "forward_only":

--- a/SimPEG/potential_fields/gravity/simulation.py
+++ b/SimPEG/potential_fields/gravity/simulation.py
@@ -46,7 +46,7 @@ class Simulation3DIntegral(BasePFSimulation):
             # Compute the linear operation without forming the full dense G
             fields = mkvc(self.linear_operator())
         else:
-            fields = self.G @ (self.rho).astype(np.float32)
+            fields = self.G @ (self.rho).astype(self.sensitivity_dtype)
 
         return np.asarray(fields)
 
@@ -80,13 +80,13 @@ class Simulation3DIntegral(BasePFSimulation):
         Sensitivity times a vector
         """
         dmu_dm_v = self.rhoDeriv @ v
-        return self.G @ dmu_dm_v.astype(np.float32)
+        return self.G @ dmu_dm_v.astype(self.sensitivity_dtype)
 
     def Jtvec(self, m, v, f=None):
         """
         Sensitivity transposed times a vector
         """
-        Jtvec = self.G.T @ v.astype(np.float32)
+        Jtvec = self.G.T @ v.astype(self.sensitivity_dtype)
         return np.asarray(self.rhoDeriv.T @ Jtvec)
 
     @property

--- a/SimPEG/potential_fields/gravity/simulation.py
+++ b/SimPEG/potential_fields/gravity/simulation.py
@@ -46,7 +46,7 @@ class Simulation3DIntegral(BasePFSimulation):
             # Compute the linear operation without forming the full dense G
             fields = mkvc(self.linear_operator())
         else:
-            fields = self.G @ (self.rho).astype(self.sensitivity_dtype)
+            fields = self.G @ (self.rho).astype(self.sensitivity_dtype, copy=False)
 
         return np.asarray(fields)
 
@@ -80,13 +80,13 @@ class Simulation3DIntegral(BasePFSimulation):
         Sensitivity times a vector
         """
         dmu_dm_v = self.rhoDeriv @ v
-        return self.G @ dmu_dm_v.astype(self.sensitivity_dtype)
+        return self.G @ dmu_dm_v.astype(self.sensitivity_dtype, copy=False)
 
     def Jtvec(self, m, v, f=None):
         """
         Sensitivity transposed times a vector
         """
-        Jtvec = self.G.T @ v.astype(self.sensitivity_dtype)
+        Jtvec = self.G.T @ v.astype(self.sensitivity_dtype, copy=False)
         return np.asarray(self.rhoDeriv.T @ Jtvec)
 
     @property
@@ -198,7 +198,12 @@ class Simulation3DIntegral(BasePFSimulation):
             else:
                 rows[component] *= constants.G * 1e8  # conversion for mGal
 
-        return np.stack([rows[component] for component in components])
+        return np.stack(
+            [
+                rows[component].astype(self.sensitivity_dtype, copy=False)
+                for component in components
+            ]
+        )
 
 
 class SimulationEquivalentSourceLayer(

--- a/SimPEG/potential_fields/magnetics/simulation.py
+++ b/SimPEG/potential_fields/magnetics/simulation.py
@@ -108,7 +108,7 @@ class Simulation3DIntegral(BasePFSimulation):
         if self.store_sensitivities == "forward_only":
             fields = mkvc(self.linear_operator())
         else:
-            fields = np.asarray(self.G @ self.chi.astype(np.float32))
+            fields = np.asarray(self.G @ self.chi.astype(self.sensitivity_dtype))
 
         if self.is_amplitude_data:
             fields = self.compute_amplitude(fields)
@@ -182,7 +182,7 @@ class Simulation3DIntegral(BasePFSimulation):
         self.model = m
         dmu_dm_v = self.chiDeriv @ v
 
-        Jvec = self.G @ dmu_dm_v.astype(np.float32)
+        Jvec = self.G @ dmu_dm_v.astype(self.sensitivity_dtype)
 
         if self.is_amplitude_data:
             # dask doesn't support an "order" argument to reshape...
@@ -199,13 +199,13 @@ class Simulation3DIntegral(BasePFSimulation):
             v = self.ampDeriv * v
             # dask doesn't support and "order" argument to reshape...
             v = v.T.reshape(-1)  # .reshape(-1, order="F")
-        Jtvec = self.G.T @ v.astype(np.float32)
+        Jtvec = self.G.T @ v.astype(self.sensitivity_dtype)
         return np.asarray(self.chiDeriv.T @ Jtvec)
 
     @property
     def ampDeriv(self):
         if getattr(self, "_ampDeriv", None) is None:
-            fields = np.asarray(self.G.dot(self.chi).astype(np.float32))
+            fields = np.asarray(self.G.dot(self.chi).astype(self.sensitivity_dtype))
             self._ampDeriv = self.normalized_fields(fields)
 
         return self._ampDeriv

--- a/SimPEG/potential_fields/magnetics/simulation.py
+++ b/SimPEG/potential_fields/magnetics/simulation.py
@@ -108,7 +108,9 @@ class Simulation3DIntegral(BasePFSimulation):
         if self.store_sensitivities == "forward_only":
             fields = mkvc(self.linear_operator())
         else:
-            fields = np.asarray(self.G @ self.chi.astype(self.sensitivity_dtype))
+            fields = np.asarray(
+                self.G @ self.chi.astype(self.sensitivity_dtype, copy=False)
+            )
 
         if self.is_amplitude_data:
             fields = self.compute_amplitude(fields)
@@ -182,7 +184,7 @@ class Simulation3DIntegral(BasePFSimulation):
         self.model = m
         dmu_dm_v = self.chiDeriv @ v
 
-        Jvec = self.G @ dmu_dm_v.astype(self.sensitivity_dtype)
+        Jvec = self.G @ dmu_dm_v.astype(self.sensitivity_dtype, copy=False)
 
         if self.is_amplitude_data:
             # dask doesn't support an "order" argument to reshape...
@@ -199,13 +201,15 @@ class Simulation3DIntegral(BasePFSimulation):
             v = self.ampDeriv * v
             # dask doesn't support and "order" argument to reshape...
             v = v.T.reshape(-1)  # .reshape(-1, order="F")
-        Jtvec = self.G.T @ v.astype(self.sensitivity_dtype)
+        Jtvec = self.G.T @ v.astype(self.sensitivity_dtype, copy=False)
         return np.asarray(self.chiDeriv.T @ Jtvec)
 
     @property
     def ampDeriv(self):
         if getattr(self, "_ampDeriv", None) is None:
-            fields = np.asarray(self.G.dot(self.chi).astype(self.sensitivity_dtype))
+            fields = np.asarray(
+                self.G.dot(self.chi).astype(self.sensitivity_dtype, copy=False)
+            )
             self._ampDeriv = self.normalized_fields(fields)
 
         return self._ampDeriv
@@ -428,7 +432,12 @@ class Simulation3DIntegral(BasePFSimulation):
 
             rows[component] /= 4 * np.pi
 
-        return np.stack([rows[component] for component in components])
+        return np.stack(
+            [
+                rows[component].astype(self.sensitivity_dtype, copy=False)
+                for component in components
+            ]
+        )
 
     @property
     def deleteTheseOnModelUpdate(self):

--- a/tests/meta/test_meta_sim.py
+++ b/tests/meta/test_meta_sim.py
@@ -133,26 +133,26 @@ def test_sum_sim_correctness():
     # test fields objects
     f_full = full_sim.fields(m_test)
     f_mult = sum_sim.fields(m_test)
-    np.testing.assert_allclose(f_full, sum(f_mult))
+    np.testing.assert_allclose(f_full, sum(f_mult), rtol=1e-6)
 
     # test data output
     d_full = full_sim.dpred(m_test, f=f_full)
     d_mult = sum_sim.dpred(m_test, f=f_mult)
-    np.testing.assert_allclose(d_full, d_mult)
+    np.testing.assert_allclose(d_full, d_mult, rtol=1e-6)
 
     # test Jvec
     u = np.random.rand(mesh.n_cells)
     jvec_full = full_sim.Jvec(m_test, u, f=f_full)
     jvec_mult = sum_sim.Jvec(m_test, u, f=f_mult)
 
-    np.testing.assert_allclose(jvec_full, jvec_mult)
+    np.testing.assert_allclose(jvec_full, jvec_mult, rtol=1e-6)
 
     # test Jtvec
     v = np.random.rand(survey.nD)
     jtvec_full = full_sim.Jtvec(m_test, v, f=f_full)
     jtvec_mult = sum_sim.Jtvec(m_test, v, f=f_mult)
 
-    np.testing.assert_allclose(jtvec_full, jtvec_mult)
+    np.testing.assert_allclose(jtvec_full, jtvec_mult, rtol=1e-6)
 
     # test get diag
     diag_full = full_sim.getJtJdiag(m_test, f=f_full)

--- a/tests/pf/test_forward_Grav_Linear.py
+++ b/tests/pf/test_forward_Grav_Linear.py
@@ -83,9 +83,10 @@ def test_ana_grav_forward(tmp_path):
         + prism_2.gravitational_field(locXyz)
         + prism_3.gravitational_field(locXyz)
     ) * 1e5  # convert to mGal from m/s^2
-    np.testing.assert_allclose(d_x, d[:, 0], rtol=1e-10, atol=1e-14)
-    np.testing.assert_allclose(d_y, d[:, 1], rtol=1e-10, atol=1e-14)
-    np.testing.assert_allclose(d_z, d[:, 2], rtol=1e-10, atol=1e-14)
+    d = d.astype(np.float32)
+    np.testing.assert_allclose(d_x, d[:, 0], rtol=1e-9, atol=1e-6)
+    np.testing.assert_allclose(d_y, d[:, 1], rtol=1e-9, atol=1e-6)
+    np.testing.assert_allclose(d_z, d[:, 2], rtol=1e-9, atol=1e-6)
 
 
 def test_ana_gg_forward():

--- a/tests/pf/test_forward_Grav_Linear.py
+++ b/tests/pf/test_forward_Grav_Linear.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import discretize
 from SimPEG import maps
 from SimPEG.potential_fields import gravity
@@ -68,6 +69,11 @@ def test_ana_grav_forward(tmp_path):
         sensitivity_path=str(tmp_path) + os.sep,
     )
 
+    with pytest.raises(TypeError):
+        sim.sensitivity_dtype = float
+
+    assert sim.sensitivity_dtype is np.float32
+
     data = sim.dpred(model_reduced)
     d_x = data[0::3]
     d_y = data[1::3]
@@ -83,7 +89,7 @@ def test_ana_grav_forward(tmp_path):
         + prism_2.gravitational_field(locXyz)
         + prism_3.gravitational_field(locXyz)
     ) * 1e5  # convert to mGal from m/s^2
-    d = d.astype(np.float32)
+    d = d.astype(sim.sensitivity_dtype)
     np.testing.assert_allclose(d_x, d[:, 0], rtol=1e-9, atol=1e-6)
     np.testing.assert_allclose(d_y, d[:, 1], rtol=1e-9, atol=1e-6)
     np.testing.assert_allclose(d_z, d[:, 2], rtol=1e-9, atol=1e-6)
@@ -151,6 +157,9 @@ def test_ana_gg_forward():
         store_sensitivities="forward_only",
         n_processes=None,
     )
+
+    # forward only should default to np.float64
+    assert sim.sensitivity_dtype is np.float64
 
     data = sim.dpred(model_reduced)
     d_xx = data[0::6]


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing.html#pull-request

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
Allows users to control the type of the stored sensitivity matrix.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### What does this implement/fix?
In the non-dask version the sensitivity was being stored as a `np.float64` implicitly. This changes it to be in line with the dask version (`np.float32`), but also now allows the user to change the default if they so desire.

<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
