### PR TITLE
Em1d stitched update

### DIFF
--- a/SimPEG/electromagnetics/base_1d.py
+++ b/SimPEG/electromagnetics/base_1d.py
@@ -357,7 +357,8 @@ class BaseEM1DSimulation(BaseSimulation):
         Is = []
         n_w_past = 0
         i_count = 0
-
+        # Note: coefficients are needed to be updated if we are 
+        # inverting for the source height.
         if self.hMap is not None:
             hvec = self.h  # source height above topo
 
@@ -372,7 +373,7 @@ class BaseEM1DSimulation(BaseSimulation):
             if is_circular_loop:
                 if np.any(src.orientation[:-1] != 0.0):
                     raise ValueError("Can only simulate horizontal circular loops")
-            # Note: this assumes a fixed height for all sources
+            
             if self.hMap is not None:
                 h = hvec[i_src]
             else:

--- a/SimPEG/electromagnetics/base_1d.py
+++ b/SimPEG/electromagnetics/base_1d.py
@@ -368,8 +368,9 @@ class BaseEM1DSimulation(BaseSimulation):
             if is_circular_loop:
                 if np.any(src.orientation[:-1] != 0.0):
                     raise ValueError("Can only simulate horizontal circular loops")
+            # Note: this assumes a fixed height for all sources
             if self.hMap is not None:
-                h = 0  # source height above topo
+                h = self.h  # source height above topo
             else:
                 h = src.location[2] - self.topo[-1]
 
@@ -573,6 +574,7 @@ class BaseEM1DSimulation(BaseSimulation):
             toDelete += ["_J", "_gtgdiag"]
         return toDelete
 
+    # TODO: need to revisit this: 
     def depth_of_investigation_christiansen_2012(self, std, thres_hold=0.8):
         pred = self.survey._pred.copy()
         delta_d = std * np.log(abs(self.survey.dobs))

--- a/SimPEG/electromagnetics/base_1d.py
+++ b/SimPEG/electromagnetics/base_1d.py
@@ -357,7 +357,11 @@ class BaseEM1DSimulation(BaseSimulation):
         Is = []
         n_w_past = 0
         i_count = 0
-        for src in survey.source_list:
+
+        if self.hMap is not None:
+            hvec = self.h  # source height above topo
+
+        for i_src, src in enumerate(survey.source_list):
             # doing the check for source type by checking its name
             # to avoid importing and checking "isinstance"
             class_name = type(src).__name__
@@ -370,7 +374,7 @@ class BaseEM1DSimulation(BaseSimulation):
                     raise ValueError("Can only simulate horizontal circular loops")
             # Note: this assumes a fixed height for all sources
             if self.hMap is not None:
-                h = self.h  # source height above topo
+                h = hvec[i_src]
             else:
                 h = src.location[2] - self.topo[-1]
 

--- a/SimPEG/electromagnetics/base_1d_stitched.py
+++ b/SimPEG/electromagnetics/base_1d_stitched.py
@@ -139,7 +139,6 @@ class BaseStitchedEM1DSimulation(BaseSimulation):
         Returns
         -------
         numpy.ndarray of float
-        test
         """
         return self._topo
 

--- a/SimPEG/electromagnetics/base_1d_stitched.py
+++ b/SimPEG/electromagnetics/base_1d_stitched.py
@@ -1,0 +1,552 @@
+from scipy.constants import mu_0
+import numpy as np
+from ..simulation import BaseSimulation
+from .. import props
+from .. import utils
+from ..utils.code_utils import (
+    validate_integer,
+    validate_location_property,
+    validate_ndarray_with_shape,
+    validate_type,
+)
+###############################################################################
+#                                                                             #
+#                             BaseStitchedEM1DSimulation                      #
+#                                                                             #
+###############################################################################
+
+__all__ = ["BaseStitchedEM1DSimulation"]
+
+class BaseStitchedEM1DSimulation(BaseSimulation):
+    """
+    Base class for the stitched 1D simulation. This simulation models the EM
+    response for a set of 1D EM soundings.
+    """
+
+    _formulation = "1D"
+    _coefficients = []
+    _coefficients_set = False
+
+    # _Jmatrix_sigma = None
+    # _Jmatrix_height = None
+    # _J = None
+
+    # Properties for electrical conductivity/resistivity
+    sigma, sigmaMap, sigmaDeriv = props.Invertible(
+        "Electrical conductivity at infinite frequency (S/m)"
+    )
+
+    eta = props.PhysicalProperty("Intrinsic chargeability (V/V), 0 <= eta < 1")
+    tau = props.PhysicalProperty("Time constant for Cole-Cole model (s)")
+    c = props.PhysicalProperty("Frequency Dependency for Cole-Cole model, 0 < c < 1")
+
+    # Properties for magnetic susceptibility
+    mu, muMap, muDeriv = props.Invertible(
+        "Magnetic permeability at infinite frequency (SI)"
+    )
+    chi = props.PhysicalProperty(
+        "DC magnetic susceptibility for viscous remanent magnetization contribution (SI)"
+    )
+    tau1 = props.PhysicalProperty(
+        "Lower bound for log-uniform distribution of time-relaxation constants for viscous remanent magnetization (s)"
+    )
+    tau2 = props.PhysicalProperty(
+        "Upper bound for log-uniform distribution of time-relaxation constants for viscous remanent magnetization (s)"
+    )
+
+    # Additional properties
+    h, hMap, hDeriv = props.Invertible("Receiver Height (m), h > 0")
+
+    thicknesses, thicknessesMap, thicknessesDeriv = props.Invertible(
+        "layer thicknesses (m)"
+    )
+
+    def __init__(
+        self,
+        sigma=None,
+        sigmaMap=None,
+        thicknesses=None,
+        thicknessesMap=None,
+        mu=mu_0,
+        muMap=None,
+        h=None,
+        hMap=None,
+        eta=None,
+        tau=None,
+        c=None,
+        dchi=None,
+        tau1=None,
+        tau2=None,
+        fix_Jmatrix=False,
+        topo=None,
+        parallel=False,
+        n_cpu=None,
+        **kwargs,
+    ):
+        super().__init__(mesh=None, **kwargs)
+        self.sigma = sigma
+        self.sigmaMap = sigmaMap
+        self.mu = mu
+        self.muMap = muMap
+        self.h = h
+        self.hMap = hMap
+        if thicknesses is None:
+            thicknesses = np.array([])
+        self.thicknesses = thicknesses
+        self.thicknessesMap = thicknessesMap
+        self.eta = eta
+        self.tau = tau
+        self.c = c
+        self.dchi = dchi
+        self.tau1 = tau1
+        self.tau2 = tau2
+        self.fix_Jmatrix = fix_Jmatrix
+        self.topo = topo
+        if self.topo is None:
+            self.set_null_topography()
+        
+        self.parallel = parallel
+        self.n_cpu = n_cpu
+
+        if self.parallel:
+            if self.verbose:
+                print(">> Use multiprocessing for parallelization")
+                if self.n_cpu is None:
+                    self.n_cpu = multiprocessing.cpu_count()
+                print((">> n_cpu: %i") % (self.n_cpu))
+        else:
+            if self.verbose:
+                print(">> Serial version is used")
+
+    @property
+    def fix_Jmatrix(self):
+        """Whether to fix the sensitivity matrix.
+
+        Returns
+        -------
+        bool
+        """
+        return self._fix_Jmatrix
+
+    @fix_Jmatrix.setter
+    def fix_Jmatrix(self, value):
+        self._fix_Jmatrix = validate_type("fix_Jmatrix", value, bool)
+
+    @property
+    def topo(self):
+        """Topography.
+
+        Returns
+        -------
+        numpy.ndarray of float
+        """
+        return self._topo
+
+    @topo.setter
+    def topo(self, value):
+        self._topo = validate_ndarray_with_shape("topo", value, shape=("*",3))
+
+    @property
+    def parallel(self):
+        """Parallel
+
+        Returns
+        -------
+        bool
+        """
+        return self._parallel
+
+    @parallel.setter
+    def parallel(self, value):
+        self._parallel = validate_type("parallel", value, bool)
+
+    @property
+    def n_cpu(self):
+        """Number of cpus
+
+        Returns
+        -------
+        int
+        """
+        return self._n_cpu
+
+    @n_cpu.setter
+    def n_cpu(self, value):
+        self._n_cpu = validate_integer("n_cpu", value, min_val=1)        
+
+    @property
+    def invert_height(self):
+        if self.hMap is None:
+            return False
+        else:
+            return True
+
+    @property
+    def halfspace_switch(self):
+        """True = halfspace, False = layered Earth"""
+        if (self.thicknesses is None) | (len(self.thicknesses)==0):
+            return True
+        else:
+            return False
+
+    @property
+    def n_layer(self):
+        if self.thicknesses is None:
+            return 1
+        else:
+            return len(self.thicknesses) + 1
+
+    @property
+    def n_sounding(self):
+        return len(self.survey.source_location_by_sounding_dict)
+
+
+    @property
+    def data_index(self):
+        return self.survey.data_index
+
+
+    # ------------- For physical properties ------------- #
+    @property
+    def Sigma(self):
+        if getattr(self, '_Sigma', None) is None:
+            # Ordering: first z then x
+            self._Sigma = self.sigma.reshape((self.n_sounding, self.n_layer))
+        return self._Sigma
+
+    @property
+    def Thicknesses(self):
+        if getattr(self, '_Thicknesses', None) is None:
+            # Ordering: first z then x
+            if len(self.thicknesses) == int(self.n_sounding * (self.n_layer-1)):
+                self._Thicknesses = self.thicknesses.reshape((self.n_sounding, self.n_layer-1))
+            else:
+                self._Thicknesses = np.tile(self.thicknesses, (self.n_sounding, 1))
+        return self._Thicknesses
+
+    @property
+    def Eta(self):
+        if getattr(self, '_Eta', None) is None:
+            # Ordering: first z then x
+            if self.eta is None:
+                self._Eta = np.zeros(
+                    (self.n_sounding, self.n_layer), dtype=float, order='C'
+                )
+            else:
+                self._Eta = self.eta.reshape((self.n_sounding, self.n_layer))
+        return self._Eta
+
+    @property
+    def Tau(self):
+        if getattr(self, '_Tau', None) is None:
+            # Ordering: first z then x
+            if self.tau is None:
+                self._Tau = 1e-3*np.ones(
+                    (self.n_sounding, self.n_layer), dtype=float, order='C'
+                )
+            else:
+                self._Tau = self.tau.reshape((self.n_sounding, self.n_layer))
+        return self._Tau
+
+    @property
+    def C(self):
+        if getattr(self, '_C', None) is None:
+            # Ordering: first z then x
+            if self.c is None:
+                self._C = np.ones(
+                    (self.n_sounding, self.n_layer), dtype=float, order='C'
+                )
+            else:
+                self._C = self.c.reshape((self.n_sounding, self.n_layer))
+        return self._C
+
+    @property
+    def Chi(self):
+        if getattr(self, '_Chi', None) is None:
+            # Ordering: first z then x
+            if self.chi is None:
+                self._Chi = np.zeros(
+                    (self.n_sounding, self.n_layer), dtype=float, order='C'
+                )
+            else:
+                self._Chi = self.chi.reshape((self.n_sounding, self.n_layer))
+        return self._Chi
+
+    @property
+    def dChi(self):
+        if getattr(self, '_dChi', None) is None:
+            # Ordering: first z then x
+            if self.dchi is None:
+                self._dChi = np.zeros(
+                    (self.n_sounding, self.n_layer), dtype=float, order='C'
+                )
+            else:
+                self._dChi = self.dchi.reshape((self.n_sounding, self.n_layer))
+        return self._dChi
+
+    @property
+    def Tau1(self):
+        if getattr(self, '_Tau1', None) is None:
+            # Ordering: first z then x
+            if self.tau1 is None:
+                self._Tau1 = 1e-10 * np.ones(
+                    (self.n_sounding, self.n_layer), dtype=float, order='C'
+                )
+            else:
+                self._Tau1 = self.tau1.reshape((self.n_sounding, self.n_layer))
+        return self._Tau1
+
+    @property
+    def Tau2(self):
+        if getattr(self, '_Tau2', None) is None:
+            # Ordering: first z then x
+            if self.tau2 is None:
+                self._Tau2 = 100. * np.ones(
+                    (self.n_sounding, self.n_layer), dtype=float, order='C'
+                )
+            else:
+                self._Tau2 = self.tau2.reshape((self.n_sounding, self.n_layer))
+        return self._Tau2
+
+    @property
+    def JtJ_sigma(self):
+        return self._JtJ_sigma
+
+    def JtJ_height(self):
+        return self._JtJ_height
+
+    @property
+    def H(self):
+        if self.hMap is None:
+            return np.ones(self.n_sounding)
+        else:
+            return self.h
+
+
+    # ------------- Etcetra .... ------------- #
+    @property
+    def IJLayers(self):
+        if getattr(self, '_IJLayers', None) is None:
+            # Ordering: first z then x
+            self._IJLayers = self.set_ij_n_layer()
+        return self._IJLayers
+
+    @property
+    def IJHeight(self):
+        if getattr(self, '_IJHeight', None) is None:
+            # Ordering: first z then x
+            self._IJHeight = self.set_ij_n_layer(n_layer=1)
+        return self._IJHeight
+
+    # ------------- For physics ------------- #
+
+    def get_uniq_soundings(self):
+            self._sounding_types_uniq, self._ind_sounding_uniq = np.unique(
+                self.survey._sounding_types, return_index=True
+            )
+
+    def input_args(self, i_sounding, output_type='forward'):
+        output = (
+            self.survey.get_sources_by_sounding_number(i_sounding),
+            self.topo[i_sounding, :],
+            self.Thicknesses[i_sounding,:],
+            self.Sigma[i_sounding, :],
+            self.Eta[i_sounding, :],
+            self.Tau[i_sounding, :],
+            self.C[i_sounding, :],
+            self.Chi[i_sounding, :],
+            self.dChi[i_sounding, :],
+            self.Tau1[i_sounding, :],
+            self.Tau2[i_sounding, :],
+            self.H[i_sounding],
+            output_type,
+            self.invert_height,
+            False,
+            self._coefficients[i_sounding],
+        )
+        return output
+
+    # This is the most expensive process, but required once
+    # May need to find unique
+    def input_args_for_coeff(self, i_sounding):
+        output = (
+            self.survey.get_sources_by_sounding_number(i_sounding),
+            self.topo[i_sounding, :],
+            self.Thicknesses[i_sounding,:],
+            self.Sigma[i_sounding, :],
+            self.Eta[i_sounding, :],
+            self.Tau[i_sounding, :],
+            self.C[i_sounding, :],
+            self.Chi[i_sounding, :],
+            self.dChi[i_sounding, :],
+            self.Tau1[i_sounding, :],
+            self.Tau2[i_sounding, :],
+            self.H[i_sounding],
+            'forward',
+            self.invert_height,
+            True,
+            [],
+        )
+        return output
+
+    def fields(self, m):
+        if self.verbose:
+            print("Compute fields")
+
+        return self.forward(m)
+
+    def dpred(self, m, f=None):
+        """
+            Return predicted data.
+            Predicted data, (`_pred`) are computed when
+            self.fields is called.
+        """
+        if f is None:
+            f = self.fields(m)
+
+        return f
+
+    @property
+    def sounding_number(self):
+        self._sounding_number = [key for key in self.survey.source_location_by_sounding_dict.keys()]
+        return self._sounding_number
+
+    @property
+    def sounding_number_chunks(self):
+        self._sounding_number_chunks = list(self.chunks(self.sounding_number, self.n_sounding_for_chunk))
+        return self._sounding_number_chunks
+
+    @property
+    def n_chunk(self):
+        self._n_chunk = len(self.sounding_number_chunks)
+        return self._n_chunk
+
+    def chunks(self, lst, n):
+        """Yield successive n-sized chunks from lst."""
+        for i in range(0, len(lst), n):
+            yield lst[i:i + n]
+
+    def input_args_by_chunk(self, i_chunk, output_type):
+        args_by_chunks = []
+        for i_sounding in self.sounding_number_chunks[i_chunk]:
+            args_by_chunks.append(self.input_args(i_sounding, output_type))
+        return args_by_chunks
+
+    def set_null_topography(self):
+        self.topo = np.vstack(
+            [np.c_[src.location[0], src.location[1], 0.] for i, src in enumerate(self.survey.source_list)]
+        )
+
+
+    def set_ij_n_layer(self, n_layer=None):
+        """
+        Compute (I, J) indicies to form sparse sensitivity matrix
+        This will be used in GlobalEM1DSimulation when after sensitivity matrix
+        for each sounding is computed
+        """
+        I = []
+        J = []
+        shift_for_J = 0
+        shift_for_I = 0
+        if n_layer is None:
+            m = self.n_layer
+        else:
+            m = n_layer
+        source_location_by_sounding_dict = self.survey.source_location_by_sounding_dict
+        for i_sounding in range(self.n_sounding):
+            n = self.survey.vnD_by_sounding_dict[i_sounding]
+            J_temp = np.tile(np.arange(m), (n, 1)) + shift_for_J
+            I_temp = (
+                np.tile(np.arange(n), (1, m)).reshape((n, m), order='F') +
+                shift_for_I
+            )
+            J.append(utils.mkvc(J_temp))
+            I.append(utils.mkvc(I_temp))
+            shift_for_J += m
+            shift_for_I = I_temp[-1, -1] + 1
+        J = np.hstack(J).astype(int)
+        I = np.hstack(I).astype(int)
+        return (I, J)
+
+    def set_ij_height(self):
+        """
+        Compute (I, J) indicies to form sparse sensitivity matrix
+        This will be used in GlobalEM1DSimulation when after sensitivity matrix
+        for each sounding is computed
+        """
+        I = []
+        J = []
+        shift_for_J = 0
+        shift_for_I = 0
+        m = self.n_layer
+        for i_sounding in range(self.n_sounding):
+            n = self.survey.vnD_by_sounding_dict[i_sounding]
+            J_temp = np.tile(np.arange(m), (n, 1)) + shift_for_J
+            I_temp = (
+                np.tile(np.arange(n), (1, m)).reshape((n, m), order='F') +
+                shift_for_I
+            )
+            J.append(utils.mkvc(J_temp))
+            I.append(utils.mkvc(I_temp))
+            shift_for_J += m
+            shift_for_I = I_temp[-1, -1] + 1
+        J = np.hstack(J).astype(int)
+        I = np.hstack(I).astype(int)
+        return (I, J)
+
+    def Jvec(self, m, v, f=None):
+        J_sigma = self.getJ_sigma(m)        
+        Jv = J_sigma@(self.sigmaDeriv@v)
+        if self.hMap is not None:
+            J_height = self.getJ_height(m)
+            Jv += J_height@(self.hDeriv@v)
+        return Jv
+
+    def Jtvec(self, m, v, f=None):
+        J_sigma = self.getJ_sigma(m)        
+        Jtv = self.sigmaDeriv.T @ (J_sigma.T*v)
+        if self.hMap is not None:
+            J_height = self.getJ_height(m)
+            Jtv += self.hDeriv.T*(J_height.T*v)
+        return Jtv
+
+    def getJtJdiag(self, m, W=None, threshold=1e-8):
+        """
+        Compute diagonal component of JtJ or
+        trace of sensitivity matrix (J)
+        """
+        if getattr(self, "_gtgdiag", None) is None:
+            J_sigma = self.getJ_sigma(m)
+            J_matrix = J_sigma@(self.sigmaDeriv)
+
+            if self.hMap is not None:
+                J_height = self.getJ_height(m)
+                J_matrix += J_height*self.hDeriv
+
+            if W is None:
+                W = utils.speye(J_matrix.shape[0])
+            J_matrix = W*J_matrix
+            gtgdiag = (J_matrix.T*J_matrix).diagonal()
+            gtgdiag /= gtgdiag.max()
+            gtgdiag += threshold
+            self._gtgdiag = gtgdiag
+        return self._gtgdiag
+    
+    @property
+    def deleteTheseOnModelUpdate(self):
+        toDelete = super().deleteTheseOnModelUpdate
+        if self.fix_Jmatrix is False:            
+            toDelete += ['_Sigma', '_J', '_Jmatrix_sigma', '_Jmatrix_height', '_gtg_diag']
+        return toDelete
+
+    # def _run_simulation_by_chunk(self, args_chunk):
+    #     """
+    #     This method simulates the EM response or computes the sensitivities for
+    #     a single sounding. The method allows for parallelization of
+    #     the stitched 1D problem.
+    #     """
+    #     n = len(args_chunk)
+    #     results = [
+    #                 self.run_simulation(args_chunk[i_sounding]) for i_sounding in range(n)
+    #     ]
+    #     return results

