### PR TITLE
Fix description of source_field in gravity survey

### DIFF
--- a/SimPEG/potential_fields/gravity/survey.py
+++ b/SimPEG/potential_fields/gravity/survey.py
@@ -8,8 +8,8 @@ class Survey(BaseSurvey):
 
     Parameters
     ----------
-    source_field : SimPEG.potential_fields.magnetics.sources.SourceField
-        A source object that defines the Earth's inducing field
+    source_field : SimPEG.potential_fields.gravity.sources.SourceField
+        A source object that defines receivers locations for gravity.
     """
 
     def __init__(self, source_field, **kwargs):


### PR DESCRIPTION
#### Summary

Edits the docstring of `gravity.Survey` to correctly describe the `source_field` argument.


#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
