### PR TITLE
Fix deprecation warning for gradientType in SparseSmoothness

### DIFF
--- a/SimPEG/regularization/sparse.py
+++ b/SimPEG/regularization/sparse.py
@@ -691,7 +691,12 @@ class SparseSmoothness(BaseSparse, SmoothnessFirstOrder):
         )
 
     gradientType = utils.code_utils.deprecate_property(
-        gradient_type, "gradientType", "0.19.0", error=False, future_warn=True
+        gradient_type,
+        "gradientType",
+        new_name="gradient_type",
+        removal_version="0.19.0",
+        error=False,
+        future_warn=True,
     )
 
 


### PR DESCRIPTION
#### Summary

Fix the message for the deprecation of `gradientType` for `gradient_type` in `SparseSmoothness` regularization.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.
