### PR TITLE
Add building docs and serving them to documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,7 +14,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: all api help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: all api help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext serve
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -38,6 +38,7 @@ help:
 	@echo "  changes    to make an overview of all changed/added/deprecated items"
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@echo "  serve      to serve the docs locally"
 
 clean:
 	rm -rf $(BUILDDIR)/*
@@ -166,3 +167,6 @@ doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
+
+serve:
+	cd $(BUILDDIR)/html && python -m http.server 8001

--- a/docs/content/getting_started/contributing/documentation.rst
+++ b/docs/content/getting_started/contributing/documentation.rst
@@ -64,3 +64,22 @@ For example:
         If length scales are used to set the smoothness weights, alphas are respectively set internally using:
         >>> alpha_x = (length_scale_x * min(mesh.edge_lengths)) ** 2
         """
+
+
+
+Building the documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you would like to see the documentation changes. 
+In the repo's root directory, enter the following in your terminal.
+
+.. code:: 
+    make all
+
+Serving the documentation locally 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once the documentation is built. You can view it directly using the following command. This will automatically serve the docs and you can see them in your browser.
+
+.. code::
+    make serve


### PR DESCRIPTION
Adding a section under documentation under contributing guidelines that explains how to build and serve the docs locally. 
