### PR TITLE
Ditch deprecated functions in utils.model_builder

### DIFF
--- a/SimPEG/electromagnetics/natural_source/utils/test_utils.py
+++ b/SimPEG/electromagnetics/natural_source/utils/test_utils.py
@@ -547,7 +547,7 @@ def blockInhalfSpace(conds):
     ccM = M.gridCC
     # conds = [1e-2]
     groundInd = ccM[:, 2] < elev
-    sig = utils.model_builder.defineBlock(
+    sig = utils.model_builder.create_block_in_wholespace(
         M.gridCC, np.array([-1000, -1000, -1500]), np.array([1000, 1000, -1000]), conds
     )
     sig[~groundInd] = 1e-8

--- a/SimPEG/electromagnetics/static/utils/static_utils.py
+++ b/SimPEG/electromagnetics/static/utils/static_utils.py
@@ -1676,13 +1676,13 @@ def genTopography(mesh, zmin, zmax, seed=None, its=100, anisotropy=None):
         mesh2D = discretize.TensorMesh(
             [mesh.h[0], mesh.h[1]], x0=[mesh.x0[0], mesh.x0[1]]
         )
-        out = model_builder.randomModel(
+        out = model_builder.create_random_model(
             mesh.vnC[:2], bounds=[zmin, zmax], its=its, seed=seed, anisotropy=anisotropy
         )
         return out, mesh2D
     elif mesh.dim == 2:
         mesh1D = discretize.TensorMesh([mesh.h[0]], x0=[mesh.x0[0]])
-        out = model_builder.randomModel(
+        out = model_builder.create_random_model(
             mesh.vnC[:1], bounds=[zmin, zmax], its=its, seed=seed, anisotropy=anisotropy
         )
         return out, mesh1D

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -144,7 +144,7 @@ def create_block_in_wholespace(
         pass
 
     sigma = np.zeros(cell_centers.shape[0]) + background_value
-    ind = getIndicesBlock(p0, p1, cell_centers)
+    ind = get_indices_block(p0, p1, cell_centers)
 
     sigma[ind] = block_value
 
@@ -317,7 +317,7 @@ def create_2_layer_model(cell_centers, depth, top_value=1.0, bottom_value=0.0):
     # The depth is always defined on the last one.
     p1[len(p1) - 1] -= depth
 
-    ind = getIndicesBlock(p0, p1, cell_centers)
+    ind = get_indices_block(p0, p1, cell_centers)
 
     sigma[ind] = top_value
 
@@ -516,10 +516,6 @@ def get_indices_polygon(mesh, pts):
 #             DEPRECATED FUNCTIONS
 ################################################
 
-
-getIndicesBlock = deprecate_function(
-    get_indices_block, "getIndicesBlock", removal_version="0.19.0", future_warn=True
-)
 
 defineBlock = deprecate_function(
     create_block_in_wholespace,

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -3,7 +3,6 @@ import scipy.ndimage as ndi
 import scipy.sparse as sp
 from .mat_utils import mkvc
 from scipy.spatial import Delaunay
-from .code_utils import deprecate_function
 from discretize.base import BaseMesh
 
 
@@ -510,16 +509,3 @@ def get_indices_polygon(mesh, pts):
     hull = Delaunay(pts)
     inds = hull.find_simplex(mesh.cell_centers) >= 0
     return inds
-
-
-################################################
-#             DEPRECATED FUNCTIONS
-################################################
-
-
-scalarConductivity = deprecate_function(
-    create_from_function,
-    "scalarConductivity",
-    removal_version="0.19.0",
-    future_warn=True,
-)

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -517,10 +517,6 @@ def get_indices_polygon(mesh, pts):
 ################################################
 
 
-defineTwoLayers = deprecate_function(
-    create_2_layer_model, "defineTwoLayers", removal_version="0.19.0", future_warn=True
-)
-
 layeredModel = deprecate_function(
     create_layers_model, "layeredModel", removal_version="0.19.0", future_warn=True
 )

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -517,13 +517,6 @@ def get_indices_polygon(mesh, pts):
 ################################################
 
 
-defineBlock = deprecate_function(
-    create_block_in_wholespace,
-    "defineBlock",
-    removal_version="0.19.0",
-    future_warn=True,
-)
-
 defineEllipse = deprecate_function(
     create_ellipse_in_wholespace,
     "defineEllipse",

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -517,10 +517,6 @@ def get_indices_polygon(mesh, pts):
 ################################################
 
 
-polygonInd = deprecate_function(
-    get_indices_polygon, "polygonInd", removal_version="0.19.0", future_warn=True
-)
-
 scalarConductivity = deprecate_function(
     create_from_function,
     "scalarConductivity",

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -517,10 +517,6 @@ def get_indices_polygon(mesh, pts):
 ################################################
 
 
-addBlock = deprecate_function(
-    add_block, "addBlock", removal_version="0.19.0", future_warn=True
-)
-
 getIndicesBlock = deprecate_function(
     get_indices_block, "getIndicesBlock", removal_version="0.19.0", future_warn=True
 )

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -517,10 +517,6 @@ def get_indices_polygon(mesh, pts):
 ################################################
 
 
-randomModel = deprecate_function(
-    create_random_model, "randomModel", removal_version="0.19.0", future_warn=True
-)
-
 polygonInd = deprecate_function(
     get_indices_polygon, "polygonInd", removal_version="0.19.0", future_warn=True
 )

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -517,10 +517,6 @@ def get_indices_polygon(mesh, pts):
 ################################################
 
 
-layeredModel = deprecate_function(
-    create_layers_model, "layeredModel", removal_version="0.19.0", future_warn=True
-)
-
 randomModel = deprecate_function(
     create_random_model, "randomModel", removal_version="0.19.0", future_warn=True
 )

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -535,10 +535,6 @@ defineEllipse = deprecate_function(
     future_warn=True,
 )
 
-getIndicesSphere = deprecate_function(
-    get_indices_sphere, "getIndicesSphere", removal_version="0.19.0", future_warn=True
-)
-
 defineTwoLayers = deprecate_function(
     create_2_layer_model, "defineTwoLayers", removal_version="0.19.0", future_warn=True
 )

--- a/SimPEG/utils/model_builder.py
+++ b/SimPEG/utils/model_builder.py
@@ -517,13 +517,6 @@ def get_indices_polygon(mesh, pts):
 ################################################
 
 
-defineEllipse = deprecate_function(
-    create_ellipse_in_wholespace,
-    "defineEllipse",
-    removal_version="0.19.0",
-    future_warn=True,
-)
-
 defineTwoLayers = deprecate_function(
     create_2_layer_model, "defineTwoLayers", removal_version="0.19.0", future_warn=True
 )

--- a/examples/01-maps/plot_mesh2mesh.py
+++ b/examples/01-maps/plot_mesh2mesh.py
@@ -14,7 +14,7 @@ def run(plotIt=True):
     h1 = utils.unpack_widths([(6, 7, -1.5), (6, 10), (6, 7, 1.5)])
     h1 = h1 / h1.sum()
     M2 = discretize.TensorMesh([h1, h1])
-    V = utils.model_builder.random_model(M.vnC, seed=79, its=50)
+    V = utils.model_builder.create_random_model(M.vnC, seed=79, its=50)
     v = utils.mkvc(V)
     modh = maps.Mesh2Mesh([M, M2])
     modH = maps.Mesh2Mesh([M2, M])

--- a/examples/01-maps/plot_mesh2mesh.py
+++ b/examples/01-maps/plot_mesh2mesh.py
@@ -14,7 +14,7 @@ def run(plotIt=True):
     h1 = utils.unpack_widths([(6, 7, -1.5), (6, 10), (6, 7, 1.5)])
     h1 = h1 / h1.sum()
     M2 = discretize.TensorMesh([h1, h1])
-    V = utils.model_builder.randomModel(M.vnC, seed=79, its=50)
+    V = utils.model_builder.random_model(M.vnC, seed=79, its=50)
     v = utils.mkvc(V)
     modh = maps.Mesh2Mesh([M, M2])
     modH = maps.Mesh2Mesh([M2, M])

--- a/examples/01-maps/plot_sumMap.py
+++ b/examples/01-maps/plot_sumMap.py
@@ -72,7 +72,7 @@ def run(plotIt=True):
     model[mesh.gridCC[:, 0] < 0] = 0.01
 
     # Add a block in half-space
-    model = utils.model_builder.addBlock(
+    model = utils.model_builder.add_block(
         mesh.gridCC, model, np.r_[-10, -10, 20], np.r_[10, 10, 40], 0.05
     )
 

--- a/examples/02-gravity/plot_inv_grav_tiled.py
+++ b/examples/02-gravity/plot_inv_grav_tiled.py
@@ -115,7 +115,7 @@ nC = int(activeCells.sum())
 # Here a simple block in half-space
 # Get the indices of the magnetized block
 model = np.zeros(mesh.nC)
-ind = utils.model_builder.getIndicesBlock(
+ind = utils.model_builder.get_indices_block(
     np.r_[-10, -10, -30],
     np.r_[10, 10, -10],
     mesh.gridCC,

--- a/examples/03-magnetics/plot_inv_mag_MVI_Sparse_TreeMesh.py
+++ b/examples/03-magnetics/plot_inv_mag_MVI_Sparse_TreeMesh.py
@@ -131,7 +131,7 @@ model = np.zeros((mesh.nC, 3))
 M_xyz = utils.mat_utils.dip_azimuth2cartesian(M[0], M[1])
 
 # Get the indicies of the magnetized block
-ind = utils.model_builder.getIndicesBlock(
+ind = utils.model_builder.get_indices_block(
     np.r_[-20, -20, -10],
     np.r_[20, 20, 25],
     mesh.gridCC,

--- a/examples/03-magnetics/plot_inv_mag_MVI_VectorAmplitude.py
+++ b/examples/03-magnetics/plot_inv_mag_MVI_VectorAmplitude.py
@@ -97,7 +97,7 @@ nC = int(actv.sum())
 #
 model_azm_dip = np.zeros((mesh.nC, 2))
 model_amp = np.ones(mesh.nC) * 1e-8
-ind = utils.model_builder.getIndicesBlock(
+ind = utils.model_builder.get_indices_block(
     np.r_[-30, -20, -10],
     np.r_[30, 20, 25],
     mesh.gridCC,

--- a/examples/03-magnetics/plot_inv_mag_nonLinear_Amplitude.py
+++ b/examples/03-magnetics/plot_inv_mag_nonLinear_Amplitude.py
@@ -125,7 +125,7 @@ nC = int(actv.sum())
 M_xyz = utils.mat_utils.dip_azimuth2cartesian(np.ones(nC) * M[0], np.ones(nC) * M[1])
 
 # Get the indicies of the magnetized block
-ind = utils.model_builder.getIndicesBlock(
+ind = utils.model_builder.get_indices_block(
     np.r_[-20, -20, -10],
     np.r_[20, 20, 25],
     mesh.gridCC,

--- a/examples/07-nsem/plot_fwd_nsem_MTTipper3D.py
+++ b/examples/07-nsem/plot_fwd_nsem_MTTipper3D.py
@@ -40,7 +40,7 @@ def run(plotIt=True):
     )
     # Setup the model
     conds = [1, 1e-2]
-    sig = utils.model_builder.defineBlock(
+    sig = utils.model_builder.define_block(
         M.gridCC, [-100, -100, -350], [100, 100, -150], conds
     )
     sig[M.gridCC[:, 2] > 0] = 1e-8

--- a/examples/07-nsem/plot_fwd_nsem_MTTipper3D.py
+++ b/examples/07-nsem/plot_fwd_nsem_MTTipper3D.py
@@ -40,7 +40,7 @@ def run(plotIt=True):
     )
     # Setup the model
     conds = [1, 1e-2]
-    sig = utils.model_builder.define_block(
+    sig = utils.model_builder.create_block_in_wholespace(
         M.gridCC, [-100, -100, -350], [100, 100, -150], conds
     )
     sig[M.gridCC[:, 2] > 0] = 1e-8

--- a/examples/20-published/plot_tomo_joint_with_volume.py
+++ b/examples/20-published/plot_tomo_joint_with_volume.py
@@ -101,7 +101,7 @@ def run(plotIt=True):
     # phi model
     phi0 = 0
     phi1 = 0.65
-    phitrue = utils.model_builder.define_block(
+    phitrue = utils.model_builder.create_block_in_wholespace(
         M.gridCC, [0.4, 0.6], [0.6, 0.4], [phi1, phi0]
     )
 

--- a/examples/20-published/plot_tomo_joint_with_volume.py
+++ b/examples/20-published/plot_tomo_joint_with_volume.py
@@ -101,7 +101,7 @@ def run(plotIt=True):
     # phi model
     phi0 = 0
     phi1 = 0.65
-    phitrue = utils.model_builder.defineBlock(
+    phitrue = utils.model_builder.define_block(
         M.gridCC, [0.4, 0.6], [0.6, 0.4], [phi1, phi0]
     )
 

--- a/examples/_archived/plot_inv_dcip_2_5Dinversion.py
+++ b/examples/_archived/plot_inv_dcip_2_5Dinversion.py
@@ -64,13 +64,13 @@ def run(plotIt=True, survey_type="dipole-dipole"):
     survey_dc.drape_electrodes_on_topography(mesh, actind, option="top")
 
     # Build conductivity and chargeability model
-    blk_inds_c = utils.model_builder.getIndicesSphere(
+    blk_inds_c = utils.model_builder.get_indices_sphere(
         np.r_[60.0, -25.0], 12.5, mesh.gridCC
     )
-    blk_inds_r = utils.model_builder.getIndicesSphere(
+    blk_inds_r = utils.model_builder.get_indices_sphere(
         np.r_[140.0, -25.0], 12.5, mesh.gridCC
     )
-    blk_inds_charg = utils.model_builder.getIndicesSphere(
+    blk_inds_charg = utils.model_builder.get_indices_sphere(
         np.r_[100.0, -25], 12.5, mesh.gridCC
     )
     sigma = np.ones(mesh.nC) * 1.0 / 100.0

--- a/examples/_archived/plot_inv_dcip_dipoledipole_2_5Dinversion.py
+++ b/examples/_archived/plot_inv_dcip_dipoledipole_2_5Dinversion.py
@@ -66,10 +66,10 @@ def run(plotIt=True, survey_type="dipole-dipole"):
     survey.drape_electrodes_on_topography(mesh, actind, option="top")
 
     # Build a conductivity model
-    blk_inds_c = utils.model_builder.getIndicesSphere(
+    blk_inds_c = utils.model_builder.get_indices_sphere(
         np.r_[60.0, -25.0], 12.5, mesh.gridCC
     )
-    blk_inds_r = utils.model_builder.getIndicesSphere(
+    blk_inds_r = utils.model_builder.get_indices_sphere(
         np.r_[140.0, -25.0], 12.5, mesh.gridCC
     )
     sigma = np.ones(mesh.nC) * 1.0 / 100.0

--- a/examples/_archived/plot_inv_dcip_dipoledipole_2_5Dinversion_irls.py
+++ b/examples/_archived/plot_inv_dcip_dipoledipole_2_5Dinversion_irls.py
@@ -74,10 +74,10 @@ def run(plotIt=True, survey_type="dipole-dipole", p=0.0, qx=2.0, qz=2.0):
     survey.drape_electrodes_on_topography(mesh, actind, option="top")
 
     # Build a conductivity model
-    blk_inds_c = utils.model_builder.getIndicesSphere(
+    blk_inds_c = utils.model_builder.get_indices_sphere(
         np.r_[60.0, -25.0], 12.5, mesh.gridCC
     )
-    blk_inds_r = utils.model_builder.getIndicesSphere(
+    blk_inds_r = utils.model_builder.get_indices_sphere(
         np.r_[140.0, -25.0], 12.5, mesh.gridCC
     )
     sigma = np.ones(mesh.nC) * 1.0 / 100.0

--- a/tests/dask/test_mag_MVI_Octree.py
+++ b/tests/dask/test_mag_MVI_Octree.py
@@ -71,7 +71,7 @@ class MVIProblemTest(unittest.TestCase):
         M_xyz = utils.mat_utils.dip_azimuth2cartesian(M[0], M[1])
 
         # Get the indicies of the magnetized block
-        ind = utils.model_builder.getIndicesBlock(
+        ind = utils.model_builder.get_indices_block(
             np.r_[-20, -20, -10],
             np.r_[20, 20, 25],
             mesh.gridCC,

--- a/tests/dask/test_mag_inversion_linear_Octree.py
+++ b/tests/dask/test_mag_inversion_linear_Octree.py
@@ -83,7 +83,7 @@ class MagInvLinProblemTest(unittest.TestCase):
 
         # We can now create a susceptibility model and generate data
         # Lets start with a simple block in half-space
-        self.model = utils.model_builder.addBlock(
+        self.model = utils.model_builder.add_block(
             self.mesh.gridCC,
             np.zeros(self.mesh.nC),
             np.r_[-20, -20, -15],

--- a/tests/dask/test_mag_nonLinear_Amplitude.py
+++ b/tests/dask/test_mag_nonLinear_Amplitude.py
@@ -76,7 +76,7 @@ class AmpProblemTest(unittest.TestCase):
         )
 
         # Get the indicies of the magnetized block
-        ind = utils.model_builder.getIndicesBlock(
+        ind = utils.model_builder.get_indices_block(
             np.r_[-20, -20, -10],
             np.r_[20, 20, 25],
             mesh.gridCC,

--- a/tests/em/static/test_DC_2D_analytic.py
+++ b/tests/em/static/test_DC_2D_analytic.py
@@ -324,14 +324,14 @@ class DCProblemAnalyticTests_DPField(unittest.TestCase):
         # determine comparison locations
         ROI_large_BNW = np.array([-200, -100])
         ROI_large_TSE = np.array([200, 0])
-        ROI_largeInds = utils.model_builder.getIndicesBlock(
+        ROI_largeInds = utils.model_builder.get_indices_block(
             ROI_large_BNW, ROI_large_TSE, mesh.gridN
         )[0]
         # print(ROI_largeInds.shape)
 
         ROI_small_BNW = np.array([-50, -25])
         ROI_small_TSE = np.array([50, 0])
-        ROI_smallInds = utils.model_builder.getIndicesBlock(
+        ROI_smallInds = utils.model_builder.get_indices_block(
             ROI_small_BNW, ROI_small_TSE, mesh.gridN
         )[0]
         # print(ROI_smallInds.shape)

--- a/tests/em/static/test_DC_FieldsDipoleFullspace.py
+++ b/tests/em/static/test_DC_FieldsDipoleFullspace.py
@@ -76,14 +76,14 @@ class DC_CC_DipoleFullspaceTests(unittest.TestCase):
 
         ROI_large_BNW = np.array([-75, 75, -75])
         ROI_large_TSE = np.array([75, -75, 75])
-        ROI_largeInds = utils.model_builder.getIndicesBlock(
+        ROI_largeInds = utils.model_builder.get_indices_block(
             ROI_large_BNW, ROI_large_TSE, faceGrid
         )[0]
         # print(ROI_largeInds.shape)
 
         ROI_small_BNW = np.array([-4, 4, -4])
         ROI_small_TSE = np.array([4, -4, 4])
-        ROI_smallInds = utils.model_builder.getIndicesBlock(
+        ROI_smallInds = utils.model_builder.get_indices_block(
             ROI_small_BNW, ROI_small_TSE, faceGrid
         )[0]
         # print(ROI_smallInds.shape)
@@ -249,14 +249,14 @@ class DC_N_DipoleFullspaceTests(unittest.TestCase):
 
         ROI_large_BNW = np.array([-75, 75, -75])
         ROI_large_TSE = np.array([75, -75, 75])
-        ROI_largeInds = utils.model_builder.getIndicesBlock(
+        ROI_largeInds = utils.model_builder.get_indices_block(
             ROI_large_BNW, ROI_large_TSE, edgeGrid
         )[0]
         # print(ROI_largeInds.shape)
 
         ROI_small_BNW = np.array([-4, 4, -4])
         ROI_small_TSE = np.array([4, -4, 4])
-        ROI_smallInds = utils.model_builder.getIndicesBlock(
+        ROI_smallInds = utils.model_builder.get_indices_block(
             ROI_small_BNW, ROI_small_TSE, edgeGrid
         )[0]
         # print(ROI_smallInds.shape)

--- a/tests/em/static/test_DC_FieldsMultipoleFullspace.py
+++ b/tests/em/static/test_DC_FieldsMultipoleFullspace.py
@@ -104,14 +104,14 @@ class DC_CC_MultipoleFullspaceTests(unittest.TestCase):
 
         ROI_large_BNW = np.array([-75, 75, -75])
         ROI_large_TSE = np.array([75, -75, 75])
-        ROI_largeInds = utils.model_builder.getIndicesBlock(
+        ROI_largeInds = utils.model_builder.get_indices_block(
             ROI_large_BNW, ROI_large_TSE, faceGrid
         )[0]
         # print(ROI_largeInds.shape)
 
         ROI_small_BNW = np.array([-4, 4, -4])
         ROI_small_TSE = np.array([4, -4, 4])
-        ROI_smallInds = utils.model_builder.getIndicesBlock(
+        ROI_smallInds = utils.model_builder.get_indices_block(
             ROI_small_BNW, ROI_small_TSE, faceGrid
         )[0]
         # print(ROI_smallInds.shape)
@@ -278,14 +278,14 @@ class DC_N_MultipoleFullspaceTests(unittest.TestCase):
 
         ROI_large_BNW = np.array([-75, 75, -75])
         ROI_large_TSE = np.array([75, -75, 75])
-        ROI_largeInds = utils.model_builder.getIndicesBlock(
+        ROI_largeInds = utils.model_builder.get_indices_block(
             ROI_large_BNW, ROI_large_TSE, edgeGrid
         )[0]
         # print(ROI_largeInds.shape)
 
         ROI_small_BNW = np.array([-4, 4, -4])
         ROI_small_TSE = np.array([4, -4, 4])
-        ROI_smallInds = utils.model_builder.getIndicesBlock(
+        ROI_smallInds = utils.model_builder.get_indices_block(
             ROI_small_BNW, ROI_small_TSE, edgeGrid
         )[0]
         # print(ROI_smallInds.shape)

--- a/tests/em/static/test_IP_2D_fwd.py
+++ b/tests/em/static/test_IP_2D_fwd.py
@@ -39,7 +39,7 @@ class IPProblemAnalyticTests(unittest.TestCase):
         surveyDC = dc.Survey([src0, src1])
 
         sigmaInf = np.ones(mesh.nC) * 1.0
-        blkind = utils.model_builder.getIndicesSphere(np.r_[0, -150], 40, mesh.gridCC)
+        blkind = utils.model_builder.get_indices_sphere(np.r_[0, -150], 40, mesh.gridCC)
 
         eta = np.zeros(mesh.nC)
         eta[blkind] = 0.1
@@ -148,7 +148,7 @@ class ApparentChargeability2DTest(unittest.TestCase):
         survey_ip = ip.Survey([src0_ip, src1_ip])
 
         sigmaInf = np.ones(mesh.nC) * 1.0
-        blkind = utils.model_builder.getIndicesSphere(np.r_[0, -150], 40, mesh.gridCC)
+        blkind = utils.model_builder.get_indices_sphere(np.r_[0, -150], 40, mesh.gridCC)
 
         eta = np.zeros(mesh.nC)
         eta[blkind] = 0.05

--- a/tests/em/static/test_IP_fwd.py
+++ b/tests/em/static/test_IP_fwd.py
@@ -34,7 +34,7 @@ class IPProblemAnalyticTests(unittest.TestCase):
         N = utils.ndgrid(x + 12.5, y, np.r_[0.0])
         radius = 50.0
         xc = np.r_[0.0, 0.0, -100]
-        blkind = utils.model_builder.getIndicesSphere(xc, radius, mesh.gridCC)
+        blkind = utils.model_builder.get_indices_sphere(xc, radius, mesh.gridCC)
         sigmaInf = np.ones(mesh.nC) * 1e-2
         eta = np.zeros(mesh.nC)
         eta[blkind] = 0.1
@@ -131,7 +131,7 @@ class ApparentChargeability3DTest(unittest.TestCase):
         N = utils.ndgrid(x + 12.5, y, np.r_[0.0])
         radius = 50.0
         xc = np.r_[0.0, 0.0, -100]
-        blkind = utils.model_builder.getIndicesSphere(xc, radius, mesh.gridCC)
+        blkind = utils.model_builder.get_indices_sphere(xc, radius, mesh.gridCC)
         sigmaInf = np.ones(mesh.nC) * 1e-2
         eta = np.zeros(mesh.nC)
         eta[blkind] = 0.1

--- a/tests/em/static/test_SIP_2D_jvecjtvecadj.py
+++ b/tests/em/static/test_SIP_2D_jvecjtvecadj.py
@@ -28,10 +28,10 @@ class SIPProblemTestsCC(unittest.TestCase):
         hx = [(cs, 0, -1.3), (cs, 21), (cs, 0, 1.3)]
         hz = [(cs, 0, -1.3), (cs, 20)]
         mesh = discretize.TensorMesh([hx, hz], x0="CN")
-        blkind0 = utils.model_builder.getIndicesSphere(
+        blkind0 = utils.model_builder.get_indices_sphere(
             np.r_[-100.0, -200.0], 75.0, mesh.gridCC
         )
-        blkind1 = utils.model_builder.getIndicesSphere(
+        blkind1 = utils.model_builder.get_indices_sphere(
             np.r_[100.0, -200.0], 75.0, mesh.gridCC
         )
 
@@ -120,10 +120,10 @@ class SIPProblemTestsN(unittest.TestCase):
         hx = [(cs, 0, -1.3), (cs, 21), (cs, 0, 1.3)]
         hz = [(cs, 0, -1.3), (cs, 20)]
         mesh = discretize.TensorMesh([hx, hz], x0="CN")
-        blkind0 = utils.model_builder.getIndicesSphere(
+        blkind0 = utils.model_builder.get_indices_sphere(
             np.r_[-100.0, -200.0], 75.0, mesh.gridCC
         )
-        blkind1 = utils.model_builder.getIndicesSphere(
+        blkind1 = utils.model_builder.get_indices_sphere(
             np.r_[100.0, -200.0], 75.0, mesh.gridCC
         )
 
@@ -211,10 +211,10 @@ class SIPProblemTestsN_air(unittest.TestCase):
         hx = [(cs, 0, -1.3), (cs, 21), (cs, 0, 1.3)]
         hz = [(cs, 0, -1.3), (cs, 20)]
         mesh = discretize.TensorMesh([hx, hz], x0="CN")
-        blkind0 = utils.model_builder.getIndicesSphere(
+        blkind0 = utils.model_builder.get_indices_sphere(
             np.r_[-100.0, -200.0], 75.0, mesh.gridCC
         )
-        blkind1 = utils.model_builder.getIndicesSphere(
+        blkind1 = utils.model_builder.get_indices_sphere(
             np.r_[100.0, -200.0], 75.0, mesh.gridCC
         )
 

--- a/tests/em/static/test_SIP_jvecjtvecadj.py
+++ b/tests/em/static/test_SIP_jvecjtvecadj.py
@@ -28,10 +28,10 @@ class SIPProblemTestsCC(unittest.TestCase):
         hy = [(cs, 0, -1.3), (cs, 21), (cs, 0, 1.3)]
         hz = [(cs, 0, -1.3), (cs, 20)]
         mesh = discretize.TensorMesh([hx, hy, hz], x0="CCN")
-        blkind0 = utils.model_builder.getIndicesSphere(
+        blkind0 = utils.model_builder.get_indices_sphere(
             np.r_[-100.0, -100.0, -200.0], 75.0, mesh.gridCC
         )
-        blkind1 = utils.model_builder.getIndicesSphere(
+        blkind1 = utils.model_builder.get_indices_sphere(
             np.r_[100.0, 100.0, -200.0], 75.0, mesh.gridCC
         )
         sigma = np.ones(mesh.nC) * 1e-2
@@ -127,10 +127,10 @@ class SIPProblemTestsN(unittest.TestCase):
         hy = [(cs, 0, -1.3), (cs, 21), (cs, 0, 1.3)]
         hz = [(cs, 0, -1.3), (cs, 20)]
         mesh = discretize.TensorMesh([hx, hy, hz], x0="CCN")
-        blkind0 = utils.model_builder.getIndicesSphere(
+        blkind0 = utils.model_builder.get_indices_sphere(
             np.r_[-100.0, -100.0, -200.0], 75.0, mesh.gridCC
         )
-        blkind1 = utils.model_builder.getIndicesSphere(
+        blkind1 = utils.model_builder.get_indices_sphere(
             np.r_[100.0, 100.0, -200.0], 75.0, mesh.gridCC
         )
         sigma = np.ones(mesh.nC) * 1e-2
@@ -224,10 +224,10 @@ class SIPProblemTestsN_air(unittest.TestCase):
         hy = [(cs, 0, -1.3), (cs, 21), (cs, 0, 1.3)]
         hz = [(cs, 0, -1.3), (cs, 20), (cs, 0, 1.3)]
         mesh = discretize.TensorMesh([hx, hy, hz], x0="CCC")
-        blkind0 = utils.model_builder.getIndicesSphere(
+        blkind0 = utils.model_builder.get_indices_sphere(
             np.r_[-100.0, -100.0, -200.0], 75.0, mesh.gridCC
         )
-        blkind1 = utils.model_builder.getIndicesSphere(
+        blkind1 = utils.model_builder.get_indices_sphere(
             np.r_[100.0, 100.0, -200.0], 75.0, mesh.gridCC
         )
         sigma = np.ones(mesh.nC) * 1e-2

--- a/tests/pf/test_forward_PFproblem.py
+++ b/tests/pf/test_forward_PFproblem.py
@@ -1,7 +1,7 @@
 import unittest
 import discretize
 from SimPEG import utils, maps
-from SimPEG.utils.model_builder import getIndicesSphere
+from SimPEG.utils.model_builder import get_indices_sphere
 from SimPEG.potential_fields import magnetics as mag
 import numpy as np
 from pymatsolver import Pardiso
@@ -28,7 +28,7 @@ class MagFwdProblemTests(unittest.TestCase):
 
         self.rad = 100
         self.sphere_center = [0.0, 0.0, 0.0]
-        sph_ind = getIndicesSphere(self.sphere_center, self.rad, M.gridCC)
+        sph_ind = get_indices_sphere(self.sphere_center, self.rad, M.gridCC)
         chi[sph_ind] = self.chiblk
 
         xr = np.linspace(-300, 300, 41)

--- a/tests/pf/test_mag_MVI_Octree.py
+++ b/tests/pf/test_mag_MVI_Octree.py
@@ -70,7 +70,7 @@ class MVIProblemTest(unittest.TestCase):
         M_xyz = utils.mat_utils.dip_azimuth2cartesian(M[0], M[1])
 
         # Get the indicies of the magnetized block
-        ind = utils.model_builder.getIndicesBlock(
+        ind = utils.model_builder.get_indices_block(
             np.r_[-20, -20, -10],
             np.r_[20, 20, 25],
             mesh.gridCC,

--- a/tests/pf/test_mag_inversion_linear_Octree.py
+++ b/tests/pf/test_mag_inversion_linear_Octree.py
@@ -81,7 +81,7 @@ class MagInvLinProblemTest(unittest.TestCase):
 
         # We can now create a susceptibility model and generate data
         # Lets start with a simple block in half-space
-        self.model = utils.model_builder.addBlock(
+        self.model = utils.model_builder.add_block(
             self.mesh.gridCC,
             np.zeros(self.mesh.nC),
             np.r_[-20, -20, -15],

--- a/tests/pf/test_mag_nonLinear_Amplitude.py
+++ b/tests/pf/test_mag_nonLinear_Amplitude.py
@@ -75,7 +75,7 @@ class AmpProblemTest(unittest.TestCase):
         )
 
         # Get the indicies of the magnetized block
-        ind = utils.model_builder.getIndicesBlock(
+        ind = utils.model_builder.get_indices_block(
             np.r_[-20, -20, -10],
             np.r_[20, 20, 25],
             mesh.gridCC,

--- a/tests/pf/test_mag_vector_amplitude.py
+++ b/tests/pf/test_mag_vector_amplitude.py
@@ -70,7 +70,7 @@ class MVIProblemTest(unittest.TestCase):
         M_xyz = utils.mat_utils.dip_azimuth2cartesian(M[0], M[1])
 
         # Get the indicies of the magnetized block
-        ind = utils.model_builder.getIndicesBlock(
+        ind = utils.model_builder.get_indices_block(
             np.r_[-20, -20, -10],
             np.r_[20, 20, 25],
             mesh.gridCC,

--- a/tests/pf/test_magnetics_analytics.py
+++ b/tests/pf/test_magnetics_analytics.py
@@ -3,7 +3,7 @@ import unittest
 # from SimPEG import Mesh, PF
 import discretize
 from SimPEG.potential_fields import magnetics as mag
-from SimPEG.utils.model_builder import getIndicesSphere
+from SimPEG.utils.model_builder import get_indices_sphere
 import numpy as np
 from scipy.constants import mu_0
 
@@ -21,7 +21,7 @@ class TestBoundaryConditionAnalytics(unittest.TestCase):
         chibkg = 0.0
         chiblk = 0.01
         chi = np.ones(M3.nC) * chibkg
-        sph_ind = getIndicesSphere([0, 0, 0], 100, M3.gridCC)
+        sph_ind = get_indices_sphere([0, 0, 0], 100, M3.gridCC)
         chi[sph_ind] = chiblk
         Bbc, const = mag.analytics.CongruousMagBC(M3, np.array([1.0, 0.0, 0.0]), chi)
 

--- a/tests/pf/test_pf_quadtree_inversion_linear.py
+++ b/tests/pf/test_pf_quadtree_inversion_linear.py
@@ -316,7 +316,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
 
         # Create a density model and generate data,
         # with a block in a half space
-        self.model = utils.model_builder.addBlock(
+        self.model = utils.model_builder.add_block(
             self.mesh.cell_centers,
             np.zeros(self.mesh.nC),
             np.r_[-20, -20],
@@ -324,7 +324,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
             1.0,
         )
 
-        self.active_cells = utils.model_builder.addBlock(
+        self.active_cells = utils.model_builder.add_block(
             self.mesh.cell_centers,
             np.zeros(self.mesh.nC, dtype=bool),
             np.r_[-40, -40],

--- a/tests/pf/test_sensitivity_PFproblem.py
+++ b/tests/pf/test_sensitivity_PFproblem.py
@@ -8,7 +8,7 @@
 # #import simpeg.PF as PF
 # from SimPEG import maps, utils
 # from SimPEG.potential_fields import magnetics as mag
-# from SimPEG.utils.model_builder import getIndicesSphere
+# from SimPEG.utils.model_builder import get_indices_sphere
 # from scipy.constants import mu_0
 #
 #
@@ -30,7 +30,7 @@
 #         H0 = (Btot, Inc, Dec)
 #
 #         b0 = mag.analytics.IDTtoxyz(-Inc, Dec, Btot)
-#         sph_ind = getIndicesSphere([0., 0., 0.], 100, M.gridCC)
+#         sph_ind = get_indices_sphere([0., 0., 0.], 100, M.gridCC)
 #         chi[sph_ind] = chiblk
 #
 #         xr = np.linspace(-300, 300, 41)

--- a/tests/seis/test_tomo.py
+++ b/tests/seis/test_tomo.py
@@ -30,7 +30,7 @@ class TomoTest(unittest.TestCase):
         self.survey = survey
 
     def test_deriv(self):
-        s = utils.mkvc(utils.model_builder.randomModel(self.M.vnC)) + 1.0
+        s = utils.mkvc(utils.model_builder.create_random_model(self.M.vnC)) + 1.0
 
         def fun(x):
             return self.problem.dpred(x), lambda x: self.problem.Jvec(s, x)

--- a/tutorials/01-models_mapping/plot_1_tensor_models.py
+++ b/tutorials/01-models_mapping/plot_1_tensor_models.py
@@ -210,7 +210,9 @@ model_map = maps.InjectActiveCells(mesh, ind_active, air_value)
 model = background_value * np.ones(ind_active.sum())
 
 # Add a sphere
-ind_sphere = model_builder.getIndicesSphere(np.r_[-25.0, 0.0, -15.0], 20.0, mesh.gridCC)
+ind_sphere = model_builder.get_indices_sphere(
+    np.r_[-25.0, 0.0, -15.0], 20.0, mesh.gridCC
+)
 ind_sphere = ind_sphere[ind_active]  # So it's same size and order as model
 model[ind_sphere] = sphere_value
 
@@ -313,7 +315,9 @@ N = int(ind_active.sum())
 model = np.kron(np.ones((N, 1)), np.c_[background_sigma, background_myu])
 
 # Add a conductive and permeable sphere
-ind_sphere = model_builder.getIndicesSphere(np.r_[-25.0, 0.0, -15.0], 20.0, mesh.gridCC)
+ind_sphere = model_builder.get_indices_sphere(
+    np.r_[-25.0, 0.0, -15.0], 20.0, mesh.gridCC
+)
 ind_sphere = ind_sphere[ind_active]  # So same size and order as model
 model[ind_sphere, :] = np.c_[sphere_sigma, sphere_mu]
 

--- a/tutorials/01-models_mapping/plot_3_tree_models.py
+++ b/tutorials/01-models_mapping/plot_3_tree_models.py
@@ -221,7 +221,9 @@ model_map = maps.InjectActiveCells(mesh, ind_active, air_value)
 model = background_value * np.ones(ind_active.sum())
 
 # Add a sphere
-ind_sphere = model_builder.getIndicesSphere(np.r_[-25.0, 0.0, -15.0], 20.0, mesh.gridCC)
+ind_sphere = model_builder.get_indices_sphere(
+    np.r_[-25.0, 0.0, -15.0], 20.0, mesh.gridCC
+)
 ind_sphere = ind_sphere[ind_active]  # So same size and order as model
 model[ind_sphere] = sphere_value
 
@@ -334,7 +336,9 @@ N = int(ind_active.sum())
 model = np.kron(np.ones((N, 1)), np.c_[background_sigma_value, background_mu_value])
 
 # Add a conductive and permeable sphere
-ind_sphere = model_builder.getIndicesSphere(np.r_[-20.0, 0.0, -15.0], 20.0, mesh.gridCC)
+ind_sphere = model_builder.get_indices_sphere(
+    np.r_[-20.0, 0.0, -15.0], 20.0, mesh.gridCC
+)
 ind_sphere = ind_sphere[ind_active]  # So same size and order as model
 model[ind_sphere, :] = np.c_[sphere_sigma_value, sphere_mu_value]
 

--- a/tutorials/03-gravity/plot_1a_gravity_anomaly.py
+++ b/tutorials/03-gravity/plot_1a_gravity_anomaly.py
@@ -138,7 +138,9 @@ ind_block = (
 model[ind_block] = block_density
 
 # You can also use SimPEG utilities to add structures to the model more concisely
-ind_sphere = model_builder.getIndicesSphere(np.r_[35.0, 0.0, -40.0], 15.0, mesh.gridCC)
+ind_sphere = model_builder.get_indices_sphere(
+    np.r_[35.0, 0.0, -40.0], 15.0, mesh.gridCC
+)
 ind_sphere = ind_sphere[ind_active]
 model[ind_sphere] = sphere_density
 

--- a/tutorials/03-gravity/plot_1b_gravity_gradiometry.py
+++ b/tutorials/03-gravity/plot_1b_gravity_gradiometry.py
@@ -160,7 +160,9 @@ ind_block = (
 model[ind_block] = block_density
 
 # You can also use SimPEG utilities to add structures to the model more concisely
-ind_sphere = model_builder.getIndicesSphere(np.r_[35.0, 0.0, -40.0], 15.0, mesh.gridCC)
+ind_sphere = model_builder.get_indices_sphere(
+    np.r_[35.0, 0.0, -40.0], 15.0, mesh.gridCC
+)
 ind_sphere = ind_sphere[ind_active]
 model[ind_sphere] = sphere_density
 

--- a/tutorials/03-gravity/plot_inv_1a_gravity_anomaly.py
+++ b/tutorials/03-gravity/plot_inv_1a_gravity_anomaly.py
@@ -321,7 +321,9 @@ ind_block = (
 true_model[ind_block] = block_density
 
 # You can also use SimPEG utilities to add structures to the model more concisely
-ind_sphere = model_builder.getIndicesSphere(np.r_[35.0, 0.0, -40.0], 15.0, mesh.gridCC)
+ind_sphere = model_builder.get_indices_sphere(
+    np.r_[35.0, 0.0, -40.0], 15.0, mesh.gridCC
+)
 ind_sphere = ind_sphere[ind_active]
 true_model[ind_sphere] = sphere_density
 

--- a/tutorials/03-gravity/plot_inv_1b_gravity_anomaly_irls.py
+++ b/tutorials/03-gravity/plot_inv_1b_gravity_anomaly_irls.py
@@ -326,7 +326,9 @@ ind_block = (
 true_model[ind_block] = block_density
 
 # You can also use SimPEG utilities to add structures to the model more concisely
-ind_sphere = model_builder.getIndicesSphere(np.r_[35.0, 0.0, -40.0], 15.0, mesh.gridCC)
+ind_sphere = model_builder.get_indices_sphere(
+    np.r_[35.0, 0.0, -40.0], 15.0, mesh.gridCC
+)
 ind_sphere = ind_sphere[ind_active]
 true_model[ind_sphere] = sphere_density
 

--- a/tutorials/04-magnetics/plot_2a_magnetics_induced.py
+++ b/tutorials/04-magnetics/plot_2a_magnetics_induced.py
@@ -128,7 +128,7 @@ model_map = maps.IdentityMap(nP=nC)  # model is a vlue for each active cell
 
 # Define model. Models in SimPEG are vector arrays
 model = background_susceptibility * np.ones(ind_active.sum())
-ind_sphere = model_builder.getIndicesSphere(
+ind_sphere = model_builder.get_indices_sphere(
     np.r_[0.0, 0.0, -45.0], 15.0, mesh.cell_centers
 )
 ind_sphere = ind_sphere[ind_active]

--- a/tutorials/04-magnetics/plot_2b_magnetics_mvi.py
+++ b/tutorials/04-magnetics/plot_2b_magnetics_mvi.py
@@ -161,7 +161,7 @@ model_map = maps.IdentityMap(nP=3 * nC)  # model has 3 parameters for each cell
 
 # Define susceptibility for each cell
 susceptibility_model = background_susceptibility * np.ones(ind_active.sum())
-ind_sphere = model_builder.getIndicesSphere(np.r_[0.0, 0.0, -45.0], 15.0, mesh.gridCC)
+ind_sphere = model_builder.get_indices_sphere(np.r_[0.0, 0.0, -45.0], 15.0, mesh.gridCC)
 ind_sphere = ind_sphere[ind_active]
 susceptibility_model[ind_sphere] = sphere_susceptibility
 

--- a/tutorials/04-magnetics/plot_inv_2a_magnetics_induced.py
+++ b/tutorials/04-magnetics/plot_inv_2a_magnetics_induced.py
@@ -345,7 +345,7 @@ background_susceptibility = 0.0001
 sphere_susceptibility = 0.01
 
 true_model = background_susceptibility * np.ones(nC)
-ind_sphere = model_builder.getIndicesSphere(
+ind_sphere = model_builder.get_indices_sphere(
     np.r_[0.0, 0.0, -45.0], 15.0, mesh.cell_centers
 )
 ind_sphere = ind_sphere[active_cells]

--- a/tutorials/05-dcr/plot_fwd_2_dcr2d.py
+++ b/tutorials/05-dcr/plot_fwd_2_dcr2d.py
@@ -183,11 +183,13 @@ conductivity_map = maps.InjectActiveCells(mesh, ind_active, air_conductivity)
 # Define model
 conductivity_model = background_conductivity * np.ones(nC)
 
-ind_conductor = model_builder.getIndicesSphere(np.r_[-120.0, -160.0], 60.0, mesh.gridCC)
+ind_conductor = model_builder.get_indices_sphere(
+    np.r_[-120.0, -160.0], 60.0, mesh.gridCC
+)
 ind_conductor = ind_conductor[ind_active]
 conductivity_model[ind_conductor] = conductor_conductivity
 
-ind_resistor = model_builder.getIndicesSphere(np.r_[120.0, -100.0], 60.0, mesh.gridCC)
+ind_resistor = model_builder.get_indices_sphere(np.r_[120.0, -100.0], 60.0, mesh.gridCC)
 ind_resistor = ind_resistor[ind_active]
 conductivity_model[ind_resistor] = resistor_conductivity
 

--- a/tutorials/05-dcr/plot_fwd_3_dcr3d.py
+++ b/tutorials/05-dcr/plot_fwd_3_dcr3d.py
@@ -190,12 +190,12 @@ conductivity_map = maps.InjectActiveCells(mesh, ind_active, air_value)
 # Define model
 conductivity_model = background_value * np.ones(nC)
 
-ind_conductor = model_builder.getIndicesSphere(
+ind_conductor = model_builder.get_indices_sphere(
     np.r_[-350.0, 0.0, -300.0], 160.0, mesh.cell_centers[ind_active, :]
 )
 conductivity_model[ind_conductor] = conductor_value
 
-ind_resistor = model_builder.getIndicesSphere(
+ind_resistor = model_builder.get_indices_sphere(
     np.r_[350.0, 0.0, -300.0], 160.0, mesh.cell_centers[ind_active, :]
 )
 conductivity_model[ind_resistor] = resistor_value

--- a/tutorials/05-dcr/plot_inv_2_dcr2d.py
+++ b/tutorials/05-dcr/plot_inv_2_dcr2d.py
@@ -369,10 +369,12 @@ true_resistor_conductivity = 1e-3
 
 true_conductivity_model = true_background_conductivity * np.ones(len(mesh))
 
-ind_conductor = model_builder.getIndicesSphere(np.r_[-120.0, -180.0], 60.0, mesh.gridCC)
+ind_conductor = model_builder.get_indices_sphere(
+    np.r_[-120.0, -180.0], 60.0, mesh.gridCC
+)
 true_conductivity_model[ind_conductor] = true_conductor_conductivity
 
-ind_resistor = model_builder.getIndicesSphere(np.r_[120.0, -180.0], 60.0, mesh.gridCC)
+ind_resistor = model_builder.get_indices_sphere(np.r_[120.0, -180.0], 60.0, mesh.gridCC)
 true_conductivity_model[ind_resistor] = true_resistor_conductivity
 
 true_conductivity_model[~ind_active] = np.NaN

--- a/tutorials/05-dcr/plot_inv_2_dcr2d_irls.py
+++ b/tutorials/05-dcr/plot_inv_2_dcr2d_irls.py
@@ -385,10 +385,12 @@ true_resistor_conductivity = 1e-3
 
 true_conductivity_model = true_background_conductivity * np.ones(len(mesh))
 
-ind_conductor = model_builder.getIndicesSphere(np.r_[-120.0, -180.0], 60.0, mesh.gridCC)
+ind_conductor = model_builder.get_indices_sphere(
+    np.r_[-120.0, -180.0], 60.0, mesh.gridCC
+)
 true_conductivity_model[ind_conductor] = true_conductor_conductivity
 
-ind_resistor = model_builder.getIndicesSphere(np.r_[120.0, -180.0], 60.0, mesh.gridCC)
+ind_resistor = model_builder.get_indices_sphere(np.r_[120.0, -180.0], 60.0, mesh.gridCC)
 true_conductivity_model[ind_resistor] = true_resistor_conductivity
 
 true_conductivity_model[~ind_active] = np.NaN

--- a/tutorials/05-dcr/plot_inv_3_dcr3d.py
+++ b/tutorials/05-dcr/plot_inv_3_dcr3d.py
@@ -388,12 +388,12 @@ resistor_value = 1e-3
 # Define model
 true_conductivity_model = background_value * np.ones(nC)
 
-ind_conductor = model_builder.getIndicesSphere(
+ind_conductor = model_builder.get_indices_sphere(
     np.r_[-350.0, 0.0, -300.0], 160.0, mesh.cell_centers[ind_active, :]
 )
 true_conductivity_model[ind_conductor] = conductor_value
 
-ind_resistor = model_builder.getIndicesSphere(
+ind_resistor = model_builder.get_indices_sphere(
     np.r_[350.0, 0.0, -300.0], 160.0, mesh.cell_centers[ind_active, :]
 )
 true_conductivity_model[ind_resistor] = resistor_value

--- a/tutorials/06-ip/plot_fwd_2_dcip2d.py
+++ b/tutorials/06-ip/plot_fwd_2_dcip2d.py
@@ -195,11 +195,13 @@ conductivity_map = maps.InjectActiveCells(mesh, ind_active, air_conductivity)
 # Define model
 conductivity_model = background_conductivity * np.ones(nC)
 
-ind_conductor = model_builder.getIndicesSphere(np.r_[-120.0, -160.0], 60.0, mesh.gridCC)
+ind_conductor = model_builder.get_indices_sphere(
+    np.r_[-120.0, -160.0], 60.0, mesh.gridCC
+)
 ind_conductor = ind_conductor[ind_active]
 conductivity_model[ind_conductor] = conductor_conductivity
 
-ind_resistor = model_builder.getIndicesSphere(np.r_[120.0, -100.0], 60.0, mesh.gridCC)
+ind_resistor = model_builder.get_indices_sphere(np.r_[120.0, -100.0], 60.0, mesh.gridCC)
 ind_resistor = ind_resistor[ind_active]
 conductivity_model[ind_resistor] = resistor_conductivity
 
@@ -353,7 +355,7 @@ chargeability_map = maps.InjectActiveCells(mesh, ind_active, air_chargeability)
 # Define chargeability model
 chargeability_model = background_chargeability * np.ones(nC)
 
-ind_chargeable = model_builder.getIndicesSphere(
+ind_chargeable = model_builder.get_indices_sphere(
     np.r_[-120.0, -160.0], 60.0, mesh.gridCC
 )
 ind_chargeable = ind_chargeable[ind_active]

--- a/tutorials/06-ip/plot_fwd_3_dcip3d.py
+++ b/tutorials/06-ip/plot_fwd_3_dcip3d.py
@@ -196,12 +196,12 @@ conductivity_map = maps.InjectActiveCells(mesh, ind_active, air_value)
 # Define model
 conductivity_model = background_value * np.ones(nC)
 
-ind_conductor = model_builder.getIndicesSphere(
+ind_conductor = model_builder.get_indices_sphere(
     np.r_[-350.0, 0.0, -300.0], 160.0, mesh.cell_centers[ind_active, :]
 )
 conductivity_model[ind_conductor] = conductor_value
 
-ind_resistor = model_builder.getIndicesSphere(
+ind_resistor = model_builder.get_indices_sphere(
     np.r_[350.0, 0.0, -300.0], 160.0, mesh.cell_centers[ind_active, :]
 )
 conductivity_model[ind_resistor] = resistor_value
@@ -388,7 +388,7 @@ chargeability_map = maps.InjectActiveCells(mesh, ind_active, air_value)
 # Define model
 chargeability_model = background_value * np.ones(nC)
 
-ind_chargeable = model_builder.getIndicesSphere(
+ind_chargeable = model_builder.get_indices_sphere(
     np.r_[-350.0, 0.0, -300.0], 160.0, mesh.cell_centers[ind_active, :]
 )
 

--- a/tutorials/06-ip/plot_inv_2_dcip2d.py
+++ b/tutorials/06-ip/plot_inv_2_dcip2d.py
@@ -393,10 +393,12 @@ true_resistor_conductivity = 1e-3
 
 true_conductivity_model = true_background_conductivity * np.ones(len(mesh))
 
-ind_conductor = model_builder.getIndicesSphere(np.r_[-120.0, -180.0], 60.0, mesh.gridCC)
+ind_conductor = model_builder.get_indices_sphere(
+    np.r_[-120.0, -180.0], 60.0, mesh.gridCC
+)
 true_conductivity_model[ind_conductor] = true_conductor_conductivity
 
-ind_resistor = model_builder.getIndicesSphere(np.r_[120.0, -180.0], 60.0, mesh.gridCC)
+ind_resistor = model_builder.get_indices_sphere(np.r_[120.0, -180.0], 60.0, mesh.gridCC)
 true_conductivity_model[ind_resistor] = true_resistor_conductivity
 
 true_conductivity_model[~ind_active] = np.NaN

--- a/tutorials/06-ip/plot_inv_3_dcip3d.py
+++ b/tutorials/06-ip/plot_inv_3_dcip3d.py
@@ -430,12 +430,12 @@ conductor_value = 1e-1
 resistor_value = 1e-3
 true_conductivity_model = background_value * np.ones(nC)
 
-ind_conductor = model_builder.getIndicesSphere(
+ind_conductor = model_builder.get_indices_sphere(
     np.r_[-350.0, 0.0, -300.0], 160.0, mesh.cell_centers[ind_active, :]
 )
 true_conductivity_model[ind_conductor] = conductor_value
 
-ind_resistor = model_builder.getIndicesSphere(
+ind_resistor = model_builder.get_indices_sphere(
     np.r_[350.0, 0.0, -300.0], 160.0, mesh.cell_centers[ind_active, :]
 )
 true_conductivity_model[ind_resistor] = resistor_value
@@ -672,7 +672,7 @@ background_value = 1e-6
 chargeable_value = 1e-1
 
 true_chargeability_model = background_value * np.ones(nC)
-ind_chargeable = model_builder.getIndicesSphere(
+ind_chargeable = model_builder.get_indices_sphere(
     np.r_[-350.0, 0.0, -300.0], 160.0, mesh.cell_centers[ind_active, :]
 )
 true_chargeability_model[ind_chargeable] = chargeable_value

--- a/tutorials/12-seismic/plot_fwd_1_tomography_2D.py
+++ b/tutorials/12-seismic/plot_fwd_1_tomography_2D.py
@@ -94,7 +94,7 @@ block_velocity = 1500.0
 # Define the model. Models in SimPEG are vector arrays.
 model = background_velocity * np.ones(mesh.nC)
 
-ind_block = model_builder.getIndicesBlock(np.r_[-50, 20], np.r_[50, -20], mesh.gridCC)
+ind_block = model_builder.get_indices_block(np.r_[-50, 20], np.r_[50, -20], mesh.gridCC)
 model[ind_block] = block_velocity
 
 # Define a mapping from the model (velocity) to the slowness. If your model


### PR DESCRIPTION
Addresses name change for functions in `utils.model_builder`.
Update tutorials, examples and tests that were using the deprecated functions.

Related to issue #1265 