--- a/SimPEG/electromagnetics/base_1d_stitched.py
+++ b/SimPEG/electromagnetics/base_1d_stitched.py
@@ -139,6 +139,7 @@ class BaseStitchedEM1DSimulation(BaseSimulation):
         Returns
         -------
         numpy.ndarray of float
+        test
         """
         return self._topo
 

--- a/SimPEG/electromagnetics/frequency_domain/__init__.py
+++ b/SimPEG/electromagnetics/frequency_domain/__init__.py
@@ -83,6 +83,7 @@ from .simulation import (
     Simulation3DMagneticField,
 )
 from .simulation_1d import Simulation1DLayered
+from .simulation_1d_stitched import Simulation1DLayeredStitched
 from .fields import (
     Fields3DElectricField,
     Fields3DMagneticFluxDensity,

--- a/SimPEG/electromagnetics/frequency_domain/simulation_1d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_1d.py
@@ -104,9 +104,9 @@ class Simulation1DLayered(BaseEM1DSimulation):
         receiver and outputs it as a list. Used for computing response
         or sensitivities.
         """
-        self._compute_coefficients()
-
         self.model = m
+        
+        self._compute_coefficients()
 
         C0s = self._C0s
         C1s = self._C1s

--- a/SimPEG/electromagnetics/frequency_domain/simulation_1d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_1d.py
@@ -149,28 +149,30 @@ class Simulation1DLayered(BaseEM1DSimulation):
                 # Grab a copy
                 C0s_dh = C0s.copy()
                 C1s_dh = C1s.copy()
-                h_vec = self.h
-                i = 0
-                for i_src, src in enumerate(self.survey.source_list):
-                    class_name = type(src).__name__
-                    is_wire_loop = class_name == "LineCurrent"
+                # h_vec = self.h
+                # i = 0
+                # for i_src, src in enumerate(self.survey.source_list):
+                #     class_name = type(src).__name__
+                #     is_wire_loop = class_name == "LineCurrent"
 
-                    h = h_vec[i_src]
-                    if is_wire_loop:
-                        n_quad_points = src.n_segments * self.n_points_per_path
-                        nD = sum(
-                            rx.locations.shape[0] * n_quad_points
-                            for rx in src.receiver_list
-                        )
-                    else:
-                        nD = sum(rx.locations.shape[0] for rx in src.receiver_list)
-                    ip1 = i + nD
-                    v = np.exp(-lambs[i:ip1] * h)
-                    C0s_dh[i:ip1] *= v * -lambs[i:ip1]
-                    C1s_dh[i:ip1] *= v * -lambs[i:ip1]
-                    i = ip1
+                #     # h = h_vec[i_src]
+                #     if is_wire_loop:
+                #         n_quad_points = src.n_segments * self.n_points_per_path
+                #         nD = sum(
+                #             rx.locations.shape[0] * n_quad_points
+                #             for rx in src.receiver_list
+                #         )
+                #     else:
+                #         nD = sum(rx.locations.shape[0] for rx in src.receiver_list)
+                #     ip1 = i + nD
+                #     # v = np.exp(-lambs[i:ip1] * h)
+                #     C0s_dh[i:ip1] *= - lambs[i:ip1]
+                #     C1s_dh[i:ip1] *= - lambs[i:ip1]
+                #     i = ip1
                     # J will be n_d * n_src (each source has it's own h)...
 
+                C0s_dh *= - lambs
+                C1s_dh *= - lambs
                 rTE = rTE_forward(frequencies, unique_lambs, sig, mu, self.thicknesses)
                 rTE = rTE[i_freq]
                 rTE = np.take_along_axis(rTE, inv_lambs, axis=1)

--- a/SimPEG/electromagnetics/frequency_domain/simulation_1d.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_1d.py
@@ -181,7 +181,7 @@ class Simulation1DLayered(BaseEM1DSimulation):
                 # need to re-arange v_dh as it's currently (n_data x 1)
                 # however it already contains all the relevant information...
                 # just need to map it from the rx index to the source index associated..
-                v_dh = np.zeros((self.survey.nSrc, v_dh_temp.shape[0]))
+                v_dh = np.zeros((self.survey.nSrc, v_dh_temp.shape[0]), dtype=complex)
 
                 i = 0
                 for i_src, src in enumerate(self.survey.source_list):

--- a/SimPEG/electromagnetics/frequency_domain/simulation_1d_stitched.py
+++ b/SimPEG/electromagnetics/frequency_domain/simulation_1d_stitched.py
@@ -1,0 +1,221 @@
+import numpy as np
+from scipy import sparse as sp
+from ... import utils
+from ..base_1d_stitched import BaseStitchedEM1DSimulation
+from .simulation_1d import Simulation1DLayered
+from .survey import Survey
+from ... import maps
+from multiprocessing import Pool
+
+def run_simulation_frequency_domain(args):
+    """
+    This method simulates the EM response or computes the sensitivities for
+    a single sounding. The method allows for parallelization of
+    the stitched 1D problem.
+    :param src: a EM1DFM source object
+    :param topo: Topographic location (x, y, z)
+    :param np.array thicknesses: np.array(N-1,) layer thicknesses for a single sounding
+    :param np.array sigma: np.array(N,) layer conductivities for a single sounding
+    :param np.array eta: np.array(N,) intrinsic chargeabilities for a single sounding
+    :param np.array tau: np.array(N,) Cole-Cole time constant for a single sounding
+    :param np.array c: np.array(N,) Cole-Cole frequency distribution constant for a single sounding
+    :param np.array chi: np.array(N,) magnetic susceptibility for a single sounding
+    :param np.array dchi: np.array(N,) DC susceptibility for magnetic viscosity for a single sounding
+    :param np.array tau1: np.array(N,) lower time-relaxation constant for magnetic viscosity for a single sounding
+    :param np.array tau2: np.array(N,) upper time-relaxation constant for magnetic viscosity for a single sounding
+    :param float h: source height for a single sounding
+    :param string output_type: "response", "sensitivity_sigma", "sensitivity_height"
+    :param bool invert_height: boolean switch for inverting for source height
+    :return: response or sensitivities
+    """
+
+    (
+        source_list,
+        topo,
+        thicknesses,
+        sigma,
+        eta,
+        tau,
+        c,
+        chi,
+        dchi,
+        tau1,
+        tau2,
+        h,
+        output_type,
+        return_projection,
+        coefficients
+    ) = args
+
+    n_layer = len(thicknesses) + 1
+    local_survey = Survey(source_list)
+    n_src = len(source_list)
+    if output_type == "sensitivity":
+        wires = maps.Wires(("sigma", n_layer), ("h", n_src))
+        sigma_map = wires.sigma
+        h_map = wires.h
+    elif output_type == "forward":
+        sigma_map = maps.IdentityMap(nP=n_layer)
+        h_map = None
+
+    sim = Simulation1DLayered(
+        survey=local_survey,
+        thicknesses=thicknesses,
+        sigmaMap=sigma_map,
+        hMap=h_map,
+        eta=eta,
+        tau=tau,
+        c=c,
+        topo=topo,
+        hankel_filter="key_101_2009",
+    )
+
+    if return_projection:
+        return sim.get_coefficients()
+
+    sim._set_coefficients(coefficients)
+
+    if output_type == "sensitivity":
+        J = sim.getJ(np.r_[sigma, h *  np.ones(n_src)])
+        J['dh'] = J['dh'].sum(axis=1)
+        return J
+    else:
+        em_response = sim.dpred(sigma)
+        return em_response
+
+
+#######################################################################
+#       STITCHED 1D SIMULATION CLASS AND GLOBAL FUNCTIONS
+#######################################################################
+
+
+class Simulation1DLayeredStitched(BaseStitchedEM1DSimulation):
+
+    _simulation_type = 'frequency'
+
+    def get_coefficients(self):
+
+        run_simulation = run_simulation_frequency_domain
+
+        if self.verbose:
+            print(">> Calculate coefficients")
+        if self.parallel:
+            pool = Pool(self.n_cpu)
+            self._coefficients = pool.map(
+                run_simulation,
+                [
+                    self.input_args_for_coeff(i) for i in range(self.n_sounding)
+                ]
+             )
+            self._coefficients_set = True
+            pool.close()
+            pool.join()
+        else:
+            self._coefficients = [
+                run_simulation(self.input_args_for_coeff(i)) for i in range(self.n_sounding)
+            ]
+
+    def forward(self, m):
+        self.model = m
+
+        if self.verbose:
+            print(">> Compute response")
+
+        # Set flat topo at zero
+        # if self.topo is None:
+            
+
+        # TODO: Need to pull separate hankel coeffcients
+        #       and A matrix for convolution
+        #       hankel coefficients vary with variable height!
+
+        if self._coefficients_set is False:
+            self.get_coefficients()
+
+        run_simulation = run_simulation_frequency_domain
+
+        if self.parallel:
+            if self.verbose:
+                print ('parallel')
+            #This assumes the same # of layers for each of sounding
+            # if self.n_sounding_for_chunk is None:
+            pool = Pool(self.n_cpu)
+            result = pool.map(
+                run_simulation,
+                [
+                    self.input_args(i, output_type='forward') for i in range(self.n_sounding)
+                ]
+            )
+
+            pool.close()
+            pool.join()
+        else:
+
+            result = [
+                run_simulation(self.input_args(i, output_type='forward')) for i in range(self.n_sounding)
+            ]
+
+        return np.hstack(result)
+
+    def getJ(self, m):
+        """
+             Compute d F / d sigma
+        """
+        self.model = m        
+        if getattr(self, "_J", None) is None:
+
+            if self.verbose:
+                print(">> Compute J")
+
+            if self._coefficients_set is False:
+                self.get_coefficients()
+
+            run_simulation = run_simulation_frequency_domain
+
+            if self.parallel:
+                if self.verbose:
+                    print(">> Start pooling")
+
+                pool = Pool(self.n_cpu)
+
+                # Deprecate this for now, but revisit later
+                # It is an idea of chunking for parallelization
+                # if self.n_sounding_for_chunk is None:
+                self._J = pool.map(
+                    run_simulation,
+                    [
+                        self.input_args(i, output_type='sensitivity') for i in range(self.n_sounding)
+                    ]
+                )
+
+
+                if self.verbose:
+                    print(">> End pooling and form J matrix")
+
+            else:
+                self._J = [
+                        run_simulation(self.input_args(i, output_type='sensitivity')) for i in range(self.n_sounding)
+                ]
+        return self._J
+
+    def getJ_sigma(self, m):
+        """
+             Compute d F / d sigma
+        """
+        if getattr(self, "_Jmatrix_sigma", None) is None:
+            J =  self.getJ(m)
+            self._Jmatrix_sigma = np.hstack([utils.mkvc(J[i]['ds']) for i in range(self.n_sounding)])
+            self._Jmatrix_sigma = sp.coo_matrix(
+                (self._Jmatrix_sigma, self.IJLayers), dtype=float
+            ).tocsr()
+        return self._Jmatrix_sigma
+
+
+    def getJ_height(self, m):
+        if getattr(self, "_Jmatrix_height", None) is None:
+            J =  self.getJ(m)
+            self._Jmatrix_height = np.hstack([utils.mkvc(J[i]['dh']) for i in range(self.n_sounding)])
+            self._Jmatrix_height = sp.coo_matrix(
+                (self._Jmatrix_height, self.IJHeight), dtype=float
+            ).tocsr()
+        return self._Jmatrix_height

