### PR TITLE
Allow to use random seed in make_synthetic_data

### DIFF
--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -328,7 +328,7 @@ class BaseSimulation(props.HasModel):
         f : array or None
             Fields for the given model (if pre-calculated).
         add_noise : bool
-            Wether to add gaussian noise to the synthetic data or not.
+            Whether to add gaussian noise to the synthetic data or not.
         random_seed : int or None
             Random seed to pass to `numpy.random.default_rng`.
 

--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -305,14 +305,36 @@ class BaseSimulation(props.HasModel):
         return mkvc(self.dpred(m, f=f) - dobs)
 
     def make_synthetic_data(
-        self, m, relative_error=0.05, noise_floor=0.0, f=None, add_noise=False, **kwargs
+        self,
+        m,
+        relative_error=0.05,
+        noise_floor=0.0,
+        f=None,
+        add_noise=False,
+        random_seed=None,
+        **kwargs,
     ):
         """
         Make synthetic data given a model, and a standard deviation.
-        :param numpy.ndarray m: geophysical model
-        :param numpy.ndarray | float relative_error: standard deviation
-        :param numpy.ndarray | float noise_floor: noise floor
-        :param numpy.ndarray f: fields for the given model (if pre-calculated)
+
+        Parameters
+        ----------
+        m : array
+            Array containing with geophysical model.
+        relative_error : float
+            Standard deviation.
+        noise_floor : float
+            Noise floor.
+        f : array or None
+            Fields for the given model (if pre-calculated).
+        add_noise : bool
+            Wether to add gaussian noise to the synthetic data or not.
+        random_seed : int or None
+            Random seed to pass to `numpy.random.default_rng`.
+
+        Returns
+        -------
+        SyntheticData
         """
 
         std = kwargs.pop("std", None)
@@ -328,7 +350,8 @@ class BaseSimulation(props.HasModel):
 
         if add_noise is True:
             std = np.sqrt((relative_error * np.abs(dclean)) ** 2 + noise_floor**2)
-            noise = std * np.random.randn(*dclean.shape)
+            random_num_generator = np.random.default_rng(seed=random_seed)
+            noise = random_num_generator.normal(loc=0, scale=std, size=dclean.shape)
             dobs = dclean + noise
         else:
             dobs = dclean

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -589,7 +589,7 @@ class TestSCEMT(unittest.TestCase):
     def test_sphericalInclusions(self):
         mesh = discretize.TensorMesh([4, 5, 3])
         mapping = maps.SelfConsistentEffectiveMedium(mesh, sigma0=1e-1, sigma1=1.0)
-        m = np.abs(np.random.rand(mesh.nC))
+        m = np.random.default_rng(seed=0).random(mesh.n_cells)
         mapping.test(m=m, dx=0.05 * np.ones(mesh.n_cells), num=3)
 
     def test_spheroidalInclusions(self):

--- a/tests/em/static/test_DC_2D_jvecjtvecadj.py
+++ b/tests/em/static/test_DC_2D_jvecjtvecadj.py
@@ -18,8 +18,6 @@ try:
 except ImportError:
     from SimPEG import SolverLU as Solver
 
-np.random.seed(41)
-
 
 class DCProblem_2DTests(unittest.TestCase):
     formulation = "Simulation2DCellCentered"
@@ -85,9 +83,9 @@ class DCProblem_2DTests(unittest.TestCase):
 
     def test_adjoint(self):
         # Adjoint Test
-        # u = np.random.rand(self.mesh.nC * self.survey.nSrc)
-        v = np.random.rand(self.mesh.nC)
-        w = np.random.rand(self.data.nD)
+        rng = np.random.default_rng(seed=41)
+        v = rng.random(self.mesh.nC)
+        w = rng.random(self.data.nD)
         wtJv = w.dot(self.p.Jvec(self.m0, v))
         vtJtw = v.dot(self.p.Jtvec(self.m0, w))
         passed = np.abs(wtJv - vtJtw) < self.adjoint_tol

