### PR TITLE
Add admonition with link to old Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,8 @@ section of our documentation.
 
 > **Important**
 > Our contributing guidelines have been recently updated. Until we deploy the
-> new documentation pages the previous link won't work. Please visit the
-> [current
+> new documentation pages (for version v0.20.0), the previous link won't work.
+> Please visit the [current
 > one](https://docs.simpeg.xyz/content/basic/installing_for_developers.html)
 > instead.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,11 +7,12 @@ You can find guidelines on how to contribute to SimPEG in the [Contributing to
 SimPEG](https://docs.simpeg.xyz/content/getting_started/contributing/index.html)
 section of our documentation.
 
-**Important**
-Our contributing guidelines have been recently updated. Until we deploy the new
-documentation pages the previous link won't work. Please visit the [current
-one](https://docs.simpeg.xyz/content/basic/installing_for_developers.html)
-instead.
+> **Important**
+> Our contributing guidelines have been recently updated. Until we deploy the
+> new documentation pages the previous link won't work. Please visit the
+> [current
+> one](https://docs.simpeg.xyz/content/basic/installing_for_developers.html)
+> instead.
 
 
 ## Licensing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,12 @@ You can find guidelines on how to contribute to SimPEG in the [Contributing to
 SimPEG](https://docs.simpeg.xyz/content/getting_started/contributing/index.html)
 section of our documentation.
 
+**Important**
+Our contributing guidelines have been recently updated. Until we deploy the new
+documentation pages the previous link won't work. Please visit the [current
+one](https://docs.simpeg.xyz/content/basic/installing_for_developers.html)
+instead.
+
 
 ## Licensing
 


### PR DESCRIPTION
#### Summary

Add admonition in the `CONTRIBUTING.md` that includes a link to the old Contributing Guidelines in SimPEG's website. Until we deploy the new docs, the link in `CONTRIBUTING.md` to the Contributing Guidelines is broken (because that page doesn't exist yet). By adding the "old" link, we allow contributors to have some resource to learn how to do so.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/practices.html#style).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.


#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information

This issue was raised by @andieie during the 2023 BIRS Workshop. I think we should add her as co-author of this PR since she took the time to explore the Contributing guides and identify broken links. 