--- a/SimPEG/electromagnetics/frequency_domain/sources.py
+++ b/SimPEG/electromagnetics/frequency_domain/sources.py
@@ -39,9 +39,10 @@ class BaseFDEMSrc(BaseEMSrc):
     _hPrimary = None
     _jPrimary = None
 
-    def __init__(self, receiver_list, frequency, location=None, **kwargs):
+    def __init__(self, receiver_list, frequency, location=None, i_sounding=0, **kwargs):
         super().__init__(receiver_list=receiver_list, location=location, **kwargs)
         self.frequency = frequency
+        self.i_sounding = i_sounding
 
     @property
     def frequency(self):
@@ -58,6 +59,20 @@ class BaseFDEMSrc(BaseEMSrc):
     def frequency(self, freq):
         freq = validate_float("frequency", freq, min_val=0.0)
         self._frequency = freq
+
+    @property
+    def i_sounding(self):
+        """Sounding number for the source
+
+        Returns
+        -------
+        int
+        """
+        return self._i_sounding
+
+    @i_sounding.setter
+    def i_sounding(self, value):
+        self._i_sounding = validate_integer("i_sounding", value, min_val=0)        
 
     def bPrimary(self, simulation):
         """Compute primary magnetic flux density

--- a/SimPEG/electromagnetics/frequency_domain/survey.py
+++ b/SimPEG/electromagnetics/frequency_domain/survey.py
@@ -16,13 +16,23 @@ class Survey(BaseSurvey):
         super(Survey, self).__init__(source_list, **kwargs)
 
         _frequency_dict = {}
+        _source_location_dict = {}
+        _source_location_by_sounding_dict = {}        
         for src in self.source_list:
             if src.frequency not in _frequency_dict:
                 _frequency_dict[src.frequency] = []
             _frequency_dict[src.frequency] += [src]
+            if src.i_sounding not in _source_location_dict:
+                _source_location_dict[src.i_sounding] = []
+                _source_location_by_sounding_dict[src.i_sounding] = []
+            _source_location_dict[src.i_sounding] += [src]
+            _source_location_by_sounding_dict[src.i_sounding] += [src.location]
+
 
         self._frequency_dict = _frequency_dict
         self._frequencies = sorted([f for f in self._frequency_dict])
+        self._source_location_dict = _source_location_dict
+        self._source_location_by_sounding_dict = _source_location_by_sounding_dict
 
     @property
     def source_list(self):
@@ -97,3 +107,35 @@ class Survey(BaseSurvey):
             frequency in self._frequency_dict
         ), "The requested frequency is not in this survey."
         return self._frequency_dict[frequency]
+
+    @property
+    def source_location_by_sounding_dict(self):
+        """
+        Source locations in the survey as a dictionary
+        """
+        return self._source_location_by_sounding_dict
+
+    def get_sources_by_sounding_number(self, i_sounding):
+        """
+        Returns the sources associated with a specific source location.
+        :param float i_sounding: source location number
+        :rtype: dictionary
+        :return: sources at the sepcified source location
+        """
+        assert (
+            i_sounding in self._source_location_dict
+        ), "The requested sounding is not in this survey."
+        return self._source_location_dict[i_sounding]
+
+
+    @property
+    def vnD_by_sounding_dict(self):
+        if getattr(self, "_vnD_by_sounding_dict", None) is None:
+            self._vnD_by_sounding_dict = {}
+            for i_sounding in self.source_location_by_sounding_dict:
+                source_list = self.get_sources_by_sounding_number(i_sounding)
+                nD = 0
+                for src in source_list:
+                    nD += src.nD
+                self._vnD_by_sounding_dict[i_sounding] = nD
+        return self._vnD_by_sounding_dict        

--- a/SimPEG/electromagnetics/time_domain/__init__.py
+++ b/SimPEG/electromagnetics/time_domain/__init__.py
@@ -96,6 +96,7 @@ from .simulation import (
     Simulation3DCurrentDensity,
 )
 from .simulation_1d import Simulation1DLayered
+from .simulation_1d_stitched import Simulation1DLayeredStitched
 from .fields import (
     Fields3DMagneticFluxDensity,
     Fields3DElectricField,

--- a/SimPEG/electromagnetics/time_domain/receivers.py
+++ b/SimPEG/electromagnetics/time_domain/receivers.py
@@ -1,6 +1,6 @@
 import scipy.sparse as sp
 
-from ...utils import mkvc, validate_type, validate_direction
+from ...utils import mkvc, validate_type, validate_direction, validate_float
 from discretize.utils import Zero
 from ...survey import BaseTimeRx
 import warnings
@@ -25,6 +25,10 @@ class BaseRx(BaseTimeRx):
         times,
         orientation="z",
         use_source_receiver_offset=False,
+        bw_cutoff_frequency=3e5,
+        bw_power=0.,
+        lp_cutoff_frequency=2.1e5,
+        lp_power=0.,                
         **kwargs
     ):
         proj = kwargs.pop("projComp", None)
@@ -45,6 +49,11 @@ class BaseRx(BaseTimeRx):
 
         self.orientation = orientation
         self.use_source_receiver_offset = use_source_receiver_offset
+        self.bw_cutoff_frequency = bw_cutoff_frequency
+        self.bw_power = bw_power
+        self.lp_cutoff_frequency = lp_cutoff_frequency
+        self.lp_power = lp_power
+
         super().__init__(locations=locations, times=times, **kwargs)
 
     @property
@@ -83,6 +92,67 @@ class BaseRx(BaseTimeRx):
         self._use_source_receiver_offset = validate_type(
             "use_source_receiver_offset", val, bool
         )
+
+    @property
+    def bw_cutoff_frequency(self):
+        """Butter worth low pass filter
+
+        Returns
+        -------
+        numpy.ndarray
+            Butter worth low pass filter
+        """
+        return self._bw_cutoff_frequency
+
+    @bw_cutoff_frequency.setter
+    def bw_cutoff_frequency(self, var):
+        self._bw_cutoff_frequency = validate_float("bw_cutoff_frequency", var, min_val=0.)        
+
+    @property
+    def lp_cutoff_frequency(self):
+        """Low pass filter
+
+        Returns
+        -------
+        numpy.ndarray
+            Low pass filter
+        """
+        return self._lp_cutoff_frequency
+
+    @lp_cutoff_frequency.setter
+    def lp_cutoff_frequency(self, var):
+        self._lp_cutoff_frequency = validate_float("lp_cutoff_frequency", var, min_val=0.)
+
+
+    @property
+    def bw_power(self):
+        """Butter worth low pass filter
+
+        Returns
+        -------
+        numpy.ndarray
+            Butter worth low pass filter
+        """
+        return self._bw_power
+
+    @bw_power.setter
+    def bw_power(self, var):
+        self._bw_power = validate_float("bw_power", var, min_val=0., max_val=2)        
+
+    @property
+    def lp_power(self):
+        """Low pass filter
+
+        Returns
+        -------
+        numpy.ndarray
+            Low pass filter
+        """
+        return self._lp_power
+
+    @lp_power.setter
+    def lp_power(self, var):
+        self._lp_power = validate_float("lp_power", var, min_val=0., max_val=0.99999)
 
     def getSpatialP(self, mesh, f):
         """Get spatial projection matrix from mesh to receivers.

--- a/SimPEG/electromagnetics/time_domain/simulation_1d.py
+++ b/SimPEG/electromagnetics/time_domain/simulation_1d.py
@@ -264,17 +264,23 @@ class Simulation1DLayered(BaseEM1DSimulation):
                 # Grab a copy
                 C0s_dh = C0s.copy()
                 C1s_dh = C1s.copy()
-                h_vec = self.h
-                i = 0
-                for i_src, src in enumerate(self.survey.source_list):
-                    h = h_vec[i_src]
-                    nD = sum(rx.locations.shape[0] for rx in src.receiver_list)
-                    ip1 = i + nD
-                    v = np.exp(-lambs[i:ip1] * h)
-                    C0s_dh[i:ip1] *= v * -lambs[i:ip1]
-                    C1s_dh[i:ip1] *= v * -lambs[i:ip1]
-                    i = ip1
-                    # J will be n_d * n_src (each source has it's own h)...
+                # h_vec = self.h
+                # i = 0
+                # for i_src, src in enumerate(self.survey.source_list):
+                #     rx = src.receiver_list[0]
+                #     h = h_vec[i_src]
+                #     # if rx.use_source_receiver_offset:
+                #     #     dz = rx.locations[:, 2]
+                #     # else:
+                #     #     dz = rx.locations[:, 2] - src.location[2]
+                #     nD = sum(rx.locations.shape[0] for rx in src.receiver_list)
+                #     ip1 = i + nD
+                #     C0s_dh[i:ip1] *= 2 * -lambs[i:ip1]
+                #     C1s_dh[i:ip1] *= 2 * -lambs[i:ip1]
+                #     i = ip1
+                #     # J will be n_d * n_src (each source has it's own h)...
+                C0s_dh *= 2 * -lambs
+                C1s_dh *= 2 * -lambs
 
                 rTE = rTE_forward(frequencies, unique_lambs, sig, mu, self.thicknesses)
                 rTE = rTE[:, inv_lambs]

--- a/SimPEG/electromagnetics/time_domain/simulation_1d.py
+++ b/SimPEG/electromagnetics/time_domain/simulation_1d.py
@@ -78,6 +78,7 @@ class Simulation1DLayered(BaseEM1DSimulation):
             self._inv_lambs,
             self._C0s,
             self._C1s,
+            self._W
         )
 
     def _set_coefficients(self, coefficients):
@@ -88,6 +89,7 @@ class Simulation1DLayered(BaseEM1DSimulation):
         self._inv_lambs = coefficients[4]
         self._C0s = coefficients[5]
         self._C1s = coefficients[6]
+        self._W = coefficients[7]
         self._coefficients_set = True
         return
 
@@ -285,7 +287,7 @@ class Simulation1DLayered(BaseEM1DSimulation):
                 # need to re-arange v_dh as it's currently (n_data x n_freqs)
                 # however it already contains all the relevant information...
                 # just need to map it from the rx index to the source index associated..
-                v_dh = np.zeros((self.survey.nSrc, *v_dh_temp.shape))
+                v_dh = np.zeros((self.survey.nSrc, *v_dh_temp.shape), dtype=complex)
 
                 i = 0
                 for i_src, src in enumerate(self.survey.source_list):

