### PR TITLE
Update test_regularization.py

### DIFF
--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -574,6 +574,8 @@ class RegularizationTests(unittest.TestCase):
             reg.objfcts[0].f_m(model.flatten(order="F")), np.linalg.norm(model, axis=1)
         )
 
+        reg.test(model.flatten(order="F"))
+
 
 def test_WeightedLeastSquares():
     mesh = discretize.TensorMesh([3, 4, 5])


### PR DESCRIPTION
Following on the discussion in #1301, it doesn't look like we are testing the derivatives for the vector amplitude. This pr adds a derivative test for the vector amplitude regularization. When running locally, I obtain the following: 

```
Testing VectorAmplitude Deriv
==================== check_derivative ====================
iter    h         |ft-f0|   |ft-f0-h*J0*dx|  Order
---------------------------------------------------------
 0   1.00e-01    9.980e-04     9.697e-03      nan
 1   1.00e-02    1.858e-03     9.881e-04      0.992
 2   1.00e-03    2.060e-04     1.190e-04      0.919
 3   1.00e-04    2.080e-05     1.210e-05      0.993
*********************************************************
<<<<<<<<<<<<<<<<<<<<<<<<< FAIL! >>>>>>>>>>>>>>>>>>>>>>>>>
*********************************************************
Boooooooo  :(
```

We can chat further on #1301 on how best to handle this.