### PR TITLE
Add `weights_keys` method to `BaseRegularization`

### DIFF
--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -55,7 +55,7 @@ class BaseRegularization(BaseObjectiveFunction):
         mapping: maps.IdentityMap | None = None,
         reference_model: np.ndarray | None = None,
         units: str | None = None,
-        weights: dict | np.ndarray | None = None,
+        weights: dict | None = None,
         **kwargs,
     ):
         if isinstance(mesh, BaseMesh):

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -55,7 +55,7 @@ class BaseRegularization(BaseObjectiveFunction):
         mapping: maps.IdentityMap | None = None,
         reference_model: np.ndarray | None = None,
         units: str | None = None,
-        weights: dict | None = None,
+        weights: dict | np.ndarray | None = None,
         **kwargs,
     ):
         if isinstance(mesh, BaseMesh):
@@ -382,6 +382,13 @@ class BaseRegularization(BaseObjectiveFunction):
             )
             self._weights[key] = values
         self._W = None
+
+    @property
+    def weights_keys(self) -> list[str]:
+        """
+        Return the keys for the existing cell weights
+        """
+        return list(self._weights.keys())
 
     def remove_weights(self, key):
         """Removes the weights for the key provided.

--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -6,7 +6,13 @@ import inspect
 
 import discretize
 from SimPEG import maps, objective_function, regularization, utils
-from SimPEG.regularization import BaseRegularization, WeightedLeastSquares
+from SimPEG.regularization import (
+    BaseRegularization,
+    WeightedLeastSquares,
+    Smallness,
+    SmoothnessFirstOrder,
+    SmoothnessSecondOrder,
+)
 from SimPEG.objective_function import ComboObjectiveFunction
 
 
@@ -655,6 +661,67 @@ class TestParent:
         msg = "Invalid parent of type 'Dummy'."
         with pytest.raises(TypeError, match=msg):
             regularization.parent = invalid_parent
+
+
+class TestWeightsKeys:
+    """
+    Test weights_keys property of regularizations
+    """
+
+    @pytest.fixture
+    def mesh(self):
+        """Sample mesh."""
+        return discretize.TensorMesh([8, 7, 6])
+
+    def test_empty_weights(self, mesh):
+        """
+        Test weights_keys when no weight is defined
+        """
+        reg = BaseRegularization(mesh)
+        assert reg.weights_keys == []
+
+    def test_user_defined_weights_as_dict(self, mesh):
+        """
+        Test weights_keys after user defined weights as dictionary
+        """
+        weights = dict(dummy_weight=np.ones(mesh.n_cells))
+        reg = BaseRegularization(mesh, weights=weights)
+        assert reg.weights_keys == ["dummy_weight"]
+
+    def test_user_defined_weights_as_array(self, mesh):
+        """
+        Test weights_keys after user defined weights as dictionary
+        """
+        weights = np.ones(mesh.n_cells)
+        reg = BaseRegularization(mesh, weights=weights)
+        assert reg.weights_keys == ["user_weights"]
+
+    @pytest.mark.parametrize(
+        "regularization_class", (Smallness, SmoothnessFirstOrder, SmoothnessSecondOrder)
+    )
+    def test_volume_weights(self, mesh, regularization_class):
+        """
+        Test weights_keys has "volume" by default on some regularizations
+        """
+        reg = regularization_class(mesh)
+        assert reg.weights_keys == ["volume"]
+
+    @pytest.mark.parametrize(
+        "regularization_class",
+        (BaseRegularization, Smallness, SmoothnessFirstOrder, SmoothnessSecondOrder),
+    )
+    def test_multiple_weights(self, mesh, regularization_class):
+        """
+        Test weights_keys has "volume" by default on some regularizations
+        """
+        weights = dict(
+            dummy_weight=np.ones(mesh.n_cells), other_weights=np.ones(mesh.n_cells)
+        )
+        reg = regularization_class(mesh, weights=weights)
+        if regularization_class == BaseRegularization:
+            assert reg.weights_keys == ["dummy_weight", "other_weights"]
+        else:
+            assert reg.weights_keys == ["dummy_weight", "other_weights", "volume"]
 
 
 class TestDeprecatedArguments:


### PR DESCRIPTION

#### Summary

Add a new `weights_keys` method to `BaseRegularization` that exposes the keys of the private `_weights` attribute. Add tests for the new feature.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue

Fixes #1318

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