--- a/SimPEG/electromagnetics/time_domain/simulation_1d.py
+++ b/SimPEG/electromagnetics/time_domain/simulation_1d.py
@@ -221,9 +221,9 @@ class Simulation1DLayered(BaseEM1DSimulation):
         receiver and outputs it as a list. Used for computing response
         or sensitivities.
         """
-        self._compute_coefficients()
-
         self.model = m
+        
+        self._compute_coefficients()
 
         C0s = self._C0s
         C1s = self._C1s

--- a/SimPEG/electromagnetics/time_domain/simulation_1d_stitched.py
+++ b/SimPEG/electromagnetics/time_domain/simulation_1d_stitched.py
@@ -45,21 +45,17 @@ def run_simulation_time_domain(args):
         tau2,
         h,
         output_type,
-        return_projection,
-        coefficients
+        # return_projection,
+        # coefficients
     ) = args
 
     n_layer = len(thicknesses) + 1
     n_src = len(source_list)
 
     local_survey = Survey(source_list)
-    if output_type == "sensitivity":
-        wires = maps.Wires(("sigma", n_layer), ("h", n_src))
-        sigma_map = wires.sigma
-        h_map = wires.h
-    elif output_type == "forward":
-        sigma_map = maps.IdentityMap(nP=n_layer)
-        h_map = None
+    wires = maps.Wires(("sigma", n_layer), ("h", n_src))
+    sigma_map = wires.sigma
+    h_map = wires.h
     
     sim = Simulation1DLayered(
         survey=local_survey,
@@ -72,19 +68,14 @@ def run_simulation_time_domain(args):
         topo=topo,
         hankel_filter="key_101_2009",
     )
-
-    if return_projection:
-        return sim.get_coefficients()
-
-    sim._set_coefficients(coefficients)
-
+    model = np.r_[sigma, h*np.ones(n_src)]
     if output_type == "sensitivity":
-        J = sim.getJ(np.r_[sigma, h*np.ones(n_src)])
+        J = sim.getJ(model)
         # we assumed the tx heights in a sounding is fixed
-        J['dh'] = J['dh'].sum(axis=1)        
+        J['dh'] = J['dh'].sum(axis=1)   
         return J
     else:
-        em_response = sim.dpred(sigma)
+        em_response = sim.dpred(model)
         return em_response
 
 #######################################################################
@@ -126,14 +117,6 @@ class Simulation1DLayeredStitched(BaseStitchedEM1DSimulation):
 
         # Set flat topo at zero
         # if self.topo is None:
-            
-
-        # TODO: Need to pull separate hankel coeffcients
-        #       and A matrix for convolution
-        #       hankel coefficients vary with variable height!
-
-        if self._coefficients_set is False:
-            self.get_coefficients()
 
         run_simulation = run_simulation_time_domain
 
@@ -169,9 +152,6 @@ class Simulation1DLayeredStitched(BaseStitchedEM1DSimulation):
 
             if self.verbose:
                 print(">> Compute J")
-
-            if self._coefficients_set is False:
-                self.get_coefficients()
 
             run_simulation = run_simulation_time_domain
 

--- a/SimPEG/electromagnetics/time_domain/simulation_1d_stitched.py
+++ b/SimPEG/electromagnetics/time_domain/simulation_1d_stitched.py
@@ -1,0 +1,246 @@
+import numpy as np
+from scipy import sparse as sp
+from ... import utils
+from ..base_1d_stitched import BaseStitchedEM1DSimulation
+from .simulation_1d import Simulation1DLayered
+from .survey import Survey
+from ... import maps
+from multiprocessing import Pool
+
+def run_simulation_time_domain(args):
+    import os
+    os.environ["MKL_NUM_THREADS"] = "1"     
+    """
+    This method simulates the EM response or computes the sensitivities for
+    a single sounding. The method allows for parallelization of
+    the stitched 1D problem.
+    :param src: a EM1DTM source object
+    :param topo: Topographic location (x, y, z)
+    :param np.array thicknesses: np.array(N-1,) layer thicknesses for a single sounding
+    :param np.array sigma: np.array(N,) layer conductivities for a single sounding
+    :param np.array eta: np.array(N,) intrinsic chargeabilities for a single sounding
+    :param np.array tau: np.array(N,) Cole-Cole time constant for a single sounding
+    :param np.array c: np.array(N,) Cole-Cole frequency distribution constant for a single sounding
+    :param np.array chi: np.array(N,) magnetic susceptibility for a single sounding
+    :param np.array dchi: np.array(N,) DC susceptibility for magnetic viscosity for a single sounding
+    :param np.array tau1: np.array(N,) lower time-relaxation constant for magnetic viscosity for a single sounding
+    :param np.array tau2: np.array(N,) upper time-relaxation constant for magnetic viscosity for a single sounding
+    :param float h: source height for a single sounding
+    :param string output_type: "response", "sensitivity_sigma", "sensitivity_height"
+    :param bool invert_height: boolean switch for inverting for source height
+    :return: response or sensitivities
+    """
+
+    (
+        source_list,
+        topo,
+        thicknesses,
+        sigma,
+        eta,
+        tau,
+        c,
+        chi,
+        dchi,
+        tau1,
+        tau2,
+        h,
+        output_type,
+        invert_height,
+        return_projection,
+        coefficients
+    ) = args
+
+    n_layer = len(thicknesses) + 1
+    local_survey = Survey(source_list)
+    if output_type == "sensitivity":
+        wires = maps.Wires(("sigma", n_layer), ("h", 1))
+        sigma_map = wires.sigma
+        h_map = wires.h
+    elif output_type == "forward":
+        sigma_map = maps.IdentityMap(nP=n_layer)
+        h_map = None
+    
+    sim = Simulation1DLayered(
+        survey=local_survey,
+        thicknesses=thicknesses,
+        sigmaMap=sigma_map,
+        hMap=h_map,
+        eta=eta,
+        tau=tau,
+        c=c,
+        topo=topo,
+        hankel_filter="key_101_2009",
+    )
+
+    if return_projection:
+        return sim.get_coefficients()
+
+    sim._set_coefficients(coefficients)
+
+    if output_type == "sensitivity":
+        J = sim.getJ(np.r_[sigma, h])
+        return J
+    else:
+        em_response = sim.dpred(sigma)
+        return em_response
+
+#######################################################################
+#       STITCHED 1D SIMULATION CLASS AND GLOBAL FUNCTIONS
+#######################################################################
+
+
+class Simulation1DLayeredStitched(BaseStitchedEM1DSimulation):
+
+    _simulation_type = 'time'
+    # survey = properties.Instance("a survey object", Survey, required=True)
+    # def run_simulation(self, args):
+    #     if self.verbose:
+    #         print(">> Time-domain")
+    #     return self._run_simulation(args)
+
+    # TODO: need to think about if there are piecies that are height invariant. 
+    #     
+    # def get_uniq_soundings(self):
+    #         self._sounding_types_uniq, self._ind_sounding_uniq = np.unique(
+    #             self.survey._sounding_types, return_index=True
+    #         )
+    # def get_coefficients(self):
+    #     if self.verbose:
+    #         print(">> Calculate coefficients")
+
+    #     self.get_uniq_soundings()
+
+    #     run_simulation = run_simulation_time_domain
+
+    #     self._coefficients = {}
+    #     for kk, ii in enumerate(self._ind_sounding_uniq):
+    #         name = self._sounding_types_uniq[kk]
+    #         self._coefficients[name] = run_simulation(self.input_args_for_coeff(ii))
+    #     self._coefficients_set = True
+
+    def get_coefficients(self):
+
+        run_simulation = run_simulation_time_domain
+
+        if self.verbose:
+            print(">> Calculate coefficients")
+        if self.parallel:
+            pool = Pool(self.n_cpu)
+            self._coefficients = pool.map(
+                run_simulation,
+                [
+                    self.input_args_for_coeff(i) for i in range(self.n_sounding)
+                ]
+             )
+            self._coefficients_set = True
+            pool.close()
+            pool.join()
+        else:
+            self._coefficients = [
+                run_simulation(self.input_args_for_coeff(i)) for i in range(self.n_sounding)
+            ]
+
+    def forward(self, m):
+        self.model = m
+
+        if self.verbose:
+            print(">> Compute response")
+
+        # Set flat topo at zero
+        # if self.topo is None:
+            
+
+        # TODO: Need to pull separate hankel coeffcients
+        #       and A matrix for convolution
+        #       hankel coefficients vary with variable height!
+
+        if self._coefficients_set is False:
+            self.get_coefficients()
+
+        run_simulation = run_simulation_time_domain
+
+        if self.parallel:
+            if self.verbose:
+                print ('parallel')
+            #This assumes the same # of layers for each of sounding
+            # if self.n_sounding_for_chunk is None:
+            pool = Pool(self.n_cpu)
+            result = pool.map(
+                run_simulation,
+                [
+                    self.input_args(i, output_type='forward') for i in range(self.n_sounding)
+                ]
+            )
+
+            pool.close()
+            pool.join()
+        else:
+
+            result = [
+                run_simulation(self.input_args(i, output_type='forward')) for i in range(self.n_sounding)
+            ]
+
+        return np.hstack(result)
+
+    def getJ(self, m):
+        """
+             Compute d F / d sigma
+        """
+        self.model = m        
+        if getattr(self, "_J", None) is None:
+
+            if self.verbose:
+                print(">> Compute J")
+
+            if self._coefficients_set is False:
+                self.get_coefficients()
+
+            run_simulation = run_simulation_time_domain
+
+            if self.parallel:
+                if self.verbose:
+                    print(">> Start pooling")
+
+                pool = Pool(self.n_cpu)
+
+                # Deprecate this for now, but revisit later
+                # It is an idea of chunking for parallelization
+                # if self.n_sounding_for_chunk is None:
+                self._J = pool.map(
+                    run_simulation,
+                    [
+                        self.input_args(i, output_type='sensitivity') for i in range(self.n_sounding)
+                    ]
+                )
+
+
+                if self.verbose:
+                    print(">> End pooling and form J matrix")
+
+            else:
+                self._J = [
+                        run_simulation(self.input_args(i, output_type='sensitivity')) for i in range(self.n_sounding)
+                ]
+        return self._J
+
+    def getJ_sigma(self, m):
+        """
+             Compute d F / d sigma
+        """
+        if getattr(self, "_Jmatrix_sigma", None) is None:
+            J =  self.getJ(m)
+            self._Jmatrix_sigma = np.hstack([utils.mkvc(J[i]['ds']) for i in range(self.n_sounding)])
+            self._Jmatrix_sigma = sp.coo_matrix(
+                (self._Jmatrix_sigma, self.IJLayers), dtype=float
+            ).tocsr()
+        return self._Jmatrix_sigma
+
+
+    def getJ_height(self, m):
+        if getattr(self, "_Jmatrix_height", None) is None:
+            J =  self.getJ(m)
+            self._Jmatrix_height = np.hstack([utils.mkvc(J[i]['dh']) for i in range(self.n_sounding)])
+            self._Jmatrix_height = sp.coo_matrix(
+                (self._Jmatrix_height, self.IJHeight), dtype=float
+            ).tocsr()
+        return self._Jmatrix_height

--- a/SimPEG/electromagnetics/time_domain/sources.py
+++ b/SimPEG/electromagnetics/time_domain/sources.py
@@ -1037,6 +1037,7 @@ class BaseTDEMSrc(BaseEMSrc):
         location=None,
         waveform=None,
         srcType=None,
+        i_sounding=0,
         **kwargs,
     ):
         if waveform is None:
@@ -1048,6 +1049,8 @@ class BaseTDEMSrc(BaseEMSrc):
         self.waveform = waveform
         if srcType is not None:
             self.srcType = srcType
+
+        self.i_sounding = i_sounding
 
     @property
     def waveform(self):
@@ -1078,6 +1081,20 @@ class BaseTDEMSrc(BaseEMSrc):
     @srcType.setter
     def srcType(self, var):
         self._srcType = validate_string("srcType", var, ["inductive", "galvanic"])
+
+    @property
+    def i_sounding(self):
+        """Sounding number for the source
+
+        Returns
+        -------
+        int
+        """
+        return self._i_sounding
+
+    @i_sounding.setter
+    def i_sounding(self, value):
+        self._i_sounding = validate_integer("i_sounding", value, min_val=0)
 
     def bInitial(self, simulation):
         """Return initial B-field (``Zero`` for ``BaseTDEMSrc`` class)

--- a/SimPEG/electromagnetics/time_domain/survey.py
+++ b/SimPEG/electromagnetics/time_domain/survey.py
@@ -20,6 +20,20 @@ class Survey(BaseSurvey):
     def __init__(self, source_list, **kwargs):
         super(Survey, self).__init__(source_list, **kwargs)
 
+        _source_location_dict = {}
+        _source_location_by_sounding_dict = {}
+        _source_frequency_by_sounding_dict = {}
+
+        for src in source_list:
+            if src.i_sounding not in _source_location_dict:
+                _source_location_dict[src.i_sounding] = []
+                _source_location_by_sounding_dict[src.i_sounding] = []
+            _source_location_dict[src.i_sounding] += [src]
+            _source_location_by_sounding_dict[src.i_sounding] += [src.location]
+
+        self._source_location_dict = _source_location_dict
+        self._source_location_by_sounding_dict = _source_location_by_sounding_dict        
+
     @property
     def source_list(self):
         """List of TDEM sources associated with the survey
@@ -36,3 +50,34 @@ class Survey(BaseSurvey):
         self._source_list = validate_list_of_types(
             "source_list", new_list, BaseTDEMSrc, ensure_unique=True
         )
+
+    @property
+    def source_location_by_sounding_dict(self):
+        """
+        Source location in the survey as a dictionary
+        """
+        return self._source_location_by_sounding_dict
+
+    def get_sources_by_sounding_number(self, i_sounding):
+        """
+        Returns the sources associated with a specific source location.
+        :param float i_sounding: source location number
+        :rtype: dictionary
+        :return: sources at the sepcified source location
+        """
+        assert (
+            i_sounding in self._source_location_dict
+        ), "The requested sounding is not in this survey."
+        return self._source_location_dict[i_sounding]
+
+    @property
+    def vnD_by_sounding_dict(self):
+        if getattr(self, '_vnD_by_sounding_dict', None) is None:
+            self._vnD_by_sounding_dict = {}
+            for i_sounding in self.source_location_by_sounding_dict:
+                source_list = self.get_sources_by_sounding_number(i_sounding)
+                nD = 0
+                for src in source_list:
+                    nD +=src.nD
+                self._vnD_by_sounding_dict[i_sounding] = nD
+        return self._vnD_by_sounding_dict

--- a/SimPEG/electromagnetics/utils/em1d_utils.py
+++ b/SimPEG/electromagnetics/utils/em1d_utils.py
@@ -1,9 +1,21 @@
 import numpy as np
 from geoana.em.fdem.base import skin_depth
 from geoana.em.tdem import diffusion_distance
+import matplotlib.pyplot as plt
 
 from SimPEG import utils
+from discretize import TensorMesh
 
+from SimPEG.utils.code_utils import (
+    validate_ndarray_with_shape,
+)
+
+from scipy.spatial import cKDTree as kdtree
+import scipy.sparse as sp
+from matplotlib.colors import LogNorm
+
+def set_mesh_1d(hz):
+    return TensorMesh([hz], x0=[0])
 
 def get_vertical_discretization(n_layer, minimum_dz, geomtric_factor):
     """
@@ -219,3 +231,405 @@ def LogUniform(f, chi_inf=0.05, del_chi=0.05, tau1=1e-5, tau2=1e-2):
     return chi_inf + del_chi * (
         1 - np.log((1 + 1j * w * tau2) / (1 + 1j * w * tau1)) / np.log(tau2 / tau1)
     )
