### PR TITLE
Move `__init__` in `BaseSimulation` to the top of the class

### DIFF
--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -46,6 +46,33 @@ class BaseSimulation(props.HasModel):
     SimPEG.
     """
 
+    def __init__(
+        self,
+        mesh=None,
+        survey=None,
+        solver=None,
+        solver_opts=None,
+        sensitivity_path=None,
+        counter=None,
+        verbose=False,
+        **kwargs,
+    ):
+        self.mesh = mesh
+        self.survey = survey
+        if solver is None:
+            solver = DefaultSolver
+        self.solver = solver
+        if solver_opts is None:
+            solver_opts = {}
+        self.solver_opts = solver_opts
+        if sensitivity_path is None:
+            sensitivity_path = os.path.join(".", "sensitivity")
+        self.sensitivity_path = sensitivity_path
+        self.counter = counter
+        self.verbose = verbose
+
+        super().__init__(**kwargs)
+
     ###########################################################################
     # Properties
 
@@ -162,36 +189,6 @@ class BaseSimulation(props.HasModel):
     @verbose.setter
     def verbose(self, value):
         self._verbose = validate_type("verbose", value, bool)
-
-    ###########################################################################
-    # Instantiation
-
-    def __init__(
-        self,
-        mesh=None,
-        survey=None,
-        solver=None,
-        solver_opts=None,
-        sensitivity_path=None,
-        counter=None,
-        verbose=False,
-        **kwargs,
-    ):
-        self.mesh = mesh
-        self.survey = survey
-        if solver is None:
-            solver = DefaultSolver
-        self.solver = solver
-        if solver_opts is None:
-            solver_opts = {}
-        self.solver_opts = solver_opts
-        if sensitivity_path is None:
-            sensitivity_path = os.path.join(".", "sensitivity")
-        self.sensitivity_path = sensitivity_path
-        self.counter = counter
-        self.verbose = verbose
-
-        super().__init__(**kwargs)
 
     ###########################################################################
     # Methods


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing/pull-requests.html

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary

Move the `__init__`` method in `BaseSimulation` to the top of the class. This just improves readability and shouldn't change the behaviour of the class.


#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