--- a/tests/meta/test_meta_sim.py
+++ b/tests/meta/test_meta_sim.py
@@ -61,14 +61,15 @@ def test_multi_sim_correctness():
     np.testing.assert_allclose(d_full, d_mult)
 
     # test Jvec
-    u = np.random.rand(mesh.n_cells)
+    rng = np.random.default_rng(seed=0)
+    u = rng.random(mesh.n_cells)
     jvec_full = full_sim.Jvec(m_test, u, f=f_full)
     jvec_mult = multi_sim.Jvec(m_test, u, f=f_mult)
 
     np.testing.assert_allclose(jvec_full, jvec_mult)
 
     # test Jtvec
-    v = np.random.rand(survey_full.nD)
+    v = rng.random(survey_full.nD)
     jtvec_full = full_sim.Jtvec(m_test, v, f=f_full)
     jtvec_mult = multi_sim.Jtvec(m_test, v, f=f_mult)
 
@@ -141,14 +142,16 @@ def test_sum_sim_correctness():
     np.testing.assert_allclose(d_full, d_mult, rtol=1e-6)
 
     # test Jvec
-    u = np.random.rand(mesh.n_cells)
+    rng = np.random.default_rng(seed=0)
+    u = rng.random(mesh.n_cells)
     jvec_full = full_sim.Jvec(m_test, u, f=f_full)
     jvec_mult = sum_sim.Jvec(m_test, u, f=f_mult)
 
     np.testing.assert_allclose(jvec_full, jvec_mult, rtol=1e-6)
 
     # test Jtvec
-    v = np.random.rand(survey.nD)
+    rng = np.random.default_rng(seed=0)
+    v = rng.random(survey.nD)
     jtvec_full = full_sim.Jtvec(m_test, v, f=f_full)
     jtvec_mult = sum_sim.Jtvec(m_test, v, f=f_mult)
 
@@ -218,7 +221,8 @@ def test_repeat_sim_correctness():
     multi_sim = MetaSimulation(simulations, mappings)
     repeat_sim = RepeatedSimulation(sim, mappings)
 
-    model = np.random.rand(time_mesh.n_cells, mesh.n_cells).reshape(-1)
+    rng = np.random.default_rng(seed=0)
+    model = rng.random((time_mesh.n_cells, mesh.n_cells)).reshape(-1)
 
     # test field things
     f_full = multi_sim.fields(model)
@@ -230,13 +234,13 @@ def test_repeat_sim_correctness():
     np.testing.assert_equal(d_full, d_repeat)
 
     # test Jvec
-    u = np.random.rand(len(model))
+    u = rng.random(len(model))
     jvec_full = multi_sim.Jvec(model, u, f=f_full)
     jvec_mult = repeat_sim.Jvec(model, u, f=f_mult)
     np.testing.assert_allclose(jvec_full, jvec_mult)
 
     # test Jtvec
-    v = np.random.rand(len(sim_ts) * survey.nD)
+    v = rng.random(len(sim_ts) * survey.nD)
     jtvec_full = multi_sim.Jtvec(model, v, f=f_full)
     jtvec_mult = repeat_sim.Jtvec(model, v, f=f_mult)
     np.testing.assert_allclose(jtvec_full, jtvec_mult)

--- a/tests/pf/test_grav_inversion_linear.py
+++ b/tests/pf/test_grav_inversion_linear.py
@@ -84,7 +84,11 @@ class GravInvLinProblemTest(unittest.TestCase):
 
         # Compute linear forward operator and compute some data
         data = sim.make_synthetic_data(
-            self.model, relative_error=0.0, noise_floor=0.0005, add_noise=True
+            self.model,
+            relative_error=0.0,
+            noise_floor=0.0005,
+            add_noise=True,
+            random_seed=2,
         )
 
         # Create a regularization

--- a/tests/pf/test_mag_inversion_linear.py
+++ b/tests/pf/test_mag_inversion_linear.py
@@ -88,7 +88,11 @@ class MagInvLinProblemTest(unittest.TestCase):
 
         # Compute linear forward operator and compute some data
         data = sim.make_synthetic_data(
-            self.model, relative_error=0.0, noise_floor=1.0, add_noise=True
+            self.model,
+            relative_error=0.0,
+            noise_floor=1.0,
+            add_noise=True,
+            random_seed=2,
         )
 
         # Create a regularization