+
+#############################################################
+#       PLOTTING RESTIVITY MODEL
+#############################################################
+
+class Stitched1DModel:
+
+    def __init__(
+        self, 
+        topography=None,
+        physical_property=None,
+        line=None,
+        time_stamp=None,
+        thicknesses=None,
+        **kwargs
+        ):
+        super().__init__(**kwargs)
+
+        self.topography = topography
+        self.physical_property = physical_property
+        self.line = line
+        self.time_stamp = time_stamp
+        self.thicknesses = thicknesses        
+
+    @property
+    def topography(self):
+        """Topography
+
+        Returns
+        -------
+        (n_sounding, n_dim) np.ndarray
+            Topography.
+        """
+        return self._topography
+
+    @topography.setter
+    def topography(self, locs):
+        self._topography = validate_ndarray_with_shape(
+            "topography", locs, shape=("*", "*"), dtype=float
+        )    
+
+    @property
+    def physical_property(self):
+        """Physical property
+
+        Returns
+        -------
+        (n_sounding x n_layer,) np.ndarray
+            physical_property.
+        """
+        return self._physical_property
+
+    @physical_property.setter
+    def physical_property(self, values):
+        self._physical_property = validate_ndarray_with_shape(
+            "physical_property", values, shape=("*"), dtype=float
+        )
+
+    @property
+    def line(self):
+        """Line number
+
+        Returns
+        -------
+        (n_sounding,) np.ndarray
+            line.
+        """
+        return self._line
+
+    @line.setter
+    def line(self, values):
+        self._line = validate_ndarray_with_shape(
+            "line", values, shape=("*"), dtype=int
+        )
+
+    @property
+    def timestamp(self):
+        """Time stamp
+
+        Returns
+        -------
+        (n_sounding,) np.ndarray
+            timestamp.
+        """
+        return self._timestamp
+
+    @timestamp.setter
+    def timestamp(self, values):
+        self._timestamp = validate_ndarray_with_shape(
+            "timestamp", values, shape=("*"), dtype=float
+        )
+
+    @property
+    def thicknesses(self):
+        """Layer thicknesses
+
+        Returns
+        -------
+        (n_sounding,) np.ndarray
+            thicknesses.
+        """
+        return self._thicknesses
+
+    @thicknesses.setter
+    def thicknesses(self, values):
+        self._thicknesses = validate_ndarray_with_shape(
+            "thicknesses", values, shape=("*"), dtype=float
+        )
+    
+    @property
+    def n_layer(self):
+        return len(self.hz)
+
+    @property
+    def hz(self):
+        if getattr(self, '_hz', None) is None:
+            self._hz = np.r_[self.thicknesses, self.thicknesses[-1]]
+        return self._hz
+
+    @property
+    def n_sounding(self):
+        if getattr(self, '_n_sounding', None) is None:
+            self._n_sounding = self.topography.shape[0]
+        return self._n_sounding
+
+    @property
+    def unique_line(self):
+        if getattr(self, '_unique_line', None) is None:
+            if self.line is None:
+                raise Exception("line information is required!")
+            self._unique_line = np.unique(self.line)
+        return self._unique_line
+
+    @property
+    def xyz(self):
+        if getattr(self, '_xyz', None) is None:
+            xyz = np.empty(
+                (self.n_layer, self.topography.shape[0], 3), order='F'
+            )
+            for i_xy in range(self.topography.shape[0]):
+                z = -self.mesh_1d.vectorCCx + self.topography[i_xy, 2]
+                x = np.ones_like(z) * self.topography[i_xy, 0]
+                y = np.ones_like(z) * self.topography[i_xy, 1]
+                xyz[:, i_xy, :] = np.c_[x, y, z]
+            self._xyz = xyz
+        return self._xyz
+
+    @property
+    def mesh_1d(self):
+        if getattr(self, '_mesh_1d', None) is None:
+            if self.thicknesses is None:
+                raise Exception("thicknesses information is required!")
+            self._mesh_1d = set_mesh_1d(np.r_[self.hz[:self.n_layer]])
+        return self._mesh_1d
+
+    @property
+    def mesh_3d(self):
+        if getattr(self, '_mesh_3d', None) is None:
+            if self.mesh_3d is None:
+                raise Exception("Run get_mesh_3d!")
+        return self._mesh_3d
+
+    @property
+    def physical_property_matrix(self):
+        if getattr(self, '_physical_property_matrix', None) is None:
+            if self.physical_property is None:
+                raise Exception("physical_property information is required!")
+            self._physical_property_matrix = self.physical_property.reshape((self.n_layer, self.n_sounding), order='F')
+        return self._physical_property_matrix
+
+    @property
+    def depth_matrix(self):
+        if getattr(self, '_depth_matrix', None) is None:
+            if self.hz.size == self.n_layer:
+                depth = np.cumsum(np.r_[0, self.hz])
+                self._depth_matrix = np.tile(depth, (self.n_sounding, 1)).T
+            else:
+                self._depth_matrix =np.hstack(
+                    (np.zeros((self.n_sounding,1)), np.cumsum(self.hz.reshape((self.n_sounding, self.n_layer)), axis=1))
+                ).T
+        return self._depth_matrix
+
+    @property
+    def distance(self):
+        if getattr(self, '_distance', None) is None:
+            self._distance = np.zeros(self.n_sounding, dtype=float)
+            for line_tmp in self.unique_line:
+                ind_line = self.line == line_tmp
+                xy_line = self.topography[ind_line,:2]
+                distance_line = np.r_[0, np.cumsum(np.sqrt((np.diff(xy_line, axis=0)**2).sum(axis=1)))]
+                self._distance[ind_line] = distance_line
+        return self._distance
+
+    def plot_section(
+        self, i_layer=0, i_line=0, x_axis='x',
+        plot_type="contour",
+        physical_property=None, clim=None,
+        ax=None, cmap='viridis', ncontour=20, scale='log',
+        show_colorbar=True, aspect=1, zlim=None, dx=20.,
+        invert_xaxis=False,
+        alpha=0.7,
+        pcolorOpts={}
+    ):
+        ind_line = self.line == self.unique_line[i_line]
+        if physical_property is not None:
+            physical_property_matrix = physical_property.reshape(
+                (self.n_layer, self.n_sounding), order='F'
+            )
+        else:
+            physical_property_matrix = self.physical_property_matrix
+
+        if x_axis.lower() == 'y':
+            x_ind = 1
+            xlabel = 'Northing (m)'
+        elif x_axis.lower() == 'x':
+            x_ind = 0
+            xlabel = 'Easting (m)'
+        elif x_axis.lower() == 'distance':
+            xlabel = 'Distance (m)'
+
+        if ax is None:
+            fig = plt.figure(figsize=(15, 10))
+            ax = plt.subplot(111)
+
+        if clim is None:
+            vmin = np.percentile(physical_property_matrix, 5)
+            vmax = np.percentile(physical_property_matrix, 95)
+        else:
+            vmin, vmax = clim
+
+        if scale == 'log':
+            norm = LogNorm(vmin=vmin, vmax=vmax)
+            vmin=None
+            vmax=None
+        else:
+            norm=None
+
+        ind_line = np.arange(ind_line.size)[ind_line]
+
+        for i in ind_line:
+            inds_temp = [i]
+            if x_axis == 'distance':
+                x_tmp = self.distance[i]
+            else:
+                x_tmp = self.topography[i, x_ind]
+
+            topo_temp = np.c_[
+                x_tmp-dx,
+                x_tmp+dx
+            ]
+            out = ax.pcolormesh(
+                topo_temp, -self.depth_matrix[:,i]+self.topography[i, 2], physical_property_matrix[:, inds_temp],
+                cmap=cmap, alpha=alpha,
+                vmin=vmin, vmax=vmax, norm=norm, shading='auto', **pcolorOpts
+            )
+
+        if show_colorbar:
+            from mpl_toolkits import axes_grid1
+            cb = plt.colorbar(out, ax=ax, fraction=0.01)
+            cb.set_label("Conductivity (S/m)")
+
+        ax.set_aspect(aspect)
+        ax.set_xlabel(xlabel)
+        ax.set_ylabel('Elevation (m)')
+        if zlim is not None:
+            ax.set_ylim(zlim)
+
+        if x_axis == 'distance':
+            xlim = self.distance[ind_line].min()-dx, self.distance[ind_line].max()+dx
+        else:
+            xlim = self.topography[ind_line, x_ind].min()-dx, self.topography[ind_line, x_ind].max()+dx
+        if invert_xaxis:
+            ax.set_xlim(xlim[1], xlim[0])
+        else:
+            ax.set_xlim(xlim)
+
+        plt.tight_layout()
+
+        if show_colorbar:
+            return out, ax, cb
+        else:
+            return out, ax
+        return ax,
+
+    def get_3d_mesh(
+        self, dx=None, dy=None, dz=None,
+        npad_x=0, npad_y=0, npad_z=0,
+        core_z_length=None,
+        nx=100,
+        ny=100,
+    ):
+
+        xmin, xmax = self.topography[:, 0].min(), self.topography[:, 0].max()
+        ymin, ymax = self.topography[:, 1].min(), self.topography[:, 1].max()
+        zmin, zmax = self.topography[:, 2].min(), self.topography[:, 2].max()
+        zmin -= self.mesh_1d.vectorNx.max()
+
+        lx = xmax-xmin
+        ly = ymax-ymin
+        lz = zmax-zmin
+
+        if dx is None:
+            dx = lx/nx
+            print ((">> dx:%.1e")%(dx))
+        if dy is None:
+            dy = ly/ny
+            print ((">> dy:%.1e")%(dy))
+        if dz is None:
+            dz = np.median(self.mesh_1d.hx)
+
+        nx = int(np.floor(lx/dx))
+        ny = int(np.floor(ly/dy))
+        nz = int(np.floor(lz/dz))
+
+        if nx*ny*nz > 1e6:
+            warnings.warn(
+                ("Size of the mesh (%i) will greater than 1e6")%(nx*ny*nz)
+            )
+        hx = [(dx, npad_x, -1.2), (dx, nx), (dx, npad_x, -1.2)]
+        hy = [(dy, npad_y, -1.2), (dy, ny), (dy, npad_y, -1.2)]
+        hz = [(dz, npad_z, -1.2), (dz, nz)]
+
+        zmin = self.topography[:, 2].max() - utils.meshTensor(hz).sum()
+        self._mesh_3d = TensorMesh([hx, hy, hz], x0=[xmin, ymin, zmin])
+
+        return self.mesh_3d
+
+    @property
+    def P(self):
+        if getattr(self, '_P', None) is None:
+            raise Exception("Run get_interpolation_matrix first!")
+        return self._P
+
+    def get_interpolation_matrix(
+        self,
+        npts=20,
+        epsilon=None
+    ):
+
+        tree_2d = kdtree(self.topography[:, :2])
+        xy = utils.ndgrid(self.mesh_3d.vectorCCx, self.mesh_3d.vectorCCy)
+
+        distance, inds = tree_2d.query(xy, k=npts)
+        if epsilon is None:
+            epsilon = np.min([self.mesh_3d.hx.min(), self.mesh_3d.hy.min()])
+
+        w = 1. / (distance + epsilon)**2
+        w = utils.sdiag(1./np.sum(w, axis=1)) * (w)
+        I = utils.mkvc(
+            np.arange(inds.shape[0]).reshape([-1, 1]).repeat(npts, axis=1)
+        )
+        J = utils.mkvc(inds)
+
+        self._P = sp.coo_matrix(
+            (utils.mkvc(w), (I, J)),
+            shape=(inds.shape[0], self.topography.shape[0])
+        )
+
+        mesh_1d = TensorMesh([np.r_[self.hz[:-1], 1e20]])
+
+        z = self.P*self.topography[:, 2]
+
+        self._actinds = utils.surface2ind_topo(self.mesh_3d, np.c_[xy, z])
+
+        Z = np.empty(self.mesh_3d.vnC, dtype=float, order='F')
+        Z = self.mesh_3d.gridCC[:, 2].reshape(
+            (self.mesh_3d.nCx*self.mesh_3d.nCy, self.mesh_3d.nCz), order='F'
+        )
+        ACTIND = self._actinds.reshape(
+            (self.mesh_3d.nCx*self.mesh_3d.nCy, self.mesh_3d.nCz), order='F'
+        )
+
+        self._Pz = []
+
+        # This part can be cythonized or parallelized
+        for i_xy in range(self.mesh_3d.nCx*self.mesh_3d.nCy):
+            actind_temp = ACTIND[i_xy, :]
+            z_temp = -(Z[i_xy, :] - z[i_xy])
+            self._Pz.append(mesh_1d.getInterpolationMat(z_temp[actind_temp]))
+
+    def interpolate_from_1d_to_3d(self, physical_property_1d):
+        physical_property_2d = self.P*(
+            physical_property_1d.reshape(
+                (self.n_layer, self.n_sounding), order='F'
+            ).T
+        )
+        physical_property_3d = np.ones(
+            (self.mesh_3d.nCx*self.mesh_3d.nCy, self.mesh_3d.nCz),
+            order='C', dtype=float
+        ) * np.nan
+
+        ACTIND = self._actinds.reshape(
+            (self.mesh_3d.nCx*self.mesh_3d.nCy, self.mesh_3d.nCz), order='F'
+        )
+
+        for i_xy in range(self.mesh_3d.nCx*self.mesh_3d.nCy):
+            actind_temp = ACTIND[i_xy, :]
+            physical_property_3d[i_xy, actind_temp] = (
+                self._Pz[i_xy]*physical_property_2d[i_xy, :]
+            )
+
+        return physical_property_3d    

--- a/SimPEG/regularization/__init__.py
+++ b/SimPEG/regularization/__init__.py
@@ -156,6 +156,7 @@ from .base import (
     SmoothnessSecondOrder,
 )
 from .regularization_mesh import RegularizationMesh
+from .regularization_mesh_lateral import LCRegularizationMesh
 from .sparse import BaseSparse, SparseSmallness, SparseSmoothness, Sparse
 from .pgi import PGIsmallness, PGI
 from .cross_gradient import CrossGradient

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -8,6 +8,7 @@ from .. import maps
 from ..objective_function import BaseObjectiveFunction, ComboObjectiveFunction
 from .. import utils
 from .regularization_mesh import RegularizationMesh
+from .regularization_mesh_lateral import LCRegularizationMesh
 
 from SimPEG.utils.code_utils import deprecate_property, validate_ndarray_with_shape
 
@@ -875,20 +876,24 @@ class SmoothnessFirstOrder(BaseRegularization):
         self, mesh, orientation="x", reference_model_in_smooth=False, **kwargs
     ):
         self.reference_model_in_smooth = reference_model_in_smooth
+        if isinstance(mesh, LCRegularizationMesh):
+            if orientation not in ["r", "z"]:
+                raise ValueError("Orientation must be 'r' or 'z'")            
+        else:
+            if orientation not in ["x", "y", "z"]:
+                raise ValueError("Orientation must be 'x', 'y' or 'z'")
 
-        if orientation not in ["x", "y", "z"]:
-            raise ValueError("Orientation must be 'x', 'y' or 'z'")
+            if orientation == "y" and mesh.dim < 2:
+                raise ValueError(
+                    "Mesh must have at least 2 dimensions to regularize along the "
+                    "y-direction."
+                )
+            elif orientation == "z" and mesh.dim < 3:
+                raise ValueError(
+                    "Mesh must have at least 3 dimensions to regularize along the "
+                    "z-direction"
+                )
 
-        if orientation == "y" and mesh.dim < 2:
-            raise ValueError(
-                "Mesh must have at least 2 dimensions to regularize along the "
-                "y-direction."
-            )
-        elif orientation == "z" and mesh.dim < 3:
-            raise ValueError(
-                "Mesh must have at least 3 dimensions to regularize along the "
-                "z-direction"
-            )
         self._orientation = orientation
 
         super().__init__(mesh=mesh, **kwargs)

--- a/SimPEG/regularization/laterally_constrained.py
+++ b/SimPEG/regularization/laterally_constrained.py
@@ -4,6 +4,11 @@ from .sparse import SparseSmoothness, SparseSmallness, Sparse
 from .. import utils
 import properties
 from .. import props
+from .regularization_mesh_lateral import LCRegularizationMesh
+from typing import TYPE_CHECKING
+# if TYPE_CHECKING:
+from scipy.sparse import csr_matrix
+
 
 class LaterallyConstrainedSmallness(SparseSmallness):
     """
@@ -16,163 +21,12 @@ class LaterallyConstrainedSmoothness(SparseSmoothness):
     for addressing radial and vertical gradients of model parameters,
     which is a 1D vertical resistivity profile at each of lateral locations.
     """
-    @property
-    def cell_gradient(self):
-        if getattr(self, "_cell_gradient", None) is None:
-            self._cell_gradient = getattr(
-                self.regularization_mesh, "cell_gradient_{}".format(self.orientation)
-            )
-        return self._cell_gradient        
-    @property
-    def _cell_distances(self):
-        """
-        Distances between cell centers for the cell center difference.
-        """
-        return getattr(self.regularization_mesh, f"cell_distances_{self.orientation}")
-
-    @property
-    def orientation(self):
-        """Direction along which smoothness is enforced.
-
-        Returns
-        -------
-        {'x','y','z'}
-            The direction along which smoothness is enforced.
-
-        """
-        return self._orientation     
-        
-    def f_m(self, m):
-        dfm_dl = self.cell_gradient @ (self.mapping * self._delta_m(m))
-
-        if self.units is not None and self.units.lower() == "radian":
-            return (
-                utils.mat_utils.coterminal(dfm_dl * self._cell_distances)
-                / self._cell_distances
-            )
-        return dfm_dl        
-
-    def f_m_deriv(self, m) -> csr_matrix:
-        return self.cell_gradient @ self.mapping.deriv(self._delta_m(m))
-
-    def update_weights(self, m):
-        if self.gradient_type == "total" and self.parent is not None:
-            f_m = np.zeros(self.regularization_mesh.nC)
-            for obj in self.parent.objfcts:
-                if isinstance(obj, SparseSmoothness):
-                    avg = getattr(self.regularization_mesh, f"aveF{obj.orientation}2CC")
-                    f_m += np.abs(avg * obj.f_m(m))
-
-            f_m = getattr(self.regularization_mesh, f"aveCC2F{self.orientation}") * f_m
-
+    def __init__(self, mesh, orientation="r", gradient_type="total", **kwargs):
+        if "gradientType" in kwargs:
+            self.gradientType = kwargs.pop("gradientType")
         else:
