### PR TITLE
Fix sparse inversion example: remove beta schedule

### DIFF
--- a/tutorials/03-gravity/plot_inv_1b_gravity_anomaly_irls.py
+++ b/tutorials/03-gravity/plot_inv_1b_gravity_anomaly_irls.py
@@ -267,10 +267,6 @@ update_IRLS = directives.Update_IRLS(
     beta_tol=1e-2,
 )
 
-# Defining the fractional decrease in beta and the number of Gauss-Newton solves
-# for each beta value.
-beta_schedule = directives.BetaSchedule(coolingFactor=5, coolingRate=1)
-
 # Options for outputting recovered models and predicted data for each beta.
 save_iteration = directives.SaveOutputEveryIteration(save_txt=False)
 
@@ -285,7 +281,6 @@ directives_list = [
     update_IRLS,
     sensitivity_weights,
     starting_beta,
-    beta_schedule,
     save_iteration,
     update_jacobi,
 ]


### PR DESCRIPTION
#### Summary

Modify example that runs a gravity sparse inversion: remove the `BetaSchedule` directive to avoid cooling beta twice. The `Update_IRLS` directive has its own builtin beta scheduling scheme.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->