--- a/tests/pf/test_pf_quadtree_inversion_linear.py
+++ b/tests/pf/test_pf_quadtree_inversion_linear.py
@@ -17,8 +17,6 @@ from SimPEG import (
 )
 from SimPEG.potential_fields import gravity, magnetics
 
-np.random.seed(44)
-
 
 class QuadTreeLinProblemTest(unittest.TestCase):
     def setUp(self):
@@ -101,6 +99,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
                 relative_error=0.0,
                 noise_floor=noise_floor,
                 add_noise=True,
+                random_seed=44,
             )
 
         def create_magnetics_sim_flat(self, block_value=1.0, noise_floor=0.01):
@@ -128,6 +127,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
                 relative_error=0.0,
                 noise_floor=noise_floor,
                 add_noise=True,
+                random_seed=44,
             )
 
         def create_gravity_sim(self, block_value=1.0, noise_floor=0.01):
@@ -154,6 +154,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
                 relative_error=0.0,
                 noise_floor=noise_floor,
                 add_noise=True,
+                random_seed=1,
             )
 
         def create_magnetics_sim(self, block_value=1.0, noise_floor=0.01):
@@ -181,6 +182,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
                 relative_error=0.0,
                 noise_floor=noise_floor,
                 add_noise=True,
+                random_seed=1,
             )
 
         def create_gravity_sim_active(self, block_value=1.0, noise_floor=0.01):
@@ -208,6 +210,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
                 relative_error=0.0,
                 noise_floor=noise_floor,
                 add_noise=True,
+                random_seed=1,
             )
 
         def create_magnetics_sim_active(self, block_value=1.0, noise_floor=0.01):
@@ -236,6 +239,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
                 relative_error=0.0,
                 noise_floor=noise_floor,
                 add_noise=True,
+                random_seed=1,
             )
 
         def create_inversion(self, sim, data, beta=1e3, all_active=True):
@@ -445,8 +449,6 @@ class QuadTreeLinProblemTest(unittest.TestCase):
         print("Z_TOP OR Z_BOTTOM LENGTH MATCHING NACTIVE-CELLS ERROR TEST PASSED.")
 
     def test_quadtree_grav_inverse(self):
-        np.random.seed(44)
-
         # Run the inversion from a zero starting model
         mrec = self.grav_inv.run(np.zeros(self.mesh.nC))
 
@@ -465,8 +467,6 @@ class QuadTreeLinProblemTest(unittest.TestCase):
         self.assertLess(data_misfit, dpred.shape[0] * 1.15)
 
     def test_quadtree_mag_inverse(self):
-        np.random.seed(44)
-
         # Run the inversion from a zero starting model
         mrec = self.mag_inv.run(np.zeros(self.mesh.nC))
 
@@ -485,8 +485,6 @@ class QuadTreeLinProblemTest(unittest.TestCase):
         self.assertLess(data_misfit, dpred.shape[0] * 1.1)
 
     def test_quadtree_grav_inverse_activecells(self):
-        np.random.seed(44)
-
         # Run the inversion from a zero starting model
         mrec = self.grav_inv_active.run(np.zeros(int(self.active_cells.sum())))
 
@@ -509,8 +507,6 @@ class QuadTreeLinProblemTest(unittest.TestCase):
         self.assertLess(data_misfit, dpred.shape[0] * 1.1)
 
     def test_quadtree_mag_inverse_activecells(self):
-        np.random.seed(44)
-
         # Run the inversion from a zero starting model
         mrec = self.mag_inv_active.run(np.zeros(int(self.active_cells.sum())))
 


### PR DESCRIPTION
#### Summary

Add a new `random_seed` argument to the `make_synthetic_data` method.
Switch to the Numpy's random number generator object and pass the
`random_seed` argument to `np.random.default_rng`, allowing users to
specify a random seed for the synthetic noise. Set random seeds in some 
tests that were failing due to the new random state that the usage of 
`make_synthetic_data` with `random_seed` created in the test suite.


#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