-            f_m = self.f_m(m)
-
-        self.set_weights(irls=self.get_lp_weights(f_m))
-
-    @property
-    def W(self) -> csr_matrix:
-        r"""Weighting matrix.
-
-        Returns the weighting matrix for the objective function. To see how the
-        weighting matrix is constructed, see the *Notes* section for the
-        :class:`SmoothnessFirstOrder` regularization class.
-
-        Returns
-        -------
-        scipy.sparse.csr_matrix
-            The weighting matrix applied in the objective function.
-        """
-        if getattr(self, "_W", None) is None:
-            average_cell_2_face = getattr(
-                self.regularization_mesh, "aveCC2F{}".format(self.orientation)
-            )
-            weights = 1.0
-            for values in self._weights.values():
-                if values.shape[0] == self.regularization_mesh.nC:
-                    values = average_cell_2_face * values
-                weights *= values
-            self._W = utils.sdiag(weights**0.5)
-        return self._W
-   
-
-###################
-    @property
-    def W(self):
-
-        gradient = getattr(self.regmesh, "gradient_{}".format(self.orientation))
-
-        if getattr(self, "model", None) is None:
-            R = utils.speye(gradient.shape[0])
-
-        else:
-            r = self.R(self.f_m)
-            R = utils.sdiag(r)
-
-        if self.scale is None:
-            self.scale = np.ones(self.mapping.shape[0])
-
-        weights = self.scale * self.regmesh.vol
-
-        if self.cell_weights is not None:
-            weights *= self.cell_weights
-        gradient = getattr(self.regmesh, "gradient_{}".format(self.orientation))
-        average = getattr(self.regmesh, "average_{}".format(self.orientation))
-        return utils.sdiag((average * weights ** 0.5)) * R * gradient
-
-    @property
-    def f_m(self):
-
-        if self.mrefInSmooth:
-
-            f_m = self._delta_m(self.model)
-
-        else:
-            f_m = self.model
-
-        # Not sure how effective it is
-        if self.gradientType == "total":
-
-            average = getattr(self.regmesh, "average_{}".format(self.orientation))
-
-            dm_dx = np.abs(
-                self.regmesh.aveE2N
-                * self.regmesh.gradient_r
-                * (self.mapping * f_m)
-            )
-
-            dm_dx += np.abs(
-                self.regmesh.aveFz2CC
-                * self.regmesh.gradient_z
-                * (self.mapping * f_m)
-            )
-
-            dm_dx = average * dm_dx
-
-        else:
-            gradient = getattr(self.regmesh, "gradient_{}".format(self.orientation))
-            dm_dx = gradient * (self.mapping * f_m)
-
-        return dm_dx
-
-    @property
-    def length_scales(self):
-        """
-        Normalized cell based weighting
-
-        """
-        average = getattr(self.regmesh, "average_{}".format(self.orientation))
-
-        if getattr(self, "_length_scales", None) is None:
-            if self.orientation == 'r':
-                # removing the length scale for the radial component seems better
-                # length_scales = average * self.regmesh.h_gridded_r
-                length_scales = np.ones(average.shape[0], dtype=float)
-            elif self.orientation == 'z':
-                length_scales = average * self.regmesh.h_gridded_z
-            self._length_scales = length_scales.min() / length_scales
-
-        return self._length_scales
+            self.gradient_type = gradient_type
+        super().__init__(mesh=mesh, orientation=orientation, **kwargs)
 
 
 class LaterallyConstrained(Sparse):
@@ -190,29 +44,102 @@ class LaterallyConstrained(Sparse):
     """
 
     def __init__(
-        self, mesh, alpha_s=1.0, alpha_r=1.0, alpha_z=1.0, **kwargs
+        self,
+        mesh,
+        active_cells=None,
+        alpha_r=None,
+        length_scale_r=None,        
+        norms=None,
+        gradient_type="total",
+        irls_scaled=True,
+        irls_threshold=1e-8,
+        objfcts=None,
+        **kwargs,
     ):
-        objfcts = [
-            LaterallyConstrainedSmall(mesh=mesh, **kwargs),
-            LaterallyConstrainedDeriv(mesh=mesh, orientation="r", **kwargs),
-            LaterallyConstrainedDeriv(mesh=mesh, orientation="z", **kwargs),
-        ]
-        # Inherits the upper level class of Sparse
-        self.alpha_r = alpha_r
+        if not isinstance(mesh, LCRegularizationMesh):
+            mesh = LCRegularizationMesh(mesh)
 
-        super(Sparse, self).__init__(
-            mesh=mesh,
+        if not isinstance(mesh, LCRegularizationMesh):
+            TypeError(
+                f"'regularization_mesh' must be of type {LCRegularizationMesh}. "
+                f"Value of type {type(mesh)} provided."
+            )
+        self._regularization_mesh = mesh
+        if active_cells is not None:
+            self._regularization_mesh.active_cells = active_cells
+
+        if alpha_r is not None:
+            if length_scale_r is not None:
+                raise ValueError(
+                    "Attempted to set both alpha_r and length_scale_r at the same time. Please "
+                    "use only one of them"
+                )
+            self.alpha_r = alpha_r
+        else:
+            self.length_scale_r = length_scale_r
+
+        if objfcts is None:
+            objfcts = [
+                SparseSmallness(mesh=self.regularization_mesh),
+                SparseSmoothness(mesh=self.regularization_mesh, orientation="r"),
+                SparseSmoothness(mesh=self.regularization_mesh, orientation="z"),
+            ]
+        gradientType = kwargs.pop("gradientType", None)
+        
+        super().__init__(
+            self.regularization_mesh,
             objfcts=objfcts,
-            alpha_s=alpha_s,
-            alpha_z=alpha_z,
-            **kwargs
+            **kwargs,
         )
 
-    alpha_r = props.Float("weight for the first radial-derivative")
-    # Observers
-    @properties.observer("norms")
-    def _mirror_norms_to_objfcts(self, change):
-        self.objfcts[0].norm = change["value"][:, 0]
-        for i, objfct in enumerate(self.objfcts[1:]):
-            ave_cc_f = getattr(objfct.regmesh, "average_{}".format(objfct.orientation))
-            objfct.norm = ave_cc_f * change["value"][:, i + 1]
+    @property
+    def alpha_r(self):
+        """Multiplier constant for first-order smoothness along x.
+
+        Returns
+        -------
+        float
+            Multiplier constant for first-order smoothness along x.
+        """
+        return self._alpha_r
+
+    @alpha_r.setter
+    def alpha_r(self, value):
+        try:
+            value = float(value)
+        except (ValueError, TypeError):
+            raise TypeError(f"alpha_r must be a real number, saw type{type(value)}")
+        if value < 0:
+            raise ValueError(f"alpha_r must be non-negative, not {value}")
+        self._alpha_r = value        
+
+    @property
+    def length_scale_r(self):
+        r"""Multiplier constant for smoothness along x relative to base scale length.
+
+        Where the :math:`\Delta h` defines the base length scale (i.e. minimum cell dimension),
+        and  :math:`\alpha_r` defines the multiplier constant for first-order smoothness along x,
+        the length-scale is given by:
+
+        .. math::
+            L_x = \bigg ( \frac{\alpha_r}{\Delta h} \bigg )^{1/2}
+
+        Returns
+        -------
+        float
+            Multiplier constant for smoothness along x relative to base scale length.
+        """
+        return np.sqrt(self.alpha_r) / self.regularization_mesh.base_length
+
+    @length_scale_r.setter
+    def length_scale_r(self, value: float):
+        if value is None:
+            value = 1.0
+        try:
+            value = float(value)
+        except (TypeError, ValueError):
+            raise TypeError(
+                f"length_scale_r must be a real number, saw type{type(value)}"
+            )
+        print ("Set alpha_s")
+        self.alpha_r = (value * self.regularization_mesh.base_length) ** 2

--- a/SimPEG/regularization/laterally_constrained.py
+++ b/SimPEG/regularization/laterally_constrained.py
@@ -1,0 +1,218 @@
+import scipy as sp
+import numpy as np
+from .sparse import SparseSmoothness, SparseSmallness, Sparse
+from .. import utils
+import properties
+from .. import props
+
+class LaterallyConstrainedSmallness(SparseSmallness):
+    """
+    Duplicate of SparseSmallness Class
+    """
+
+class LaterallyConstrainedSmoothness(SparseSmoothness):
+    """
+    Modification of SparseSmoothness Class
+    for addressing radial and vertical gradients of model parameters,
+    which is a 1D vertical resistivity profile at each of lateral locations.
+    """
+    @property
+    def cell_gradient(self):
+        if getattr(self, "_cell_gradient", None) is None:
+            self._cell_gradient = getattr(
+                self.regularization_mesh, "cell_gradient_{}".format(self.orientation)
+            )
+        return self._cell_gradient        
+    @property
+    def _cell_distances(self):
+        """
+        Distances between cell centers for the cell center difference.
+        """
+        return getattr(self.regularization_mesh, f"cell_distances_{self.orientation}")
+
+    @property
+    def orientation(self):
+        """Direction along which smoothness is enforced.
+
+        Returns
+        -------
+        {'x','y','z'}
+            The direction along which smoothness is enforced.
+
+        """
+        return self._orientation     
+        
+    def f_m(self, m):
+        dfm_dl = self.cell_gradient @ (self.mapping * self._delta_m(m))
+
+        if self.units is not None and self.units.lower() == "radian":
+            return (
+                utils.mat_utils.coterminal(dfm_dl * self._cell_distances)
+                / self._cell_distances
+            )
+        return dfm_dl        
+
+    def f_m_deriv(self, m) -> csr_matrix:
+        return self.cell_gradient @ self.mapping.deriv(self._delta_m(m))
+
+    def update_weights(self, m):
+        if self.gradient_type == "total" and self.parent is not None:
+            f_m = np.zeros(self.regularization_mesh.nC)
+            for obj in self.parent.objfcts:
+                if isinstance(obj, SparseSmoothness):
+                    avg = getattr(self.regularization_mesh, f"aveF{obj.orientation}2CC")
+                    f_m += np.abs(avg * obj.f_m(m))
+
+            f_m = getattr(self.regularization_mesh, f"aveCC2F{self.orientation}") * f_m
+
+        else:
+            f_m = self.f_m(m)
+
+        self.set_weights(irls=self.get_lp_weights(f_m))
+
+    @property
+    def W(self) -> csr_matrix:
+        r"""Weighting matrix.
+
+        Returns the weighting matrix for the objective function. To see how the
+        weighting matrix is constructed, see the *Notes* section for the
+        :class:`SmoothnessFirstOrder` regularization class.
+
+        Returns
+        -------
+        scipy.sparse.csr_matrix
+            The weighting matrix applied in the objective function.
+        """
+        if getattr(self, "_W", None) is None:
+            average_cell_2_face = getattr(
+                self.regularization_mesh, "aveCC2F{}".format(self.orientation)
+            )
+            weights = 1.0
+            for values in self._weights.values():
+                if values.shape[0] == self.regularization_mesh.nC:
+                    values = average_cell_2_face * values
+                weights *= values
+            self._W = utils.sdiag(weights**0.5)
+        return self._W
+   
+
+###################
+    @property
+    def W(self):
+
+        gradient = getattr(self.regmesh, "gradient_{}".format(self.orientation))
+
+        if getattr(self, "model", None) is None:
+            R = utils.speye(gradient.shape[0])
+
+        else:
+            r = self.R(self.f_m)
+            R = utils.sdiag(r)
+
+        if self.scale is None:
+            self.scale = np.ones(self.mapping.shape[0])
+
+        weights = self.scale * self.regmesh.vol
+
+        if self.cell_weights is not None:
+            weights *= self.cell_weights
+        gradient = getattr(self.regmesh, "gradient_{}".format(self.orientation))
+        average = getattr(self.regmesh, "average_{}".format(self.orientation))
+        return utils.sdiag((average * weights ** 0.5)) * R * gradient
+
+    @property
+    def f_m(self):
+
+        if self.mrefInSmooth:
+
+            f_m = self._delta_m(self.model)
+
+        else:
+            f_m = self.model
+
+        # Not sure how effective it is
+        if self.gradientType == "total":
+
+            average = getattr(self.regmesh, "average_{}".format(self.orientation))
+
+            dm_dx = np.abs(
+                self.regmesh.aveE2N
+                * self.regmesh.gradient_r
+                * (self.mapping * f_m)
+            )
+
+            dm_dx += np.abs(
+                self.regmesh.aveFz2CC
+                * self.regmesh.gradient_z
+                * (self.mapping * f_m)
+            )
+
+            dm_dx = average * dm_dx
+
+        else:
+            gradient = getattr(self.regmesh, "gradient_{}".format(self.orientation))
+            dm_dx = gradient * (self.mapping * f_m)
+
+        return dm_dx
+
+    @property
+    def length_scales(self):
+        """
+        Normalized cell based weighting
+
+        """
+        average = getattr(self.regmesh, "average_{}".format(self.orientation))
+
+        if getattr(self, "_length_scales", None) is None:
+            if self.orientation == 'r':
+                # removing the length scale for the radial component seems better
+                # length_scales = average * self.regmesh.h_gridded_r
+                length_scales = np.ones(average.shape[0], dtype=float)
+            elif self.orientation == 'z':
+                length_scales = average * self.regmesh.h_gridded_z
+            self._length_scales = length_scales.min() / length_scales
+
+        return self._length_scales
+
+
+class LaterallyConstrained(Sparse):
+    """
+    This regularization function is designed to regularize model parameters
+    connected with a 2D simplex mesh and 1D vertical mesh.
+    Motivating example is a stitched inversion of the electromagnetic data.
+    In such a case, a model is a 1D vertical conductivity (or resistivity) profile
+    at each sounding location. Each profile has the same number of layers.
+    The 2D simplex mesh connects resistivity values of each layer in lateral dimensions
+    while the 1D vertical mesh connects resistivity values along the vertical profile.
+    This LaterallyConstrained class is designed in a way that can handle sparse norm inversion.
+    And that is the reason why it inherits the Sparse Class.
+
+    """
+
+    def __init__(
+        self, mesh, alpha_s=1.0, alpha_r=1.0, alpha_z=1.0, **kwargs
+    ):
+        objfcts = [
+            LaterallyConstrainedSmall(mesh=mesh, **kwargs),
+            LaterallyConstrainedDeriv(mesh=mesh, orientation="r", **kwargs),
+            LaterallyConstrainedDeriv(mesh=mesh, orientation="z", **kwargs),
+        ]
+        # Inherits the upper level class of Sparse
+        self.alpha_r = alpha_r
+
+        super(Sparse, self).__init__(
+            mesh=mesh,
+            objfcts=objfcts,
+            alpha_s=alpha_s,
+            alpha_z=alpha_z,
+            **kwargs
+        )
+
+    alpha_r = props.Float("weight for the first radial-derivative")
+    # Observers
+    @properties.observer("norms")
+    def _mirror_norms_to_objfcts(self, change):
+        self.objfcts[0].norm = change["value"][:, 0]
+        for i, objfct in enumerate(self.objfcts[1:]):
+            ave_cc_f = getattr(objfct.regmesh, "average_{}".format(objfct.orientation))
+            objfct.norm = ave_cc_f * change["value"][:, i + 1]

--- a/SimPEG/regularization/laterally_constrained.py
+++ b/SimPEG/regularization/laterally_constrained.py
@@ -47,6 +47,7 @@ class LaterallyConstrained(Sparse):
         self,
         mesh,
         active_cells=None,
+        active_edges=None,
         alpha_r=None,
         length_scale_r=None,        
         norms=None,
@@ -67,6 +68,8 @@ class LaterallyConstrained(Sparse):
         self._regularization_mesh = mesh
         if active_cells is not None:
             self._regularization_mesh.active_cells = active_cells
+        if active_edges is not None:
+            self._regularization_mesh.active_edges = active_edges
 
         if alpha_r is not None:
             if length_scale_r is not None:

--- a/SimPEG/regularization/regularization_mesh_lateral.py
+++ b/SimPEG/regularization/regularization_mesh_lateral.py
@@ -1,0 +1,282 @@
+import numpy as np
+import scipy.sparse as sp
+from SimPEG.utils.code_utils import deprecate_property, validate_active_indices
+
+from .. import props
+from .. import utils
+
+class LCRegularizationMesh(RegularizationMesh):
+    """
+    **LCRegularization Mesh**
+
+    :param list mesh: lit including two discretize meshes
+    :param numpy.ndarray active_cells: bool array, size nC, that is True where we have active cells. Used to reduce the operators so we regularize only on active cells
+    :param numpy.ndarray active_edges: bool array, size nE, that is True where we have active edges. Used to reduce the operators so we regularize only on active edges
+
+    """
+    
+    _active_edges = None    
+
+    def __init__(self, mesh, active_cells=None, active_edges=None, **kwargs):
+        self.mesh_radial = mesh[0]
+        self.mesh_vertical = mesh[1]
+        self.active_cells = active_cells
+        self.active_edges = active_edges
+        utils.setKwargs(self, **kwargs)
+
+    @active_cells.setter
+    def active_cells(self, values: np.ndarray):
+        if getattr(self, "_active_cells", None) is not None and not all(
+            self._active_cells == values
+        ):
+            raise AttributeError(
+                "The RegulatizationMesh already has an 'active_cells' property set."
+            )
+        if values is not None:
+            values = validate_active_indices("values", values, self.mesh.nC)
+            # Ensure any cached operators created when
+            # active_cells was None are deleted
+            self._vol = None
+            self._Pac = None
+            self._Paer = None
+            self._Pafz = None
+            self._h_gridded_r = None
+            self._h_gridded_z = None
+            self._gradient_r = None
+            self._average_r = None
+            self._gradient_z = None
+            self._average_z = None
+            self._aveFz2CC = None
+            self._aveE2N = None
+        self._active_cells = values
+
+    @active_edges.setter
+    def active_edges(self, values: np.ndarray):
+        if getattr(self, "_active_edges", None) is not None and not all(
+            self._active_edges == values
+        ):
+            raise AttributeError(
+                "The RegulatizationMesh already has an 'active_edges' property set."
+            )
+        self._active_edges = values
+        
+    @property
+    def vol(self) -> np.ndarray:
+        # Assume a unit area for the radial points)
+        # We could use the average of cells to nodes
+        self._vol = (np.ones(self.n_nodes, dtype=float)[:, None] * self.mesh_vertical.h[0]).flatten()
+        return self._vol[self.active_cells].flatten()
+
+    @property
+    def h_gridded_r(self) -> np.ndarray:
+        """
+        Length of cells in the raidal direction
+
+        """
+        if getattr(self, "_h_gridded_r", None) is None:
+            # assume a unit length scale in radial direction
+            n = self.nz * self.n_nodes
+            self._h_gridded_r = np.ones(n)
+        return self._h_gridded_r
+
+    @property
+    def h_gridded_z(self) -> np.ndarray:
+        """
+        Length of cells in the vertical direction
+
+        """
+        if getattr(self, "_h_gridded_z", None) is None:
+            self._h_gridded_z = np.tile(
+                self.mesh_vertical.h[0], self.n_nodes
+            ).flatten()
+        return self._h_gridded_z
+
+    @property
+    def nodal_gradient_stencil(self) -> sp.csr_matrix:
+        ind_ptr = 2 * np.arange(self.mesh_radial.n_edges+1)
+        col_inds = self.mesh_radial._edges.reshape(-1)
+        Aijs = (np.ones(self.mesh_radial.n_edges, dtype=float)[:, None] * [-1, 1]).reshape(-1)
+
+        return sp.csr_matrix((Aijs, col_inds, ind_ptr), shape=(self.mesh_radial.n_edges, self.n_nodes))
+
+    @property
+    def gradient_r(self) -> sp.csr_matrix:
+        """
+        Nodal gradient in radial direction
+
+        """
+        if getattr(self, "_gradient_r", None) is None:
+            grad = self.nodal_gradient_stencil
+            self._gradient_r = self.Paer.T * sp.kron(grad, utils.speye(self.nz)) * self.Pac
+        return self._gradient_r
+
+    @property
+    def average_r(self) -> sp.csr_matrix:
+        """
+        Average of cells in the radial direction
+
+        """
+        if getattr(self, "_average_r", None) is None:
+            ave = self.mesh_radial.average_node_to_edge
+            self._average_r = self.Paer.T * sp.kron(ave, utils.speye(self.nz)) * self.Pac
+        return self._average_r
+
+    @property
+    def gradient_z(self) -> sp.csr_matrix:
+        """
+        Cell gradeint in vertical direction
+
+        """
+        if getattr(self, "_gradient_z", None) is None:
+            grad = self.mesh_vertical.stencil_cell_gradient
+            self._gradient_z = self.Pafz.T * sp.kron(utils.speye(self.n_nodes), grad) * self.Pac
+        return self._gradient_z
+
+    @property
+    def average_z(self) -> sp.csr_matrix:
+        """
+        Average of cells in the vertical direction
+
+        """
+        if getattr(self, "_average_z", None) is None:
+            ave = self.mesh_vertical.average_cell_to_face
+            self._average_z = self.Pafz.T * sp.kron(utils.speye(self.n_nodes), ave) * self.Pac
+        return self._average_z
+
+    @property
+    def nz(self) -> int:
+        """
+        Number of cells of the 1D vertical mesh
+        """
+        if getattr(self, "_nz", None) is None:
+            self._nz = self.mesh_vertical.n_cells
+        return self._nz
+
+    @property
+    def nFz(self) -> int:
+        """
+        Number of faces in the vertical direction
+        """
+        if getattr(self, "_nFz", None) is None:
+            self._nFz = self.mesh_vertical.n_faces * self.n_nodes
+        return self._nFz
+
+    @property
+    def nE(self) -> int:
+        """
+        Number of edges in the radial direction
+        """
+        if getattr(self, "_nE", None) is None:
+            self._nE = self.nz * self.n_edges
+        return self._nE
+
+    @property
+    def nC(self) -> int:
+        """
+        reduced number of cells
+
+        :rtype: int
+        :return: number of cells being regularized
+        """
+        if self.active_cells is not None:
+            return int(self.active_cells.sum())
+        return self.nz * self.n_nodes
+
+    @property
+    def n_nodes(self) -> int:
+        """
+        Number of nodes of the 2D simplex mesh
+        """
+        if getattr(self, "_n_nodes", None) is None:
+            self._n_nodes = self.mesh_radial.n_nodes
+        return self._n_nodes
+
+    @property
+    def n_edges(self) -> int:
+        """
+        Number of edges of the 2D simplex mesh
+        """
+        if getattr(self, "_n_edges", None) is None:
+            self._n_edges = self.mesh_radial.n_edges
+        return self._n_edges
+
+    @property
+    def Pafz(self):
+        """
+        projection matrix that takes from the reduced space of active z-faces
+        to full modelling space (ie. nFz x nactive_cells_Fz )
+
+        :rtype: scipy.sparse.csr_matrix
+        :return: active face-x projection matrix
+        """
+        if getattr(self, "_Pafz", None) is None:
+            if self.active_cells is None:
+                self._Pafz = utils.speye(self.nFz)
+            else:
+                ave = self.mesh_vertical.average_face_to_cell
+                aveFz2CC = sp.kron(utils.speye(self.n_nodes), ave)
+                active_cells_Fz = aveFz2CC.T * self.active_cells >= 1
+                self._Pafz = utils.speye(self.nFz)[:, active_cells_Fz]
+        return self._Pafz
+
+    @property
+    def Pac(self):
+        """
+        projection matrix that takes from the reduced space of active cells to
+        full modelling space (ie. nC x nactive_cells)
+
+        :rtype: scipy.sparse.csr_matrix
+        :return: active cell projection matrix
+        """
+        if getattr(self, "_Pac", None) is None:
+            if self.active_cells is None:
+                self._Pac = utils.speye(self.nz*self.n_nodes)
+            else:
+                self._Pac = utils.speye(self.nz*self.n_nodes)[:, self.active_cells]
+        return self._Pac
+
+    @property
+    def Paer(self):
+        """
+        projection matrix that takes from the reduced space of active edges
+        to full modelling space (ie. nE x nactive_cells_E )
+
+        :rtype: scipy.sparse.csr_matrix
+        :return: active edge projection matrix
+        """
+        if getattr(self, "_Paer", None) is None:
+            if self.active_edges is None:
+                self._Paer = utils.speye(self.nE)
+            else:
+                ave = self.mesh_vertical.average_face_to_cell
+                aveFz2CC = sp.kron(utils.speye(self.n_nodes), ave)
+                self._Paer = utils.speye(self.nE)[:, self.active_edges]
+        return self._Paer
+
+    @property
+    def aveFz2CC(self):
+        """
+        averaging from active cell centers to active x-faces
+
+        :rtype: scipy.sparse.csr_matrix
+        :return: averaging from active cell centers to active x-faces
+        """
+        if getattr(self, "_aveFz2CC", None) is None:
+            ave = self.mesh_vertical.average_face_to_cell
+            self._aveFz2CC = self.Pac.T * sp.kron(utils.speye(self.n_nodes), ave) * self.Pafz
+        return self._aveFz2CC
+
+    @property
+    def aveE2N(self):
+        """
+        averaging from active nodes to active edges
+
+        :rtype: scipy.sparse.csr_matrix
+        :return: averaging from active cell centers to active edges
+        """
+
+        if getattr(self, "_aveE2N", None) is None:
+            ave = self.mesh_radial.average_node_to_edge.T
+            self._aveE2N = self.Pac.T * sp.kron(ave, utils.speye(self.nz)) * self.Paer
+        return self._aveE2N
+LCRegularizationMesh.__module__ = "SimPEG.regularization"

--- a/SimPEG/regularization/regularization_mesh_lateral.py
+++ b/SimPEG/regularization/regularization_mesh_lateral.py
@@ -53,7 +53,7 @@ class LCRegularizationMesh(RegularizationMesh):
                 "The RegulatizationMesh already has an 'active_cells' property set."
             )
         if values is not None:
-            values = validate_active_indices("values", values, self.mesh.nC)
+            values = validate_active_indices("values", values, self.nC)
             # Ensure any cached operators created when
             # active_cells was None are deleted
             self._vol = None

--- a/tests/em/em1d/test_EM1D_FD_jac_layers.py
+++ b/tests/em/em1d/test_EM1D_FD_jac_layers.py
@@ -18,7 +18,7 @@ class EM1D_FD_Jacobian_Test_MagDipole(unittest.TestCase):
         deepthick = np.logspace(1, 2, 10)
         thicknesses = np.r_[nearthick, deepthick]
         topo = np.r_[0.0, 0.0, 100.0]
-
+ 
         # Survey Geometry
         height = 1e-5
         src_location = np.array([0.0, 0.0, 100.0 + height])
@@ -148,7 +148,7 @@ class EM1D_FD_Jacobian_Test_MagDipole(unittest.TestCase):
             np.log(np.ones(self.nlayers) * sigma_half),
             np.log(np.ones(self.nlayers) * 1.5 * mu_half),
             np.log(self.thicknesses) * 0.9,
-            np.log(0.5 * self.height),
+            np.log(self.height) *1.5,
         ]
         resp_ini = self.sim.dpred(m_ini)
         dr = resp_ini - dobs
@@ -307,7 +307,7 @@ class EM1D_FD_Jacobian_Test_CircularLoop(unittest.TestCase):
             np.log(np.ones(self.nlayers) * sigma_half),
             np.log(np.ones(self.nlayers) * 1.5 * mu_half),
             np.log(self.thicknesses) * 0.9,
-            np.log(0.5 * self.height),
+            np.log(self.height) * 1.5,
         ]
         resp_ini = self.sim.dpred(m_ini)
         dr = resp_ini - dobs

--- a/tests/em/em1d/test_EM1D_TD_general_jac_layers.py
+++ b/tests/em/em1d/test_EM1D_TD_general_jac_layers.py
@@ -23,7 +23,7 @@ class EM1D_TD_general_Jac_layers_ProblemTests(unittest.TestCase):
             start_time=-0.01, peak_time=-0.005, off_time=0.0
         )
 
-        # Receiver list
+        # xceiver list
 
         # Define receivers at each location.
         b_receiver = tdem.receivers.PointMagneticFluxDensity(

--- a/tests/em/em1d/test_EM1D_TD_off_fwd.py
+++ b/tests/em/em1d/test_EM1D_TD_off_fwd.py
@@ -91,7 +91,7 @@ class EM1D_TD_test_failures(unittest.TestCase):
             rx_locs, times, orientation="z", use_source_receiver_offset=False
         )
         src = tdem.sources.LineCurrent([rx], tx_locs)
-        survey = tdem.Survey(src)
+        survey = tdem.Survey([src])
         with self.assertRaises(ValueError):
             tdem.Simulation1DLayered(survey)
 
@@ -103,7 +103,7 @@ class EM1D_TD_test_failures(unittest.TestCase):
             [2.5, 2.5, 0],
         ]
         src = tdem.sources.LineCurrent([rx], tx_locs)
-        survey = tdem.Survey(src)
+        survey = tdem.Survey([src])
         tdem.Simulation1DLayered(survey)
         assert src.n_segments == 4
 

--- a/tests/em/em1d/test_Stitched_EM1D_FD_jac_layers.py
+++ b/tests/em/em1d/test_Stitched_EM1D_FD_jac_layers.py
@@ -1,0 +1,131 @@
+from __future__ import print_function
+import unittest
+import numpy as np
+import SimPEG.electromagnetics.frequency_domain as fdem
+from SimPEG import *
+from discretize import TensorMesh
+from pymatsolver import PardisoSolver
+
+np.random.seed(41)
+
+
+class STITCHED_EM1D_FD_Jacobian_Test_MagDipole(unittest.TestCase):
+
+    def setUp(self, parallel=False):
+
+        dz = 1
+        geometric_factor = 1.1
+        n_layer = 20
+        thicknesses = dz * geometric_factor ** np.arange(n_layer-1)
+
+        frequencies = np.array([900, 7200, 56000], dtype=float)
+        n_sounding = 50
+        dx = 20.
+        hx = np.ones(n_sounding) * dx
+        hz = np.r_[thicknesses, thicknesses[-1]]
+
+        mesh = TensorMesh([hx, hz], x0='00')
+
+        x = mesh.cell_centers_x
+        y = np.zeros_like(x)
+        z = np.ones_like(x) * 30.
+        receiver_locations = np.c_[x+8., y, z]
+        source_locations = np.c_[x, y, z]
+        topo = np.c_[x, y, z-30.].astype(float)
+
+        sigma_map = maps.ExpMap(mesh)
+
+        source_list = []
+
+        for i_sounding in range(0, n_sounding):
+
+            source_location = mkvc(source_locations[i_sounding, :])
+            receiver_location = mkvc(receiver_locations[i_sounding, :])
+            receiver_list = []
+            receiver_list.append(
+                fdem.receivers.PointMagneticFieldSecondary(
+                    receiver_location,
+                    orientation="z",
+                    component="both"
+                )
+            )
+
+            for i_freq, frequency in enumerate(frequencies):
+                src = fdem.sources.MagDipole(
+                    receiver_list, frequency, source_location,
+                    orientation="z", i_sounding=i_sounding
+                )
+                source_list.append(src)
+
+        survey = fdem.Survey(source_list)
+
+        simulation = fdem.Simulation1DLayeredStitched(
+            survey=survey, thicknesses=thicknesses, sigmaMap=sigma_map,
+            topo=topo, parallel=parallel, n_cpu=2, verbose=False
+        )
+        self.sim = simulation
+        self.mesh = mesh
+
+    def test_EM1DFDJvec_Layers(self):
+        # Conductivity
+        inds = self.mesh.cell_centers[:, 1] < 25
+        inds_1 = self.mesh.cell_centers[:, 1] < 50
+        sigma = np.ones(self.mesh.n_cells) * 1./100.
+        sigma[inds_1] = 1./10.
+        sigma[inds] = 1./50.
+        sigma_em1d = sigma.reshape(self.mesh.vnC, order='F').flatten()
+        m_stitched = np.log(sigma_em1d)
+
+        def fwdfun(m):
+            resp = self.sim.dpred(m)
+            return resp
+            # return Hz
+
+        def jacfun(m, dm):
+            Jvec = self.sim.Jvec(m, dm)
+            return Jvec
+
+        def derChk(m):
+            return [fwdfun(m), lambda mx: jacfun(m, mx)]
+
+        dm = m_stitched * 0.5
+
+        passed = tests.check_derivative(
+            derChk, m_stitched, num=4, dx=dm, plotIt=False, eps=1e-15
+        )
+        self.assertTrue(passed)
+        if passed:
+            print("STITCHED EM1DFM MagDipole Jvec test works")
+
+    def test_EM1DFDJtvec_Layers(self):
+        # Conductivity
+        inds = self.mesh.cell_centers[:, 1] < 25
+        inds_1 = self.mesh.cell_centers[:, 1] < 50
+        sigma = np.ones(self.mesh.n_cells) * 1./100.
+        sigma[inds_1] = 1./10.
+        sigma[inds] = 1./50.
+        sigma_em1d = sigma.reshape(self.mesh.vnC, order='F').flatten()
+        m_stitched = np.log(sigma_em1d)
+
+        dobs = self.sim.dpred(m_stitched)
+
+        m_ini = np.log(1./100.) * np.ones(self.mesh.n_cells)
+        resp_ini = self.sim.dpred(m_ini)
+        dr = resp_ini - dobs
+
+        def misfit(m, dobs):
+            dpred = self.sim.dpred(m)
+            misfit = 0.5 * np.linalg.norm(dpred - dobs) ** 2
+            dmisfit = self.sim.Jtvec(m, dr)
+            return misfit, dmisfit
+
+        def derChk(m):
+            return misfit(m, dobs)
+
+        passed = tests.check_derivative(derChk, m_ini, num=4, plotIt=False, eps=1e-27)
+        self.assertTrue(passed)
+        if passed:
+            print("STITCHED EM1DFM MagDipole Jtvec test works")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/em/em1d/test_Stitched_EM1D_FD_jac_layers.py
+++ b/tests/em/em1d/test_Stitched_EM1D_FD_jac_layers.py
@@ -58,9 +58,14 @@ class STITCHED_EM1D_FD_Jacobian_Test_MagDipole(unittest.TestCase):
                 source_list.append(src)
 
         survey = fdem.Survey(source_list)
+        wires = maps.Wires(('sigma', n_layer*n_sounding), ('h', n_sounding))
+        sigmaMap = maps.ExpMap(nP=n_layer*n_sounding) * wires.sigma
+        hMap = maps.ExpMap(nP=n_sounding) * wires.h
 
         simulation = fdem.Simulation1DLayeredStitched(
-            survey=survey, thicknesses=thicknesses, sigmaMap=sigma_map,
+            survey=survey, thicknesses=thicknesses, 
+            sigmaMap=sigmaMap,
+            hMap=hMap,
             topo=topo, parallel=parallel, n_cpu=2, verbose=False
         )
         self.sim = simulation
@@ -74,7 +79,7 @@ class STITCHED_EM1D_FD_Jacobian_Test_MagDipole(unittest.TestCase):
         sigma[inds_1] = 1./10.
         sigma[inds] = 1./50.
         sigma_em1d = sigma.reshape(self.mesh.vnC, order='F').flatten()
-        m_stitched = np.log(sigma_em1d)
+        m_stitched = np.r_[np.log(sigma_em1d), np.ones(self.sim.n_sounding)*np.log(30.)]
 
         def fwdfun(m):
             resp = self.sim.dpred(m)
@@ -105,11 +110,11 @@ class STITCHED_EM1D_FD_Jacobian_Test_MagDipole(unittest.TestCase):
         sigma[inds_1] = 1./10.
         sigma[inds] = 1./50.
         sigma_em1d = sigma.reshape(self.mesh.vnC, order='F').flatten()
-        m_stitched = np.log(sigma_em1d)
+        m_stitched = np.r_[np.log(sigma_em1d), np.ones(self.sim.n_sounding)*np.log(30.)]
 
         dobs = self.sim.dpred(m_stitched)
 
-        m_ini = np.log(1./100.) * np.ones(self.mesh.n_cells)
+        m_ini = np.r_[np.log(1./100.) * np.ones(self.mesh.n_cells), np.ones(self.sim.n_sounding)*np.log(30.)*1.5]
         resp_ini = self.sim.dpred(m_ini)
         dr = resp_ini - dobs
 

--- a/tests/em/em1d/test_Stitched_EM1D_TD_jac_layers.py
+++ b/tests/em/em1d/test_Stitched_EM1D_TD_jac_layers.py
@@ -1,0 +1,172 @@
+from __future__ import print_function
+import unittest
+import numpy as np
+import SimPEG.electromagnetics.time_domain as tdem
+from SimPEG import *
+from discretize import TensorMesh
+from pymatsolver import PardisoSolver
+
+np.random.seed(41)
+
+
+class STITCHED_EM1D_TD_Jacobian_Test_MagDipole(unittest.TestCase):
+
+    def setUp(self, parallel=False):
+
+        times_hm = np.logspace(-6, -3, 31)
+        times_lm = np.logspace(-5, -2, 31)
+
+        # Waveforms
+        waveform_hm = tdem.sources.TriangularWaveform(
+            start_time=-0.01, peak_time=-0.005, off_time=0.0
+        )
+        waveform_lm = tdem.sources.TriangularWaveform(
+            start_time=-0.01, peak_time=-0.0001, off_time=0.0
+        )
+
+        dz = 1
+        geometric_factor = 1.1
+        n_layer = 20
+        thicknesses = dz * geometric_factor ** np.arange(n_layer-1)
+        n_layer = 20
+
+        n_sounding = 5
+        dx = 20.
+        hx = np.ones(n_sounding) * dx
+        hz = np.r_[thicknesses, thicknesses[-1]]
+        mesh = TensorMesh([hx, hz], x0='00')
+        inds = mesh.cell_centers[:, 1] < 25
+        inds_1 = mesh.cell_centers[:, 1] < 50
+        sigma = np.ones(mesh.nC) * 1./100.
+        sigma[inds_1] = 1./10.
+        sigma[inds] = 1./50.
+        sigma_em1d = sigma.reshape(mesh.vnC, order='F').flatten()
+        mSynth = np.log(sigma_em1d)
+
+        x = mesh.cell_centers_x
+        y = np.zeros_like(x)
+        z = np.ones_like(x) * 30.
+        source_locations = np.c_[x, y, z]
+        source_current = 1.
+        source_orientation = 'z'
+        source_radius = 10.
+
+        receiver_offset_r = 13.25
+        receiver_offset_z = 2.
+
+        receiver_locations = np.c_[x+receiver_offset_r, np.zeros(n_sounding), 30.*np.ones(n_sounding)+receiver_offset_z]
+        receiver_orientation = "z"  # "x", "y" or "z"
+
+        topo = np.c_[x, y, z-30.].astype(float)
+
+        sigma_map = maps.ExpMap(mesh)
+
+        source_list = []
+
+        for i_sounding in range(0, n_sounding):
+
+            source_location = source_locations[i_sounding, :]
+            receiver_location = receiver_locations[i_sounding, :]
+
+            # Receiver list
+
+            # Define receivers at each location.
+            dbzdt_receiver_hm = tdem.receivers.PointMagneticFluxTimeDerivative(
+                receiver_location, times_hm, receiver_orientation
+            )
+            dbzdt_receiver_lm = tdem.receivers.PointMagneticFluxTimeDerivative(
+                receiver_location, times_lm, receiver_orientation
+            )
+            # Make a list containing all receivers even if just one
+
+            # Must define the transmitter properties and associated receivers
+            source_list.append(tdem.sources.MagDipole(
+                [dbzdt_receiver_hm],
+                location=source_location,
+                waveform=waveform_hm,
+                orientation=source_orientation,
+                i_sounding=i_sounding,
+            )
+            )
+
+            source_list.append(tdem.sources.MagDipole(
+                [dbzdt_receiver_lm],
+                location=source_location,
+                waveform=waveform_lm,
+                orientation=source_orientation,
+                i_sounding=i_sounding,
+            )
+            )
+        survey = tdem.Survey(source_list)
+
+        simulation = tdem.Simulation1DLayeredStitched(
+            survey=survey, thicknesses=thicknesses, sigmaMap=sigma_map,
+            topo=topo, parallel=False, n_cpu=2, verbose=False, solver=PardisoSolver
+        )
+
+        self.sim = simulation
+        self.mesh = mesh
+
+    def test_EM1DFDJvec_Layers(self):
+        # Conductivity
+        inds = self.mesh.cell_centers[:, 1] < 25
+        inds_1 = self.mesh.cell_centers[:, 1] < 50
+        sigma = np.ones(self.mesh.n_cells) * 1./100.
+        sigma[inds_1] = 1./10.
+        sigma[inds] = 1./50.
+        sigma_em1d = sigma.reshape(self.mesh.vnC, order='F').flatten()
+        m_stitched = np.log(sigma_em1d)
+
+        def fwdfun(m):
+            resp = self.sim.dpred(m)
+            return resp
+            # return Hz
+
+        def jacfun(m, dm):
+            Jvec = self.sim.Jvec(m, dm)
+            return Jvec
+
+        def derChk(m):
+            return [fwdfun(m), lambda mx: jacfun(m, mx)]
+
+        dm = m_stitched * 0.5
+
+        passed = tests.check_derivative(
+            derChk, m_stitched, num=4, dx=dm, plotIt=False, eps=1e-15
+        )
+        self.assertTrue(passed)
+        if passed:
+            print("STITCHED EM1DFM MagDipole Jvec test works")
+
+    def test_EM1DFDJtvec_Layers(self):
+        # Conductivity
+        inds = self.mesh.cell_centers[:, 1] < 25
+        inds_1 = self.mesh.cell_centers[:, 1] < 50
+        sigma = np.ones(self.mesh.n_cells) * 1./100.
+        sigma[inds_1] = 1./10.
+        sigma[inds] = 1./50.
+        sigma_em1d = sigma.reshape(self.mesh.vnC, order='F').flatten()
+        m_stitched = np.log(sigma_em1d)
+
+        dobs = self.sim.dpred(m_stitched)
+
+        m_ini = np.log(1./100.) * np.ones(self.mesh.n_cells)
+        resp_ini = self.sim.dpred(m_ini)
+        dr = resp_ini - dobs
+
+        def misfit(m, dobs):
+            dpred = self.sim.dpred(m)
+            misfit = 0.5 * np.linalg.norm(dpred - dobs) ** 2
+            dmisfit = self.sim.Jtvec(m, dr)
+            return misfit, dmisfit
+
+        def derChk(m):
+            return misfit(m, dobs)
+
+        passed = tests.check_derivative(derChk, m_ini, num=4, plotIt=False, eps=1e-27)
+        self.assertTrue(passed)
+        if passed:
+            print("STITCHED EM1DFM MagDipole Jtvec test works")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing/pull-requests.html

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
Finished implementing stitched 1D electromagnetic (EM) inversion (or often referred to as laterally-constrained or spatially-constrained inversion) suitable for inverting large-scale airborne EM (AEM) data or surface-based loop EM data. 

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?

- Inversion of time-domain and frequency-domain EM data for imaging subsurface resistivity
- Inversion of time-domain and frequency-domain EM data for imaging subsurface resistivity and source and receiver height [there was a bug in `base_1d.py`; also inverting height raises an issue for storing coefficients @jcapriot ]
- Parallelization using `multiprocessing` [thought about using `Meta` class, but I felt the current implementation is not relevant; but open for any other opinions]
- Visualization of inverted resistivity model on a vertical section
- Creation of a 3D voxel model from the inverted resistivity model


#### Additional information
<!--Any additional information you think is important.-->
- There was a bug in `base_1d.py`; also inverting height raises an issue for storing coefficients @jcapriot 
- For parallelization, I thought about using `Meta` class, but I felt the current implementation is not relevant; but open for any other opinions
- An example for inverting synthetic frequency domain EM data to recover both subsurface resistivity and source height is available: https://curvenote.com/@sgkang09/researches/inv-1d-stitched-inv-alt-fdem
- Results of the example are provided below:

**Estimated source height over a profile:**
![image](https://github.com/simpeg/simpeg/assets/6054371/7b3fa881-b1a8-4211-9693-381637b09194)

Estimated and True resistivity models over the same profile
![image](https://github.com/simpeg/simpeg/assets/6054371/75ed6785-30f9-4b13-a3f0-04af2b3d1f10)
![image](https://github.com/simpeg/simpeg/assets/6054371/c9cd42d1-aa05-48b9-b71f-41e53d59c5a1)

<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
