### PR TITLE
Remove factor of half in data misfits and regularizations

### DIFF
--- a/SimPEG/data_misfit.py
+++ b/SimPEG/data_misfit.py
@@ -19,7 +19,7 @@ class BaseDataMisfit(L2ObjectiveFunction):
         create your own data misfit class.
 
     .. math::
-        \phi_d (\mathbf{m}) = \frac{1}{2} \| \mathbf{W} f(\mathbf{m}) \|_2^2
+        \phi_d (\mathbf{m}) = \| \mathbf{W} f(\mathbf{m}) \|_2^2
 
     where :math:`\mathbf{m}` is the model vector, :math:`\mathbf{W}` is a linear weighting
     matrix, and :math:`f` is a mapping function that acts on the model.

--- a/SimPEG/data_misfit.py
+++ b/SimPEG/data_misfit.py
@@ -177,7 +177,7 @@ class L2DataMisfit(BaseDataMisfit):
         "__call__(m, f=None)"
 
         R = self.W * self.residual(m, f=f)
-        return 0.5 * np.vdot(R, R)
+        return np.vdot(R, R)
 
     @timeIt
     def deriv(self, m, f=None):
@@ -196,7 +196,7 @@ class L2DataMisfit(BaseDataMisfit):
         if f is None:
             f = self.simulation.fields(m)
 
-        return self.simulation.Jtvec(
+        return 2 * self.simulation.Jtvec(
             m, self.W.T * (self.W * self.residual(m, f=f)), f=f
         )
 
@@ -217,6 +217,6 @@ class L2DataMisfit(BaseDataMisfit):
         if f is None:
             f = self.simulation.fields(m)
 
-        return self.simulation.Jtvec_approx(
+        return 2 * self.simulation.Jtvec_approx(
             m, self.W * (self.W * self.simulation.Jvec_approx(m, v, f=f)), f=f
         )

--- a/SimPEG/data_misfit.py
+++ b/SimPEG/data_misfit.py
@@ -152,7 +152,7 @@ class BaseDataMisfit(L2ObjectiveFunction):
         For a discrete least-squares data misfit function of the form:
 
         .. math::
-            \phi_d (\mathbf{m}) = \frac{1}{2} \| \mathbf{W} \mathbf{f}(\mathbf{m}) \|_2^2
+            \phi_d (\mathbf{m}) = \| \mathbf{W} \mathbf{f}(\mathbf{m}) \|_2^2
 
         :math:`\mathbf{W}` is a linear weighting matrix, :math:`\mathbf{m}` is the model vector,
         and :math:`\mathbf{f}` is a discrete mapping function that acts on the model vector.
@@ -237,7 +237,7 @@ class L2DataMisfit(BaseDataMisfit):
     data and predicted data for a given model. I.e.:
 
     .. math::
-        \phi_d (\mathbf{m}) = \frac{1}{2} \big \| \mathbf{W_d}
+        \phi_d (\mathbf{m}) = \big \| \mathbf{W_d}
         \big ( \mathbf{d}_\text{pred} - \mathbf{d}_\text{obs} \big ) \big \|_2^2
 
     where :math:`\mathbf{d}_\text{obs}` is the observed data vector, :math:`\mathbf{d}_\text{pred}`

--- a/SimPEG/directives/directives.py
+++ b/SimPEG/directives/directives.py
@@ -1060,17 +1060,17 @@ class TargetMisfit(InversionDirective):
         -------
         float
         """
-        # the factor of 0.5 is because we do phid = 0.5*||dpred - dobs||^2
+        # phid = ||dpred - dobs||^2
         if self._phi_d_star is None:
             nD = 0
             for survey in self.survey:
                 nD += survey.nD
-            self._phi_d_star = 0.5 * nD
+            self._phi_d_star = nD
         return self._phi_d_star
 
     @phi_d_star.setter
     def phi_d_star(self, value):
-        # the factor of 0.5 is because we do phid = 0.5*||dpred - dobs||^2
+        # phid = ||dpred - dobs||^2
         if value is not None:
             value = validate_float(
                 "phi_d_star", value, min_val=0.0, inclusive_min=False
@@ -1166,13 +1166,13 @@ class MultiTargetMisfits(InversionDirective):
         -------
         float
         """
-        # the factor of 0.5 is because we do phid = 0.5*|| dpred - dobs||^2
+        # phid = || dpred - dobs||^2
         if getattr(self, "_phi_d_star", None) is None:
             # Check if it is a ComboObjective
             if isinstance(self.dmisfit, ComboObjectiveFunction):
-                value = np.r_[[0.5 * survey.nD for survey in self.survey]]
+                value = np.r_[[survey.nD for survey in self.survey]]
             else:
-                value = np.r_[[0.5 * self.survey.nD]]
+                value = np.r_[[self.survey.nD]]
             self._phi_d_star = value
             self._DMtarget = None
 
@@ -1180,7 +1180,7 @@ class MultiTargetMisfits(InversionDirective):
 
     @phi_d_star.setter
     def phi_d_star(self, value):
-        # the factor of 0.5 is because we do phid = 0.5*|| dpred - dobs||^2
+        # phid =|| dpred - dobs||^2
         if value is not None:
             value = validate_ndarray_with_shape("phi_d_star", value, shape=("*",))
         self._phi_d_star = value
@@ -1426,11 +1426,11 @@ class MultiTargetMisfits(InversionDirective):
             self._CLtarget = self.chiSmall * self.phi_ms_star
 
         elif getattr(self, "_CLtarget", None) is None:
-            # the factor of 0.5 is because we do phid = 0.5*|| dpred - dobs||^2
+            # phid = ||dpred - dobs||^2
             if self.phi_ms_star is None:
                 # Expected value is number of active cells * number of physical
                 # properties
-                self.phi_ms_star = 0.5 * len(self.invProb.model)
+                self.phi_ms_star = len(self.invProb.model)
 
             self._CLtarget = self.chiSmall * self.phi_ms_star
 
@@ -1747,7 +1747,7 @@ class SaveOutputEveryIteration(SaveEveryIteration):
 
         self.f = results[:, 7]
 
-        self.target_misfit = self.invProb.dmisfit.simulation.survey.nD / 2.0
+        self.target_misfit = self.invProb.dmisfit.simulation.survey.nD
         self.i_target = None
 
         if self.invProb.phi_d < self.target_misfit:
@@ -1765,9 +1765,7 @@ class SaveOutputEveryIteration(SaveEveryIteration):
         plot_small=False,
         plot_smooth=False,
     ):
-        self.target_misfit = (
-            np.sum([dmis.nD for dmis in self.invProb.dmisfit.objfcts]) / 2.0
-        )
+        self.target_misfit = np.sum([dmis.nD for dmis in self.invProb.dmisfit.objfcts])
         self.i_target = None
 
         if self.invProb.phi_d < self.target_misfit:
@@ -1821,7 +1819,7 @@ class SaveOutputEveryIteration(SaveEveryIteration):
             fig.savefig(fname, dpi=dpi)
 
     def plot_tikhonov_curves(self, fname=None, dpi=200):
-        self.target_misfit = self.invProb.dmisfit.simulation.survey.nD / 2.0
+        self.target_misfit = self.invProb.dmisfit.simulation.survey.nD
         self.i_target = None
 
         if self.invProb.phi_d < self.target_misfit:
@@ -2062,7 +2060,7 @@ class Update_IRLS(InversionDirective):
             for survey in self.survey:
                 nD += survey.nD
 
-            self._target = nD * 0.5 * self.chifact_target
+            self._target = nD * self.chifact_target
 
         return self._target
 
@@ -2076,10 +2074,10 @@ class Update_IRLS(InversionDirective):
             if isinstance(self.survey, list):
                 self._start = 0
                 for survey in self.survey:
-                    self._start += survey.nD * 0.5 * self.chifact_start
+                    self._start += survey.nD * self.chifact_start
 
             else:
-                self._start = self.survey.nD * 0.5 * self.chifact_start
+                self._start = self.survey.nD * self.chifact_start
         return self._start
 
     @start.setter

--- a/SimPEG/directives/pgi_directives.py
+++ b/SimPEG/directives/pgi_directives.py
@@ -413,7 +413,7 @@ class PGI_AddMrefInSmooth(InversionDirective):
     @property
     def DMtarget(self):
         if getattr(self, "_DMtarget", None) is None:
-            self.phi_d_target = 0.5 * self.invProb.dmisfit.survey.nD
+            self.phi_d_target = self.invProb.dmisfit.survey.nD
             self._DMtarget = self.chifact * self.phi_d_target
         return self._DMtarget
 

--- a/SimPEG/directives/sim_directives.py
+++ b/SimPEG/directives/sim_directives.py
@@ -305,7 +305,7 @@ class PairedBetaSchedule(InversionDirective):
         if getattr(self, "_target", None) is None:
             nD = np.array([survey.nD for survey in self.survey])
 
-            self._target = nD * 0.5 * self.chifact_target
+            self._target = nD * self.chifact_target
 
         return self._target
 
@@ -362,7 +362,7 @@ class MovingAndMultiTargetStopping(InversionDirective):
                 nD += [survey.nD]
             nD = np.array(nD)
 
-            self._target = nD * 0.5 * self.chifact_target
+            self._target = nD * self.chifact_target
 
         return self._target
 

--- a/SimPEG/objective_function.py
+++ b/SimPEG/objective_function.py
@@ -511,7 +511,7 @@ class L2ObjectiveFunction(BaseObjectiveFunction):
         Evaluate the objective functions for a given model
         """
         r = self.W * (self.mapping * m)
-        return 0.5 * r.dot(r)
+        return r.dot(r)
 
     def deriv(self, m):
         """
@@ -519,7 +519,7 @@ class L2ObjectiveFunction(BaseObjectiveFunction):
 
         :param numpy.ndarray m: model
         """
-        return self.mapping.deriv(m).T * (self.W.T * (self.W * (self.mapping * m)))
+        return 2 * self.mapping.deriv(m).T * (self.W.T * (self.W * (self.mapping * m)))
 
     def deriv2(self, m, v=None):
         """
@@ -529,8 +529,10 @@ class L2ObjectiveFunction(BaseObjectiveFunction):
         :param numpy.ndarray v: vector to multiply by
         """
         if v is not None:
-            return self.mapping.deriv(m).T * (
-                self.W.T * (self.W * (self.mapping.deriv(m) * v))
+            return (
+                2
+                * self.mapping.deriv(m).T
+                * (self.W.T * (self.W * (self.mapping.deriv(m) * v)))
             )
         W = self.W * self.mapping.deriv(m)
-        return W.T * W
+        return 2 * W.T * W

--- a/SimPEG/objective_function.py
+++ b/SimPEG/objective_function.py
@@ -575,7 +575,7 @@ class L2ObjectiveFunction(BaseObjectiveFunction):
     Weighting least-squares objective functions in SimPEG are defined as follows:
 
     .. math::
-        \phi = \frac{1}{2} \big \| \mathbf{W} f(\mathbf{m}) \big \|_2^2
+        \phi = \big \| \mathbf{W} f(\mathbf{m}) \big \|_2^2
 
     where :math:`\mathbf{m}` are the model parameters, :math:`f` is a mapping operator,
     and :math:`\mathbf{W}` is the weighting matrix.

--- a/SimPEG/regularization/__init__.py
+++ b/SimPEG/regularization/__init__.py
@@ -52,10 +52,10 @@ y-directions can be expressed as:
 
 .. math::
     \phi_m (m) =
-    \alpha_s \! \int_\Omega \Bigg [ \frac{1}{2} w_s(r) \, m(r)^2 \Bigg ] \, dv +
-    \alpha_x \! \int_\Omega \Bigg [ \frac{1}{2} w_x(r)
+    \alpha_s \! \int_\Omega \Bigg [ w_s(r) \, m(r)^2 \Bigg ] \, dv +
+    \alpha_x \! \int_\Omega \Bigg [ w_x(r)
     \bigg ( \frac{\partial m}{\partial x} \bigg )^2 \Bigg ] \, dv +
-    \alpha_y \! \int_\Omega \Bigg [ \frac{1}{2} w_y(r)
+    \alpha_y \! \int_\Omega \Bigg [ w_y(r)
     \bigg ( \frac{\partial m}{\partial y} \bigg )^2 \Bigg ] \, dv
 
 where :math:`w_s(r), w_x(r), w_y(r)` are user-defined weighting functions.
@@ -65,9 +65,9 @@ discrete set of model parameters :math:`\mathbf{m}`.
 And the regularization is implemented using a weighted sum of objective functions:
 
 .. math::
-    \phi_m (\mathbf{m}) \approx \frac{\alpha_s}{2} \big \| \mathbf{W_s m} \big \|^2 +
-    \frac{\alpha_x}{2} \big \| \mathbf{W_x G_x m} \big \|^2 +
-    \frac{\alpha_y}{2} \big \| \mathbf{W_y G_y m} \big \|^2
+    \phi_m (\mathbf{m}) \approx \alpha_s \big \| \mathbf{W_s m} \big \|^2 +
+    \alpha_x \big \| \mathbf{W_x G_x m} \big \|^2 +
+    \alpha_y \big \| \mathbf{W_y G_y m} \big \|^2
 
 where :math:`\mathbf{G_x}` and :math:`\mathbf{G_y}` are partial gradient operators along the x and
 y-directions, respectively. :math:`\mathbf{W_s}`, :math:`\mathbf{W_x}` and :math:`\mathbf{W_y}`

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -465,7 +465,7 @@ class BaseRegularization(BaseObjectiveFunction):
             The regularization function evaluated for the model provided.
         """
         r = self.W * self.f_m(m)
-        return 0.5 * r.dot(r)
+        return r.dot(r)
 
     def f_m(self, m) -> np.ndarray:
         """Not implemented for ``BaseRegularization`` class."""
@@ -499,7 +499,7 @@ class BaseRegularization(BaseObjectiveFunction):
             The Gradient of the regularization function evaluated for the model provided.
         """
         r = self.W * self.f_m(m)
-        return self.f_m_deriv(m).T * (self.W.T * r)
+        return 2 * self.f_m_deriv(m).T * (self.W.T * r)
 
     @utils.timeIt
     def deriv2(self, m, v=None) -> csr_matrix:
@@ -532,9 +532,9 @@ class BaseRegularization(BaseObjectiveFunction):
         """
         f_m_deriv = self.f_m_deriv(m)
         if v is None:
-            return f_m_deriv.T * ((self.W.T * self.W) * f_m_deriv)
+            return 2 * f_m_deriv.T * ((self.W.T * self.W) * f_m_deriv)
 
-        return f_m_deriv.T * (self.W.T * (self.W * (f_m_deriv * v)))
+        return 2 * f_m_deriv.T * (self.W.T * (self.W * (f_m_deriv * v)))
 
 
 class Smallness(BaseRegularization):
@@ -577,7 +577,7 @@ class Smallness(BaseRegularization):
     We define the regularization function (objective function) for smallness as:
 
     .. math::
-        \phi (m) = \frac{1}{2} \int_\Omega \, w(r) \,
+        \phi (m) = \int_\Omega \, w(r) \,
         \Big [ m(r) - m^{(ref)}(r) \Big ]^2 \, dv
 
     where :math:`m(r)` is the model, :math:`m^{(ref)}(r)` is the reference model and :math:`w(r)`
@@ -588,7 +588,7 @@ class Smallness(BaseRegularization):
     function (objective function) is expressed in linear form as:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \sum_i
+        \phi (\mathbf{m}) = \sum_i
         \tilde{w}_i \, \bigg | \, m_i - m_i^{(ref)} \, \bigg |^2
 
     where :math:`m_i \in \mathbf{m}` are the discrete model parameter values defined on the mesh and
@@ -597,7 +597,7 @@ class Smallness(BaseRegularization):
     This is equivalent to an objective function of the form:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2}
+        \phi (\mathbf{m}) =
         \Big \| \mathbf{W} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
     where
@@ -667,7 +667,7 @@ class Smallness(BaseRegularization):
         The objective function for smallness regularization is given by:
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2}
+            \phi_m (\mathbf{m}) =
             \Big \| \mathbf{W} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
         where :math:`\mathbf{m}` are the discrete model parameters defined on the mesh (model),
@@ -682,7 +682,7 @@ class Smallness(BaseRegularization):
         such that
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W} \, \mathbf{f_m} \Big \|^2
+            \phi_m (\mathbf{m}) = \Big \| \mathbf{W} \, \mathbf{f_m} \Big \|^2
 
         """
         return self.mapping * self._delta_m(m)
@@ -713,7 +713,7 @@ class Smallness(BaseRegularization):
         The objective function for smallness regularization is given by:
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2}
+            \phi_m (\mathbf{m}) =
             \Big \| \mathbf{W} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
         where :math:`\mathbf{m}` are the discrete model parameters defined on the mesh (model),
@@ -728,7 +728,7 @@ class Smallness(BaseRegularization):
         such that
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W} \, \mathbf{f_m} \Big \|^2
+            \phi_m (\mathbf{m}) = \Big \| \mathbf{W} \, \mathbf{f_m} \Big \|^2
 
         Thus, the derivative with respect to the model is:
 
@@ -787,7 +787,7 @@ class SmoothnessFirstOrder(BaseRegularization):
     along the x-direction as:
 
     .. math::
-        \phi (m) = \frac{1}{2} \int_\Omega \, w(r) \,
+        \phi (m) = \int_\Omega \, w(r) \,
         \bigg [ \frac{\partial m}{\partial x} \bigg ]^2 \, dv
 
     where :math:`m(r)` is the model and :math:`w(r)` is a user-defined weighting function.
@@ -797,7 +797,7 @@ class SmoothnessFirstOrder(BaseRegularization):
     function (objective function) is expressed in linear form as:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \sum_i
+        \phi (\mathbf{m}) = \sum_i
         \tilde{w}_i \, \bigg | \, \frac{\partial m_i}{\partial x} \, \bigg |^2
 
     where :math:`m_i \in \mathbf{m}` are the discrete model parameter values defined on the mesh
@@ -806,7 +806,7 @@ class SmoothnessFirstOrder(BaseRegularization):
     This is equivalent to an objective function of the form:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W \, G_x m } \, \Big \|^2
+        \phi (\mathbf{m}) = \Big \| \mathbf{W \, G_x m } \, \Big \|^2
 
     where
 
@@ -823,7 +823,7 @@ class SmoothnessFirstOrder(BaseRegularization):
     In this case, the objective function becomes:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W G_x}
+        \phi (\mathbf{m}) = \Big \| \mathbf{W G_x}
         \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
     This functionality is used by setting a reference model with the
@@ -981,7 +981,7 @@ class SmoothnessFirstOrder(BaseRegularization):
         is given by:
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2}
+            \phi_m (\mathbf{m}) =
             \Big \| \mathbf{W G_x} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
         where :math:`\mathbf{m}` are the discrete model parameters (model),
@@ -998,7 +998,7 @@ class SmoothnessFirstOrder(BaseRegularization):
         such that
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W \, f_m} \Big \|^2
+            \phi_m (\mathbf{m}) = \Big \| \mathbf{W \, f_m} \Big \|^2
         """
         dfm_dl = self.cell_gradient @ (self.mapping * self._delta_m(m))
 
@@ -1037,7 +1037,7 @@ class SmoothnessFirstOrder(BaseRegularization):
         is given by:
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2}
+            \phi_m (\mathbf{m}) =
             \Big \| \mathbf{W G_x} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
         where :math:`\mathbf{m}` are the discrete model parameters (model),
@@ -1054,7 +1054,7 @@ class SmoothnessFirstOrder(BaseRegularization):
         such that
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W \, f_m} \Big \|^2
+            \phi_m (\mathbf{m}) = \Big \| \mathbf{W \, f_m} \Big \|^2
 
         The derivative with respect to the model is therefore:
 
@@ -1152,7 +1152,7 @@ class SmoothnessSecondOrder(SmoothnessFirstOrder):
     smoothness along the x-direction as:
 
     .. math::
-        \phi (m) = \frac{1}{2} \int_\Omega \, w(r) \,
+        \phi (m) = \int_\Omega \, w(r) \,
         \bigg [ \frac{\partial^2 m}{\partial x^2} \bigg ]^2 \, dv
 
     where :math:`m(r)` is the model and :math:`w(r)` is a user-defined weighting function.
@@ -1162,7 +1162,7 @@ class SmoothnessSecondOrder(SmoothnessFirstOrder):
     function (objective function) is expressed in linear form as:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \sum_i
+        \phi (\mathbf{m}) = \sum_i
         \tilde{w}_i \, \bigg | \, \frac{\partial^2 m_i}{\partial x^2} \, \bigg |^2
 
     where :math:`m_i \in \mathbf{m}` are the discrete model parameter values defined on the
@@ -1171,7 +1171,7 @@ class SmoothnessSecondOrder(SmoothnessFirstOrder):
     This is equivalent to an objective function of the form:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \big \| \mathbf{W \, L_x \, m } \, \big \|^2
+        \phi (\mathbf{m}) = \big \| \mathbf{W \, L_x \, m } \, \big \|^2
 
     where
 
@@ -1185,7 +1185,7 @@ class SmoothnessSecondOrder(SmoothnessFirstOrder):
     In this case, the objective function becomes:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W L_x}
+        \phi (\mathbf{m}) = \Big \| \mathbf{W L_x}
         \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
     This functionality is used by setting a reference model with the
@@ -1248,7 +1248,7 @@ class SmoothnessSecondOrder(SmoothnessFirstOrder):
         is given by:
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2}
+            \phi_m (\mathbf{m}) =
             \Big \| \mathbf{W L_x} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
         where :math:`\mathbf{m}` are the discrete model parameters (model),
@@ -1265,7 +1265,7 @@ class SmoothnessSecondOrder(SmoothnessFirstOrder):
         such that
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W \, f_m} \Big \|^2
+            \phi_m (\mathbf{m}) = \Big \| \mathbf{W \, f_m} \Big \|^2
         """
         dfm_dl = self.cell_gradient @ (self.mapping * self._delta_m(m))
 
@@ -1306,7 +1306,7 @@ class SmoothnessSecondOrder(SmoothnessFirstOrder):
         is given by:
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2}
+            \phi_m (\mathbf{m}) =
             \Big \| \mathbf{W L_x} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
         where :math:`\mathbf{m}` are the discrete model parameters (model),
@@ -1323,7 +1323,7 @@ class SmoothnessSecondOrder(SmoothnessFirstOrder):
         such that
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W \, f_m} \Big \|^2
+            \phi_m (\mathbf{m}) = \Big \| \mathbf{W \, f_m} \Big \|^2
 
         The derivative of the regularization kernel function with respect to the model is:
 

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -1433,11 +1433,11 @@ class WeightedLeastSquares(ComboObjectiveFunction):
     :math:`\phi_m (m)` of the form:
 
     .. math::
-        \phi_m (m) =& \frac{\alpha_s}{2} \int_\Omega \, w(r)
+        \phi_m (m) =& \alpha_s \int_\Omega \, w(r)
         \Big [ m(r) - m^{(ref)}(r) \Big ]^2 \, dv \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_j}{2} \int_\Omega \, w(r)
+        &+ \sum_{j=x,y,z} \alpha_j \int_\Omega \, w(r)
         \bigg [ \frac{\partial m}{\partial \xi_j} \bigg ]^2 \, dv \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_{jj}}{2} \int_\Omega \, w(r)
+        &+ \sum_{j=x,y,z} \alpha_{jj} \int_\Omega \, w(r)
         \bigg [ \frac{\partial^2 m}{\partial \xi_j^2} \bigg ]^2 \, dv
         \;\;\;\;\;\;\;\; \big ( \textrm{optional} \big )
 
@@ -1461,10 +1461,10 @@ class WeightedLeastSquares(ComboObjectiveFunction):
     objective functions of the form:
 
     .. math::
-        \phi_m (\mathbf{m}) =& \frac{\alpha_s}{2}
+        \phi_m (\mathbf{m}) =& \alpha_s
         \Big \| \mathbf{W_s} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2 \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_j}{2} \Big \| \mathbf{W_j G_j \, m} \, \Big \|^2 \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_{jj}}{2} \Big \| \mathbf{W_{jj} L_j \, m} \, \Big \|^2
+        &+ \sum_{j=x,y,z} \alpha_j \Big \| \mathbf{W_j G_j \, m} \, \Big \|^2 \\
+        &+ \sum_{j=x,y,z} \alpha_{jj} \Big \| \mathbf{W_{jj} L_j \, m} \, \Big \|^2
         \;\;\;\;\;\;\;\; \big ( \textrm{optional} \big )
 
     where
@@ -1482,11 +1482,11 @@ class WeightedLeastSquares(ComboObjectiveFunction):
     In this case, the objective function becomes:
 
     .. math::
-        \phi_m (\mathbf{m}) =& \frac{\alpha_s}{2}
+        \phi_m (\mathbf{m}) =& \alpha_s
         \Big \| \mathbf{W_s} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2 \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_j}{2} \Big \| \mathbf{W_j G_j}
+        &+ \sum_{j=x,y,z} \alpha_j \Big \| \mathbf{W_j G_j}
         \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2 \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_{jj}}{2} \Big \| \mathbf{W_{jj} L_j}
+        &+ \sum_{j=x,y,z} \alpha_{jj} \Big \| \mathbf{W_{jj} L_j}
         \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
         \;\;\;\;\;\;\;\; \big ( \textrm{optional} \big )
 

--- a/SimPEG/regularization/correspondence.py
+++ b/SimPEG/regularization/correspondence.py
@@ -43,7 +43,7 @@ class LinearCorrespondence(BaseSimilarityMeasure):
 
     .. math::
         \phi (\mathbf{m})
-        = \frac{1}{2} \big \| \lambda_1 \mathbf{m_1} + \lambda_2 \mathbf{m_2} + \lambda_3 \big \|^2
+        = \big \| \lambda_1 \mathbf{m_1} + \lambda_2 \mathbf{m_2} + \lambda_3 \big \|^2
 
     Scalar coefficients :math:`\{ \lambda_1 , \lambda_2 , \lambda_3 \}` are set using the
     `coefficients` property. For a true linear correspondence constraint, we set
@@ -130,7 +130,7 @@ class LinearCorrespondence(BaseSimilarityMeasure):
         """
 
         result = self.relation(model)
-        return 0.5 * result.T @ result
+        return result.T @ result
 
     def deriv(self, model):
         r"""Gradient of the regularization function evaluated for the model provided.
@@ -167,7 +167,7 @@ class LinearCorrespondence(BaseSimilarityMeasure):
 
         result = np.r_[dc_dm1, dc_dm2]
 
-        return result
+        return 2 * result
 
     def deriv2(self, model, v=None):
         r"""Hessian of the regularization function evaluated for the model provided.
@@ -217,10 +217,10 @@ class LinearCorrespondence(BaseSimilarityMeasure):
             v1, v2 = self.wire_map * v
             p1 = k1**2 * v1 + k2 * k1 * v2
             p2 = k2 * k1 * v1 + k2**2 * v2
-            return np.r_[p1, p2]
+            return 2 * np.r_[p1, p2]
         else:
             n = self.regularization_mesh.nC
             A = utils.sdiag(np.ones(n) * (k1**2))
             B = utils.sdiag(np.ones(n) * (k2**2))
             C = utils.sdiag(np.ones(n) * (k1 * k2))
-            return sp.bmat([[A, C], [C, B]], format="csr")
+            return 2 * sp.bmat([[A, C], [C, B]], format="csr")

--- a/SimPEG/regularization/cross_gradient.py
+++ b/SimPEG/regularization/cross_gradient.py
@@ -265,7 +265,7 @@ class CrossGradient(BaseSimilarityMeasure):
         The gradient has the form:
 
         .. math::
-            \frac{\partial \phi}{\partial \mathbf{m}} =
+            2 \frac{\partial \phi}{\partial \mathbf{m}} =
             \begin{bmatrix} \dfrac{\partial \phi}{\partial \mathbf{m_1}} \\
             \dfrac{\partial \phi}{\partial \mathbf{m_2}} \end{bmatrix}
 
@@ -294,7 +294,7 @@ class CrossGradient(BaseSimilarityMeasure):
                 (((Av @ g_m1**2) @ Av) * g_m2) @ G
                 - (((Av @ (g_m1 * g_m2)) @ Av) * g_m1) @ G,
             ]
-        )
+        )  # factor of 2 from derviative of | grad m1 x grad m2 | ^2
 
     def deriv2(self, model, v=None):
         r"""Hessian of the regularization function evaluated for the model provided.
@@ -379,7 +379,9 @@ class CrossGradient(BaseSimilarityMeasure):
                 )
                 BT = B.T
 
-            return 2 * sp.bmat([[A, B], [BT, C]], format="csr")
+            return 2 * sp.bmat(
+                [[A, B], [BT, C]], format="csr"
+            )  # factor of 2 from derviative of | grad m1 x grad m2 | ^2
         else:
             v1, v2 = self.wire_map * v
 
@@ -405,4 +407,6 @@ class CrossGradient(BaseSimilarityMeasure):
                     - g_m1 * (Av.T @ (Av @ (g_m2 * Gv1)))
                     - (Av.T @ (Av @ (g_m2 * g_m1))) * Gv1
                 )
-            return 2 * np.r_[p1, p2]
+            return (
+                2 * np.r_[p1, p2]
+            )  # factor of 2 from derviative of | grad m1 x grad m2 | ^2

--- a/SimPEG/regularization/cross_gradient.py
+++ b/SimPEG/regularization/cross_gradient.py
@@ -366,7 +366,7 @@ class CrossGradient(BaseSimilarityMeasure):
             D22 = G.T @ D22_mid @ G
 
             return 2 * sp.bmat(
-                [[D11, D12], [D12.T, D22]], format="csr", format="csr"
+                [[D11, D12], [D12.T, D22]], format="csr"
             )  # factor of 2 from derviative of | grad m1 x grad m2 | ^2
 
         else:

--- a/SimPEG/regularization/cross_gradient.py
+++ b/SimPEG/regularization/cross_gradient.py
@@ -52,7 +52,7 @@ class CrossGradient(BaseSimilarityMeasure):
     (`Haber and Gazit, 2013 <https://link.springer.com/article/10.1007/s10712-013-9232-4>`__):
 
     .. math::
-        \phi (m_1, m_2) = \frac{1}{2} \int_\Omega \, w(r) \,
+        \phi (m_1, m_2) = \int_\Omega \, w(r) \,
         \Big | \nabla m_1 \, \times \, \nabla m_2 \, \Big |^2 \, dv
 
     where :math:`w(r)` is a user-defined weighting function.
@@ -60,7 +60,7 @@ class CrossGradient(BaseSimilarityMeasure):
     the regularization function can be re-expressed as:
 
     .. math::
-        \phi (m_1, m_2) = \frac{1}{2} \int_\Omega \, w(r) \, \Big [ \,
+        \phi (m_1, m_2) = \int_\Omega \, w(r) \, \Big [ \,
         \big | \nabla m_1 \big |^2 \big | \nabla m_2 \big |^2
         - \big ( \nabla m_1 \, \cdot \, \nabla m_2 \, \big )^2 \Big ] \, dv
 
@@ -69,7 +69,7 @@ class CrossGradient(BaseSimilarityMeasure):
     function (objective function) is given by:
 
     .. math::
-        \phi (m_1, m_2) \approx \frac{1}{2} \sum_i \tilde{w}_i \, \bigg [
+        \phi (m_1, m_2) \approx \sum_i \tilde{w}_i \, \bigg [
         \Big | (\nabla m_1)_i \Big |^2 \Big | (\nabla m_2)_i \Big |^2
         - \Big [ (\nabla m_1)_i \, \cdot \, (\nabla m_2)_i \, \Big ]^2 \, \bigg ]
 
@@ -89,9 +89,9 @@ class CrossGradient(BaseSimilarityMeasure):
 
     .. math::
         \phi (\mathbf{m}) =
-        \frac{1}{2} \Big [ \mathbf{W A} \big ( \mathbf{G \, m_1} \big )^2 \Big ]^T
+     \Big [ \mathbf{W A} \big ( \mathbf{G \, m_1} \big )^2 \Big ]^T
         \Big [ \mathbf{W A} \big ( \mathbf{G \, m_2} \big )^2 \Big ]
-        - \frac{1}{2} \bigg \| \mathbf{W A} \Big [ \big ( \mathbf{G \, m_1} \big )
+        - \bigg \| \mathbf{W A} \Big [ \big ( \mathbf{G \, m_1} \big )
         \odot \big ( \mathbf{G \, m_2} \big ) \Big ] \bigg \|^2
 
     where exponents are computed elementwise,
@@ -249,9 +249,7 @@ class CrossGradient(BaseSimilarityMeasure):
         G = self._G
         g_m1 = G @ m1
         g_m2 = G @ m2
-        return 0.5 * np.sum(
-            (Av @ g_m1**2) * (Av @ g_m2**2) - (Av @ (g_m1 * g_m2)) ** 2
-        )
+        return np.sum((Av @ g_m1**2) * (Av @ g_m2**2) - (Av @ (g_m1 * g_m2)) ** 2)
 
     def deriv(self, model):
         r"""Gradient of the regularization function evaluated for the model provided.
@@ -288,12 +286,15 @@ class CrossGradient(BaseSimilarityMeasure):
         g_m1 = G @ m1
         g_m2 = G @ m2
 
-        return np.r_[
-            (((Av @ g_m2**2) @ Av) * g_m1) @ G
-            - (((Av @ (g_m1 * g_m2)) @ Av) * g_m2) @ G,
-            (((Av @ g_m1**2) @ Av) * g_m2) @ G
-            - (((Av @ (g_m1 * g_m2)) @ Av) * g_m1) @ G,
-        ]
+        return (
+            2
+            * np.r_[
+                (((Av @ g_m2**2) @ Av) * g_m1) @ G
+                - (((Av @ (g_m1 * g_m2)) @ Av) * g_m2) @ G,
+                (((Av @ g_m1**2) @ Av) * g_m2) @ G
+                - (((Av @ (g_m1 * g_m2)) @ Av) * g_m1) @ G,
+            ]
+        )
 
     def deriv2(self, model, v=None):
         r"""Hessian of the regularization function evaluated for the model provided.
@@ -378,7 +379,7 @@ class CrossGradient(BaseSimilarityMeasure):
                 )
                 BT = B.T
 
-            return sp.bmat([[A, B], [BT, C]], format="csr")
+            return 2 * sp.bmat([[A, B], [BT, C]], format="csr")
         else:
             v1, v2 = self.wire_map * v
 
@@ -404,4 +405,4 @@ class CrossGradient(BaseSimilarityMeasure):
                     - g_m1 * (Av.T @ (Av @ (g_m2 * Gv1)))
                     - (Av.T @ (Av @ (g_m2 * g_m1))) * Gv1
                 )
-            return np.r_[p1, p2]
+            return 2 * np.r_[p1, p2]

--- a/SimPEG/regularization/jtv.py
+++ b/SimPEG/regularization/jtv.py
@@ -50,7 +50,7 @@ class JointTotalVariation(BaseSimilarityMeasure):
     (`Haber and Gazit, 2013 <https://link.springer.com/article/10.1007/s10712-013-9232-4>`__):
 
     .. math::
-        \phi (m_1, m_2) = \frac{1}{2} \int_\Omega \, w(r) \,
+        \phi (m_1, m_2) = \int_\Omega \, w(r) \,
         \Big [ \, \big | \nabla m_1 \big |^2 \, + \, \big | \nabla m_2 \big |^2 \, \Big ]^{1/2} \, dv
 
     where :math:`w(r)` is a user-defined weighting function.
@@ -60,7 +60,7 @@ class JointTotalVariation(BaseSimilarityMeasure):
     function (objective function) is given by:
 
     .. math::
-        \phi (m_1, m_2) \approx \frac{1}{2} \sum_i \tilde{w}_i \, \bigg [ \,
+        \phi (m_1, m_2) \approx \sum_i \tilde{w}_i \, \bigg [ \,
         \Big | (\nabla m_1)_i \Big |^2 \, + \, \Big | (\nabla m_2)_i \Big |^2 \, \bigg ]^{1/2}
 
     where :math:`(\nabla m_1)_i` are the gradients of property :math:`m_1` defined on the mesh and
@@ -78,7 +78,7 @@ class JointTotalVariation(BaseSimilarityMeasure):
     is therefore equivalent to an objective function of the form:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \, \mathbf{e}^T \Bigg ( \,
+        \phi (\mathbf{m}) = \mathbf{e}^T \Bigg ( \,
         \mathbf{W \, A} \bigg [ \sum_k (\mathbf{G \, m_k})^2 \bigg ] \; + \; \epsilon \mathbf{v}^2
         \, \Bigg )^{1/2}
 

--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -103,10 +103,10 @@ class PGIsmallness(Smallness):
     least-square:
 
     .. math::
-        \phi (\mathbf{m}) &= \frac{\alpha_{pgi}}{2}
+        \phi (\mathbf{m}) &= \alpha_\text{pgi}
         \big | \mathbf{W} ( \Theta , \mathbf{z}^\ast ) \, (\mathbf{m} - \mathbf{m_{ref}}(\Theta, \mathbf{z}^\ast ) \, \Big \|^2
-        &+ \sum_{j=x,y,z} \frac{\alpha_j}{2} \Big \| \mathbf{W_j G_j \, m} \, \Big \|^2 \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_{jj}}{2} \Big \| \mathbf{W_{jj} L_j \, m} \, \Big \|^2
+        &+ \sum_{j=x,y,z} \alpha_j \Big \| \mathbf{W_j G_j \, m} \, \Big \|^2 \\
+        &+ \sum_{j=x,y,z} \alpha_{jj} \Big \| \mathbf{W_{jj} L_j \, m} \, \Big \|^2
         \;\;\;\;\;\;\;\; \big ( \textrm{optional} \big )
 
     where
@@ -841,22 +841,12 @@ class PGIsmallness(Smallness):
                 mDv = self.wiresmap * (mD * v)
                 mDv = np.c_[mDv]
                 r0 = (self.W * (mkvc(mDv))).reshape(mDv.shape, order="F")
-                return mkvc(
-                    mD.T
-                    * (
-                        self.W
-                        * (
-                            mkvc(
-                                np.r_[
-                                    [
-                                        np.dot(self._r_second_deriv[i], r0[i])
-                                        for i in range(len(r0))
-                                    ]
-                                ]
-                            )
-                        )
-                    )
+                second_deriv_times_r0 = mkvc(
+                    np.r_[
+                        [np.dot(self._r_second_deriv[i], r0[i]) for i in range(len(r0))]
+                    ]
                 )
+                return 2 * mkvc(mD.T * (self.W * second_deriv_times_r0))
             else:
                 # Forming the Hessian by diagonal blocks
                 hlist = [
@@ -1041,12 +1031,12 @@ class PGI(ComboObjectiveFunction):
     ``PGI`` is given by:
 
     .. math::
-        \phi (\mathbf{m}) &= \frac{\alpha_{pgi}}{2}
+        \phi (\mathbf{m}) &= \alpha_\text{pgi}
         \big [ \mathbf{m} - \mathbf{m_{ref}}(\Theta, \mathbf{z}^\ast ) \big ]^T
         \mathbf{W} ( \Theta , \mathbf{z}^\ast ) \,
         \big [ \mathbf{m} - \mathbf{m_{ref}}(\Theta, \mathbf{z}^\ast ) \big ] \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_j}{2} \Big \| \mathbf{W_j G_j \, m} \, \Big \|^2 \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_{jj}}{2} \Big \| \mathbf{W_{jj} L_j \, m} \, \Big \|^2
+        &+ \sum_{j=x,y,z} \alpha_j \Big \| \mathbf{W_j G_j \, m} \, \Big \|^2 \\
+        &+ \sum_{j=x,y,z} \alpha_{jj} \Big \| \mathbf{W_{jj} L_j \, m} \, \Big \|^2
         \;\;\;\;\;\;\;\; \big ( \textrm{optional} \big )
 
     where
@@ -1072,10 +1062,10 @@ class PGI(ComboObjectiveFunction):
     regularization function (objective function) can be expressed as:
 
     .. math::
-        \phi (\mathbf{m}) &= \frac{\alpha_{pgi}}{2} \Big \| \mathbf{W}_{\! 1/2}(\Theta, \mathbf{z}^\ast ) \,
+        \phi (\mathbf{m}) &= \alpha_\text{pgi} \Big \| \mathbf{W}_{\! 1/2}(\Theta, \mathbf{z}^\ast ) \,
         \big [ \mathbf{m} - \mathbf{m_{ref}}(\Theta, \mathbf{z}^\ast ) \big ] \, \Big \|^2 \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_j}{2} \Big \| \mathbf{W_j G_j \, m} \, \Big \|^2 \\
-        &+ \sum_{j=x,y,z} \frac{\alpha_{jj}}{2} \Big \| \mathbf{W_{jj} L_j \, m} \, \Big \|^2
+        &+ \sum_{j=x,y,z} \alpha_j \Big \| \mathbf{W_j G_j \, m} \, \Big \|^2 \\
+        &+ \sum_{j=x,y,z} \alpha_{jj} \Big \| \mathbf{W_{jj} L_j \, m} \, \Big \|^2
         \;\;\;\;\;\;\;\; \big ( \textrm{optional} \big )
 
     When the ``approx_eval`` property is ``True``, you may also set the ``approx_gradient`` property

--- a/SimPEG/regularization/pgi.py
+++ b/SimPEG/regularization/pgi.py
@@ -497,7 +497,7 @@ class PGIsmallness(Smallness):
                     ]
                 ]
 
-            return 0.5 * mkvc(r0).dot(mkvc(r1))
+            return mkvc(r0).dot(mkvc(r1))
 
         else:
             modellist = self.wiresmap * m
@@ -506,7 +506,7 @@ class PGIsmallness(Smallness):
             if self.non_linear_relationships:
                 score = self.gmm.score_samples(model)
                 score_vec = mkvc(np.r_[[score for maps in self.wiresmap.maps]])
-                return -np.sum((W.T * W) * score_vec) / len(self.wiresmap.maps)
+                return -2 * np.sum((W.T * W) * score_vec) / len(self.wiresmap.maps)
 
             else:
                 if external_weights and getattr(self.W, "diagonal", None) is not None:
@@ -519,7 +519,7 @@ class PGIsmallness(Smallness):
                 score = self.gmm.score_samples_with_sensW(model, sensW)
                 # score_vec = mkvc(np.r_[[score for maps in self.wiresmap.maps]])
                 # return -np.sum((W.T * W) * score_vec) / len(self.wiresmap.maps)
-                return -np.sum(score)
+                return -2 * np.sum(score)
 
     @timeIt
     def deriv(self, m):
@@ -616,7 +616,7 @@ class PGIsmallness(Smallness):
                             ]
                         ]
                     )
-            return mkvc(mD.T * (self.W.T * r))
+            return 2 * mkvc(mD.T * (self.W.T * r))
 
         else:
             if self.non_linear_relationships:
@@ -726,7 +726,7 @@ class PGIsmallness(Smallness):
             logP = np.vstack([logP for maps in self.wiresmap.maps])
             numer = (W * np.exp(logP)).sum(axis=1)
             r = numer / (np.exp(score_vec))
-            return mkvc(mD.T * r)
+            return 2 * mkvc(mD.T * r)
 
     @timeIt
     def deriv2(self, m, v=None):
@@ -875,7 +875,7 @@ class PGIsmallness(Smallness):
 
                 Hr = Hr.dot(self.W)
 
-                return (mD.T * mD) * (self.W * (Hr))
+                return 2 * (mD.T * mD) * (self.W * (Hr))
 
         else:
             if self.non_linear_relationships:
@@ -953,7 +953,7 @@ class PGIsmallness(Smallness):
                 for j in range(len(self.wiresmap.maps)):
                     Hc = sp.hstack([Hc, sdiag(hlist[i][j])])
                 Hr = sp.vstack([Hr, Hc])
-            Hr = (mD.T * mD) * Hr
+            Hr = 2 * (mD.T * mD) * Hr
 
             if v is not None:
                 return Hr.dot(v)

--- a/SimPEG/regularization/sparse.py
+++ b/SimPEG/regularization/sparse.py
@@ -257,7 +257,7 @@ class SparseSmallness(BaseSparse, Smallness):
     We define the regularization function (objective function) for sparse smallness (compactness) as:
 
     .. math::
-        \phi (m) = \frac{1}{2} \int_\Omega \, w(r) \,
+        \phi (m) = \int_\Omega \, w(r) \,
         \Big | \, m(r) - m^{(ref)}(r) \, \Big |^{p(r)} \, dv
 
     where :math:`m(r)` is the model, :math:`m^{(ref)}(r)` is the reference model, :math:`w(r)`
@@ -271,7 +271,7 @@ class SparseSmallness(BaseSparse, Smallness):
     function (objective function) is expressed in linear form as:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \sum_i
+        \phi (\mathbf{m}) = \sum_i
         \tilde{w}_i \, \Big | m_i - m_i^{(ref)} \Big |^{p_i}
 
     where :math:`m_i \in \mathbf{m}` are the discrete model parameters defined on the mesh.
@@ -286,8 +286,8 @@ class SparseSmallness(BaseSparse, Smallness):
 
     .. math::
         \phi \big (\mathbf{m}^{(k)} \big )
-        = \frac{1}{2} \sum_i \tilde{w}_i \, \Big | m_i^{(k)} - m_i^{(ref)} \Big |^{p_i}
-        \approx \frac{1}{2} \sum_i \tilde{w}_i \, r_i^{(k)} \Big | m_i^{(k)} - m_i^{(ref)} \Big |^2
+        = \sum_i \tilde{w}_i \, \Big | m_i^{(k)} - m_i^{(ref)} \Big |^{p_i}
+        \approx \sum_i \tilde{w}_i \, r_i^{(k)} \Big | m_i^{(k)} - m_i^{(ref)} \Big |^2
 
     where the IRLS weight :math:`r_i` for iteration :math:`k` is given by:
 
@@ -300,7 +300,7 @@ class SparseSmallness(BaseSparse, Smallness):
     function for IRLS iteration :math:`k` can be expressed as follows:
 
     .. math::
-        \phi \big ( \mathbf{m}^{(k)} \big ) \approx \frac{1}{2} \Big \| \,
+        \phi \big ( \mathbf{m}^{(k)} \big ) \approx \Big \| \,
         \mathbf{W}^{\! (k)} \big [ \mathbf{m}^{(k)} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
     where
@@ -464,7 +464,7 @@ class SparseSmoothness(BaseSparse, SmoothnessFirstOrder):
     along the x-direction as:
 
     .. math::
-        \phi (m) = \frac{1}{2} \int_\Omega \, w(r) \,
+        \phi (m) = \int_\Omega \, w(r) \,
         \Bigg | \, \frac{\partial m}{\partial x} \, \Bigg |^{p(r)} \, dv
 
     where :math:`m(r)` is the model, :math:`w(r)`
@@ -478,7 +478,7 @@ class SparseSmoothness(BaseSparse, SmoothnessFirstOrder):
     function (objective function) is expressed in linear form as:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \sum_i
+        \phi (\mathbf{m}) = \sum_i
         \tilde{w}_i \, \Bigg | \, \frac{\partial m_i}{\partial x} \, \Bigg |^{p_i}
 
     where :math:`m_i \in \mathbf{m}` are the discrete model parameters defined on the mesh.
@@ -493,9 +493,9 @@ class SparseSmoothness(BaseSparse, SmoothnessFirstOrder):
 
     .. math::
         \phi \big (\mathbf{m}^{(k)} \big )
-        = \frac{1}{2} \sum_i
+        = \sum_i
         \tilde{w}_i \, \Bigg | \, \frac{\partial m_i^{(k)}}{\partial x} \Bigg |^{p_i}
-        \approx \frac{1}{2} \sum_i \tilde{w}_i \, r_i^{(k)}
+        \approx \sum_i \tilde{w}_i \, r_i^{(k)}
         \Bigg | \, \frac{\partial m_i^{(k)}}{\partial x} \Bigg |^2
 
     where the IRLS weight :math:`r_i` for iteration :math:`k` is given by:
@@ -509,7 +509,7 @@ class SparseSmoothness(BaseSparse, SmoothnessFirstOrder):
     function for IRLS iteration :math:`k` can be expressed as follows:
 
     .. math::
-        \phi \big ( \mathbf{m}^{(k)} \big ) \approx \frac{1}{2} \Big \| \,
+        \phi \big ( \mathbf{m}^{(k)} \big ) \approx \Big \| \,
         \mathbf{W}^{(k)} \, \mathbf{G_x} \, \mathbf{m}^{(k)} \Big \|^2
 
     where
@@ -528,7 +528,7 @@ class SparseSmoothness(BaseSparse, SmoothnessFirstOrder):
     In this case, the least-squares problem for IRLS iteration :math:`k` becomes:
 
     .. math::
-        \phi \big ( \mathbf{m}^{(k)} \big ) \approx \frac{1}{2} \Big \| \,
+        \phi \big ( \mathbf{m}^{(k)} \big ) \approx \Big \| \,
         \mathbf{W}^{(k)} \mathbf{G_x}
         \big [ \mathbf{m}^{(k)} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
@@ -765,9 +765,9 @@ class Sparse(WeightedLeastSquares):
     :math:`\phi_m (m)` of the form:
 
     .. math::
-        \phi_m (m) = \frac{\alpha_s}{2} \int_\Omega \, w(r)
+        \phi_m (m) = \alpha_s \int_\Omega \, w(r)
         \Big | \, m(r) - m^{(ref)}(r) \, \Big |^{p_s(r)} \, dv
-        + \sum_{j=x,y,z} \frac{\alpha_j}{2} \int_\Omega \, w(r)
+        + \sum_{j=x,y,z} \alpha_j \int_\Omega \, w(r)
         \Bigg | \, \frac{\partial m}{\partial \xi_j} \, \Bigg |^{p_j(r)} \, dv
 
     where :math:`m(r)` is the model, :math:`m^{(ref)}(r)` is the reference model, and :math:`w(r)`
@@ -819,9 +819,9 @@ class Sparse(WeightedLeastSquares):
     objective functions of the form:
 
     .. math::
-        \phi_m (\mathbf{m}) = \frac{\alpha_s}{2}
+        \phi_m (\mathbf{m}) = \alpha_s
         \Big \| \mathbf{W_s}^{\!\! (k)} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
-        + \sum_{j=x,y,z} \frac{\alpha_j}{2} \Big \| \mathbf{W_j}^{\! (k)} \mathbf{G_j \, m} \Big \|^2
+        + \sum_{j=x,y,z} \alpha_j \Big \| \mathbf{W_j}^{\! (k)} \mathbf{G_j \, m} \Big \|^2
 
     where
 
@@ -878,9 +878,9 @@ class Sparse(WeightedLeastSquares):
     the objective function becomes:
 
     .. math::
-        \phi_m (\mathbf{m}) = \frac{\alpha_s}{2}
+        \phi_m (\mathbf{m}) = \alpha_s
         \Big \| \mathbf{W_s}^{\! (k)} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
-        + \sum_{j=x,y,z} \frac{\alpha_j}{2} \Big \|
+        + \sum_{j=x,y,z} \alpha_j \Big \|
         \mathbf{W_j}^{\! (k)} \mathbf{G_j} \big [ \mathbf{m} - \mathbf{m}^{(ref)} \big ] \Big \|^2
 
     This functionality is used by setting the `reference_model_in_smooth` parameter

--- a/SimPEG/regularization/vector.py
+++ b/SimPEG/regularization/vector.py
@@ -82,7 +82,7 @@ class CrossReferenceRegularization(Smallness, BaseVectorRegularization):
     regularization is given by:
 
     .. math::
-        \phi (\vec{m}) = \frac{1}{2} \int_\Omega \, \vec{w}(r) \, \cdot \,
+        \phi (\vec{m}) = \int_\Omega \, \vec{w}(r) \, \cdot \,
         \Big [ \vec{m}(r) \, \times \, \vec{m}^{(ref)}(r) \Big ]^2 \, dv
 
     where :math:`\vec{m}^{(ref)}(r)` is the reference model vector and :math:`\vec{w}(r)`
@@ -93,7 +93,7 @@ class CrossReferenceRegularization(Smallness, BaseVectorRegularization):
     function (objective function) is given by:
 
     .. math::
-        \phi (\vec{m}) \approx \frac{1}{2} \sum_i \tilde{w}_i \, \cdot \,
+        \phi (\vec{m}) \approx \sum_i \tilde{w}_i \, \cdot \,
         \Big | \vec{m}_i \, \times \, \vec{m}_i^{(ref)} \Big |^2
 
     where :math:`\tilde{m}_i \in \mathbf{m}` are the model vectors at cell centers and
@@ -129,7 +129,7 @@ class CrossReferenceRegularization(Smallness, BaseVectorRegularization):
     The discrete regularization function in linear form can ultimately be expressed as:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2}
+        \phi (\mathbf{m}) =
         \Big \| \mathbf{W X m} \, \Big \|^2
 
 
@@ -262,7 +262,7 @@ class CrossReferenceRegularization(Smallness, BaseVectorRegularization):
         The objective function for cross reference regularization is given by:
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2}
+            \phi_m (\mathbf{m}) =
             \Big \| \mathbf{W X m} \, \Big \|^2
 
         where :math:`\mathbf{m}` are the discrete vector model parameters defined on the mesh (model),
@@ -277,7 +277,7 @@ class CrossReferenceRegularization(Smallness, BaseVectorRegularization):
         such that
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W} \, \mathbf{f_m} \Big \|^2
+            \phi_m (\mathbf{m}) = \Big \| \mathbf{W} \, \mathbf{f_m} \Big \|^2
 
         """
         return self._X @ (self.mapping * m)
@@ -309,7 +309,7 @@ class CrossReferenceRegularization(Smallness, BaseVectorRegularization):
         The objective function for cross reference regularization is given by:
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2}
+            \phi_m (\mathbf{m}) =
             \Big \| \mathbf{W X m} \, \Big \|^2
 
         where :math:`\mathbf{m}` are the discrete vector model parameters defined on the mesh (model),
@@ -324,7 +324,7 @@ class CrossReferenceRegularization(Smallness, BaseVectorRegularization):
         such that
 
         .. math::
-            \phi_m (\mathbf{m}) = \frac{1}{2} \Big \| \mathbf{W} \, \mathbf{f_m} \Big \|^2
+            \phi_m (\mathbf{m}) = \Big \| \mathbf{W} \, \mathbf{f_m} \Big \|^2
 
         Thus, the derivative with respect to the model is:
 
@@ -423,11 +423,15 @@ class BaseAmplitude(BaseVectorRegularization):
         """
         d_m = self._delta_m(m)
 
-        return self.f_m_deriv(m).T * (
-            self.W.T
-            @ self.W
-            @ (self.f_m_deriv(m) @ d_m).reshape((-1, self.n_comp), order="F")
-        ).flatten(order="F")
+        return (
+            2
+            * self.f_m_deriv(m).T
+            * (
+                self.W.T
+                @ self.W
+                @ (self.f_m_deriv(m) @ d_m).reshape((-1, self.n_comp), order="F")
+            ).flatten(order="F")
+        )
 
     def deriv2(self, m, v=None) -> csr_matrix:
         r"""Hessian of the regularization function evaluated for the model provided.
@@ -460,13 +464,21 @@ class BaseAmplitude(BaseVectorRegularization):
         f_m_deriv = self.f_m_deriv(m)
 
         if v is None:
-            return f_m_deriv.T * (
-                sp.block_diag([self.W.T * self.W] * self.n_comp) * f_m_deriv
+            return (
+                2
+                * f_m_deriv.T
+                * (sp.block_diag([self.W.T * self.W] * self.n_comp) * f_m_deriv)
             )
 
-        return f_m_deriv.T * (
-            self.W.T @ self.W @ (f_m_deriv * v).reshape((-1, self.n_comp), order="F")
-        ).flatten(order="F")
+        return (
+            2
+            * f_m_deriv.T
+            * (
+                self.W.T
+                @ self.W
+                @ (f_m_deriv * v).reshape((-1, self.n_comp), order="F")
+            ).flatten(order="F")
+        )
 
 
 class AmplitudeSmallness(SparseSmallness, BaseAmplitude):
@@ -519,7 +531,7 @@ class AmplitudeSmallness(SparseSmallness, BaseAmplitude):
     (compactness) as:
 
     .. math::
-        \phi (\vec{m}) = \frac{1}{2} \int_\Omega \, w(r) \,
+        \phi (\vec{m}) = \int_\Omega \, w(r) \,
         \Big | \, \vec{m}(r) - \vec{m}^{(ref)}(r) \, \Big |^{p(r)} \, dv
 
     where :math:`\vec{m}(r)` is the model, :math:`\vec{m}^{(ref)}(r)` is the reference model, :math:`w(r)`
@@ -533,7 +545,7 @@ class AmplitudeSmallness(SparseSmallness, BaseAmplitude):
     function (objective function) is expressed in linear form as:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \sum_i
+        \phi (\mathbf{m}) = \sum_i
         \tilde{w}_i \, \Big | \vec{m}_i - \vec{m}_i^{(ref)} \Big |^{p_i}
 
     where :math:`\mathbf{m}` are the model parameters, :math:`\vec{m}_i` represents the vector
@@ -549,8 +561,8 @@ class AmplitudeSmallness(SparseSmallness, BaseAmplitude):
 
     .. math::
         \phi \big (\mathbf{m}^{(k)} \big )
-        = \frac{1}{2} \sum_i \tilde{w}_i \, \Big | \, \vec{m}_i^{(k)} - \vec{m}_i^{(ref)} \, \Big |^{p_i}
-        \approx \frac{1}{2} \sum_i \tilde{w}_i \, r_i^{(k)}
+        = \sum_i \tilde{w}_i \, \Big | \, \vec{m}_i^{(k)} - \vec{m}_i^{(ref)} \, \Big |^{p_i}
+        \approx \sum_i \tilde{w}_i \, r_i^{(k)}
         \Big | \, \vec{m}_i^{(k)} - \vec{m}_i^{(ref)} \, \Big |^2
 
     where the IRLS weight :math:`r_i` for iteration :math:`k` is given by:
@@ -578,7 +590,7 @@ class AmplitudeSmallness(SparseSmallness, BaseAmplitude):
     The objective function for IRLS iteration :math:`k` is given by:
 
     .. math::
-        \phi \big ( \mathbf{\bar{m}}^{(k)} \big ) \approx \frac{1}{2} \Big \| \,
+        \phi \big ( \mathbf{\bar{m}}^{(k)} \big ) \approx \Big \| \,
         \mathbf{W}^{(k)} \, \mathbf{\bar{m}}^{(k)} \; \Big \|^2
 
     where
@@ -738,7 +750,7 @@ class AmplitudeSmoothnessFirstOrder(SparseSmoothness, BaseAmplitude):
     along the x-direction as:
 
     .. math::
-        \phi (m) = \frac{1}{2} \int_\Omega \, w(r) \,
+        \phi (m) = \int_\Omega \, w(r) \,
         \Bigg | \, \frac{\partial |\vec{m}|}{\partial x} \, \Bigg |^{p(r)} \, dv
 
     where :math:`\vec{m}(r)` is the model, :math:`w(r)`
@@ -752,7 +764,7 @@ class AmplitudeSmoothnessFirstOrder(SparseSmoothness, BaseAmplitude):
     function (objective function) is expressed in linear form as:
 
     .. math::
-        \phi (\mathbf{m}) = \frac{1}{2} \sum_i
+        \phi (\mathbf{m}) = \sum_i
         \tilde{w}_i \, \Bigg | \, \frac{\partial |\vec{m}_i|}{\partial x} \, \Bigg |^{p_i}
 
     where :math:`\vec{m}_i` is the vector defined for mesh cell :math:`i`.
@@ -767,9 +779,9 @@ class AmplitudeSmoothnessFirstOrder(SparseSmoothness, BaseAmplitude):
 
     .. math::
         \phi \big (\mathbf{m}^{(k)} \big )
-        = \frac{1}{2} \sum_i
+        = \sum_i
         \tilde{w}_i \, \left | \, \frac{\partial \big | \vec{m}_i^{(k)} \big | }{\partial x} \right |^{p_i}
-        \approx \frac{1}{2} \sum_i \tilde{w}_i \, r_i^{(k)}
+        \approx \sum_i \tilde{w}_i \, r_i^{(k)}
         \left | \, \frac{\partial \big | \vec{m}_i^{(k)} \big | }{\partial x} \right |^2
 
     where the IRLS weight :math:`r_i` for iteration :math:`k` is given by:
@@ -794,7 +806,7 @@ class AmplitudeSmoothnessFirstOrder(SparseSmoothness, BaseAmplitude):
     The objective function for IRLS iteration :math:`k` is given by:
 
     .. math::
-        \phi \big ( \mathbf{m}^{(k)} \big ) \approx \frac{1}{2} \Big \| \,
+        \phi \big ( \mathbf{m}^{(k)} \big ) \approx \Big \| \,
         \mathbf{W}^{(k)} \, \mathbf{G_x} \, \mathbf{\bar{m}}^{(k)} \Big \|^2
 
     where
@@ -813,7 +825,7 @@ class AmplitudeSmoothnessFirstOrder(SparseSmoothness, BaseAmplitude):
     In this case, the least-squares problem for IRLS iteration :math:`k` becomes:
 
     .. math::
-        \phi \big ( \mathbf{m}^{(k)} \big ) \approx \frac{1}{2} \Big \| \,
+        \phi \big ( \mathbf{m}^{(k)} \big ) \approx \Big \| \,
         \mathbf{W}^{(k)} \, \mathbf{G_x} \, \mathbf{\bar{m}}^{(k)} \Big \|^2
 
     where

--- a/SimPEG/regularization/vector.py
+++ b/SimPEG/regularization/vector.py
@@ -1052,9 +1052,9 @@ class VectorAmplitude(Sparse):
     :math:`\phi_m (m)` of the form:
 
     .. math::
-        \phi_m (m) = \frac{\alpha_s}{2} \int_\Omega \, w(r)
+        \phi_m (m) = \alpha_s \int_\Omega \, w(r)
         \Big | \, \vec{m}(r) - \vec{m}^{(ref)}(r) \, \Big |^{p_s(r)} \, dv
-        + \sum_{j=x,y,z} \frac{\alpha_j}{2} \int_\Omega \, w(r)
+        + \sum_{j=x,y,z} \alpha_j \int_\Omega \, w(r)
         \Bigg | \, \frac{\partial |\vec{m}|}{\partial \xi_j} \, \bigg |^{p_j(r)} \, dv
 
     where :math:`\vec{m}(r)` is the model, :math:`\vec{m}^{(ref)}(r)` is the reference model,
@@ -1114,9 +1114,9 @@ class VectorAmplitude(Sparse):
     objective functions of the form:
 
     .. math::
-        \phi_m (\mathbf{m}) = \frac{\alpha_s}{2}
+        \phi_m (\mathbf{m}) = \alpha_s
         \Big \| \, \mathbf{W_s}^{\! (k)} \, \Delta \mathbf{\bar{m}} \, \Big \|^2
-        + \sum_{j=x,y,z} \frac{\alpha_j}{2} \Big \| \, \mathbf{W_j}^{\! (k)} \mathbf{G_j \, \bar{m}} \, \Big \|^2
+        + \sum_{j=x,y,z} \alpha_j \Big \| \, \mathbf{W_j}^{\! (k)} \mathbf{G_j \, \bar{m}} \, \Big \|^2
 
     where
 
@@ -1181,9 +1181,9 @@ class VectorAmplitude(Sparse):
     the objective function becomes:
 
     .. math::
-        \phi_m (\mathbf{m}) = \frac{\alpha_s}{2}
+        \phi_m (\mathbf{m}) = \alpha_s
         \Big \| \, \mathbf{W_s}^{\! (k)} \, \Delta \mathbf{\bar{m}} \, \Big \|^2
-        + \sum_{j=x,y,z} \frac{\alpha_j}{2} \Big \| \, \mathbf{W_j}^{\! (k)} \mathbf{G_j \, \Delta \bar{m}} \, \Big \|^2
+        + \sum_{j=x,y,z} \alpha_j \Big \| \, \mathbf{W_j}^{\! (k)} \mathbf{G_j \, \Delta \bar{m}} \, \Big \|^2
 
     This functionality is used by setting the `reference_model_in_smooth` parameter
     to ``True``.

--- a/examples/20-published/plot_tomo_joint_with_volume.py
+++ b/examples/20-published/plot_tomo_joint_with_volume.py
@@ -42,7 +42,7 @@ class Volume(objective_function.BaseObjectiveFunction):
 
     .. math::
 
-        \phi_v = \frac{1}{2}|| \int_V m dV - \text{knownVolume} ||^2
+        \phi_v = || \int_V m dV - \text{knownVolume} ||^2
     """
 
     def __init__(self, mesh, knownVolume=0.0, **kwargs):
@@ -60,25 +60,27 @@ class Volume(objective_function.BaseObjectiveFunction):
         self._knownVolume = utils.validate_float("knownVolume", value, min_val=0.0)
 
     def __call__(self, m):
-        return 0.5 * (self.estVol(m) - self.knownVolume) ** 2
+        return (self.estVol(m) - self.knownVolume) ** 2
 
     def estVol(self, m):
         return np.inner(self.mesh.cell_volumes, m)
 
     def deriv(self, m):
         # return (self.mesh.cell_volumes * np.inner(self.mesh.cell_volumes, m))
-        return self.mesh.cell_volumes * (
-            self.knownVolume - np.inner(self.mesh.cell_volumes, m)
-        )
+        return (
+            2
+            * self.mesh.cell_volumes
+            * (self.knownVolume - np.inner(self.mesh.cell_volumes, m))
+        )  # factor of 2 from deriv of ||estVol - knownVol||^2
 
     def deriv2(self, m, v=None):
         if v is not None:
-            return utils.mkvc(
+            return 2 * utils.mkvc(
                 self.mesh.cell_volumes * np.inner(self.mesh.cell_volumes, v)
             )
         else:
             # TODO: this is inefficent. It is a fully dense matrix
-            return sp.csc_matrix(
+            return 2 * sp.csc_matrix(
                 np.outer(self.mesh.cell_volumes, self.mesh.cell_volumes)
             )
 

--- a/tests/base/test_cross_gradient.py
+++ b/tests/base/test_cross_gradient.py
@@ -96,7 +96,7 @@ class CrossGradientTensor2D(unittest.TestCase):
 
         cross_grad = self.cross_grad
 
-        v1 = 0.5 * np.sum(np.abs(cross_grad.calculate_cross_gradient(m)))
+        v1 = np.sum(np.abs(cross_grad.calculate_cross_gradient(m)))
         v2 = cross_grad(m)
         self.assertEqual(v1, v2)
 

--- a/tests/base/test_objective_function.py
+++ b/tests/base/test_objective_function.py
@@ -276,13 +276,11 @@ class TestBaseObjFct(unittest.TestCase):
         r1 = phi1.W * m
         r2 = phi2.W * m
 
-        print(phi(m), 0.5 * np.inner(r, r))
+        print(phi(m), np.inner(r, r))
 
-        self.assertTrue(np.allclose(phi(m), 0.5 * np.inner(r, r)))
+        self.assertTrue(np.allclose(phi(m), np.inner(r, r)))
         self.assertTrue(
-            np.allclose(
-                phi(m), 0.5 * (alpha1 * np.inner(r1, r1) + alpha2 * np.inner(r2, r2))
-            )
+            np.allclose(phi(m), (alpha1 * np.inner(r1, r1) + alpha2 * np.inner(r2, r2)))
         )
 
     def test_ComboConstruction(self):

--- a/tests/base/test_pgi_regularization.py
+++ b/tests/base/test_pgi_regularization.py
@@ -4,6 +4,7 @@ import discretize
 import numpy as np
 from pymatsolver import SolverLU
 from scipy.stats import multivariate_normal
+
 from SimPEG import regularization
 from SimPEG.maps import Wires
 from SimPEG.utils import WeightedGaussianMixture, mkvc
@@ -84,10 +85,8 @@ class TestPGI(unittest.TestCase):
         # check score value
         dm = self.model - mref
         score_approx0 = reg(self.model)
-        score_approx1 = dm.dot(reg.deriv2(self.model, dm))
-        passed_score_approx = np.allclose(score_approx0, score_approx1)
-        self.assertTrue(passed_score_approx)
-
+        score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
+        np.testing.assert_almost_equal(score_approx0, score_approx1)
         reg.objfcts[0].approx_eval = False
         score = reg(self.model) - reg(mref)
         passed_score = np.allclose(score_approx0, score, rtol=1e-4)
@@ -192,9 +191,8 @@ class TestPGI(unittest.TestCase):
         # check score value
         dm = self.model - mref
         score_approx0 = reg(self.model)
-        score_approx1 = dm.dot(reg.deriv2(self.model, dm))
-        passed_score_approx = np.allclose(score_approx0, score_approx1)
-        self.assertTrue(passed_score_approx)
+        score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
+        np.testing.assert_almost_equal(score_approx0, score_approx1)
         reg.objfcts[0].approx_eval = False
         score = reg(self.model) - reg(mref)
         passed_score = np.allclose(score_approx0, score, rtol=1e-4)
@@ -296,9 +294,8 @@ class TestPGI(unittest.TestCase):
         # check score value
         dm = self.model - mref
         score_approx0 = reg(self.model)
-        score_approx1 = dm.dot(reg.deriv2(self.model, dm))
-        passed_score_approx = np.allclose(score_approx0, score_approx1)
-        self.assertTrue(passed_score_approx)
+        score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
+        np.testing.assert_almost_equal(score_approx0, score_approx1)
         reg.objfcts[0].approx_eval = False
         score = reg(self.model) - reg(mref)
         passed_score = np.allclose(score_approx0, score, rtol=1e-4)
@@ -400,9 +397,8 @@ class TestPGI(unittest.TestCase):
         # check score value
         dm = self.model - mref
         score_approx0 = reg(self.model)
-        score_approx1 = dm.dot(reg.deriv2(self.model, dm))
-        passed_score_approx = np.allclose(score_approx0, score_approx1)
-        self.assertTrue(passed_score_approx)
+        score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
+        np.testing.assert_almost_equal(score_approx0, score_approx1)
         reg.objfcts[0].approx_eval = False
         score = reg(self.model) - reg(mref)
         passed_score = np.allclose(score_approx0, score, rtol=1e-4)

--- a/tests/base/test_pgi_regularization.py
+++ b/tests/base/test_pgi_regularization.py
@@ -84,7 +84,7 @@ class TestPGI(unittest.TestCase):
         # check score value
         dm = self.model - mref
         score_approx0 = reg(self.model)
-        score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
+        score_approx1 = dm.dot(reg.deriv2(self.model, dm))
         passed_score_approx = np.allclose(score_approx0, score_approx1)
         self.assertTrue(passed_score_approx)
 
@@ -192,7 +192,7 @@ class TestPGI(unittest.TestCase):
         # check score value
         dm = self.model - mref
         score_approx0 = reg(self.model)
-        score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
+        score_approx1 = dm.dot(reg.deriv2(self.model, dm))
         passed_score_approx = np.allclose(score_approx0, score_approx1)
         self.assertTrue(passed_score_approx)
         reg.objfcts[0].approx_eval = False
@@ -296,7 +296,7 @@ class TestPGI(unittest.TestCase):
         # check score value
         dm = self.model - mref
         score_approx0 = reg(self.model)
-        score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
+        score_approx1 = dm.dot(reg.deriv2(self.model, dm))
         passed_score_approx = np.allclose(score_approx0, score_approx1)
         self.assertTrue(passed_score_approx)
         reg.objfcts[0].approx_eval = False
@@ -400,7 +400,7 @@ class TestPGI(unittest.TestCase):
         # check score value
         dm = self.model - mref
         score_approx0 = reg(self.model)
-        score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
+        score_approx1 = dm.dot(reg.deriv2(self.model, dm))
         passed_score_approx = np.allclose(score_approx0, score_approx1)
         self.assertTrue(passed_score_approx)
         reg.objfcts[0].approx_eval = False

--- a/tests/base/test_pgi_regularization.py
+++ b/tests/base/test_pgi_regularization.py
@@ -86,7 +86,7 @@ class TestPGI(unittest.TestCase):
         dm = self.model - mref
         score_approx0 = reg(self.model)
         score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
-        np.testing.assert_almost_equal(score_approx0, score_approx1)
+        np.testing.assert_allclose(score_approx0, score_approx1)
         reg.objfcts[0].approx_eval = False
         score = reg(self.model) - reg(mref)
         passed_score = np.allclose(score_approx0, score, rtol=1e-4)
@@ -192,7 +192,7 @@ class TestPGI(unittest.TestCase):
         dm = self.model - mref
         score_approx0 = reg(self.model)
         score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
-        np.testing.assert_almost_equal(score_approx0, score_approx1)
+        np.testing.assert_allclose(score_approx0, score_approx1)
         reg.objfcts[0].approx_eval = False
         score = reg(self.model) - reg(mref)
         passed_score = np.allclose(score_approx0, score, rtol=1e-4)
@@ -295,7 +295,7 @@ class TestPGI(unittest.TestCase):
         dm = self.model - mref
         score_approx0 = reg(self.model)
         score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
-        np.testing.assert_almost_equal(score_approx0, score_approx1)
+        np.testing.assert_allclose(score_approx0, score_approx1)
         reg.objfcts[0].approx_eval = False
         score = reg(self.model) - reg(mref)
         passed_score = np.allclose(score_approx0, score, rtol=1e-4)
@@ -398,7 +398,7 @@ class TestPGI(unittest.TestCase):
         dm = self.model - mref
         score_approx0 = reg(self.model)
         score_approx1 = 0.5 * dm.dot(reg.deriv2(self.model, dm))
-        np.testing.assert_almost_equal(score_approx0, score_approx1)
+        np.testing.assert_allclose(score_approx0, score_approx1)
         reg.objfcts[0].approx_eval = False
         score = reg(self.model) - reg(mref)
         passed_score = np.allclose(score_approx0, score, rtol=1e-4)

--- a/tests/em/em1d/test_EM1D_FD_jac_layers.py
+++ b/tests/em/em1d/test_EM1D_FD_jac_layers.py
@@ -155,8 +155,10 @@ class EM1D_FD_Jacobian_Test_MagDipole(unittest.TestCase):
 
         def misfit(m, dobs):
             dpred = self.sim.dpred(m)
-            misfit = 0.5 * np.linalg.norm(dpred - dobs) ** 2
-            dmisfit = self.sim.Jtvec(m, dr)
+            misfit = np.linalg.norm(dpred - dobs) ** 2
+            dmisfit = 2.0 * self.sim.Jtvec(
+                m, dr
+            )  # derivative of ||dpred - dobs||^2 gives factor of 2
             return misfit, dmisfit
 
         def derChk(m):
@@ -314,8 +316,10 @@ class EM1D_FD_Jacobian_Test_CircularLoop(unittest.TestCase):
 
         def misfit(m, dobs):
             dpred = self.sim.dpred(m)
-            misfit = 0.5 * np.linalg.norm(dpred - dobs) ** 2
-            dmisfit = self.sim.Jtvec(m, dr)
+            misfit = np.linalg.norm(dpred - dobs) ** 2
+            dmisfit = 2 * self.sim.Jtvec(
+                m, dr
+            )  # derivative of ||dpred - dobs||^2 gives factor of 2
             return misfit, dmisfit
 
         def derChk(m):
@@ -450,8 +454,10 @@ class EM1D_FD_Jacobian_Test_LineCurrent(unittest.TestCase):
 
         def misfit(m, dobs):
             dpred = self.sim.dpred(m)
-            misfit = 0.5 * np.linalg.norm(dpred - dobs) ** 2
-            dmisfit = self.sim.Jtvec(m, dr)
+            misfit = np.linalg.norm(dpred - dobs) ** 2
+            dmisfit = 2 * self.sim.Jtvec(
+                m, dr
+            )  # derivative of ||dpred - dobs||^2 gives factor of 2
             return misfit, dmisfit
 
         def derChk(m):

--- a/tests/pf/test_pf_quadtree_inversion_linear.py
+++ b/tests/pf/test_pf_quadtree_inversion_linear.py
@@ -463,7 +463,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
         self.assertAlmostEqual(model_residual, 0.1, delta=0.1)
 
         # Check data converged to less than 10% of target misfit
-        data_misfit = 2.0 * self.grav_inv.invProb.dmisfit(self.grav_model)
+        data_misfit = self.grav_inv.invProb.dmisfit(self.grav_model)
         self.assertLess(data_misfit, dpred.shape[0] * 1.15)
 
     def test_quadtree_mag_inverse(self):
@@ -481,7 +481,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
         self.assertAlmostEqual(model_residual, 0.01, delta=0.05)
 
         # Check data converged to less than 10% of target misfit
-        data_misfit = 2.0 * self.mag_inv.invProb.dmisfit(self.mag_model)
+        data_misfit = self.mag_inv.invProb.dmisfit(self.mag_model)
         self.assertLess(data_misfit, dpred.shape[0] * 1.1)
 
     def test_quadtree_grav_inverse_activecells(self):
@@ -501,7 +501,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
         self.assertAlmostEqual(model_residual, 0.1, delta=0.1)
 
         # Check data converged to less than 10% of target misfit
-        data_misfit = 2.0 * self.grav_inv_active.invProb.dmisfit(
+        data_misfit = self.grav_inv_active.invProb.dmisfit(
             self.grav_model[self.active_cells]
         )
         self.assertLess(data_misfit, dpred.shape[0] * 1.1)
@@ -530,7 +530,7 @@ class QuadTreeLinProblemTest(unittest.TestCase):
         self.assertAlmostEqual(model_residual, 0.01, delta=0.05)
 
         # Check data converged to less than 10% of target misfit
-        data_misfit = 2.0 * self.mag_inv_active.invProb.dmisfit(
+        data_misfit = self.mag_inv_active.invProb.dmisfit(
             self.mag_model[self.active_cells]
         )
         self.assertLess(data_misfit, dpred.shape[0] * 1.1)

--- a/tests/utils/test_mat_utils.py
+++ b/tests/utils/test_mat_utils.py
@@ -75,7 +75,7 @@ class TestEigenvalues(unittest.TestCase):
 
     def test_dm_eigenvalue_by_power_iteration(self):
         # Test for a single data misfit
-        dmis_matrix = self.G.T.dot((self.dmis.W**2).dot(self.G))
+        dmis_matrix = 2 * self.G.T.dot((self.dmis.W**2).dot(self.G))
         field = self.dmis.simulation.fields(self.true_model)
         max_eigenvalue_numpy, _ = eigsh(dmis_matrix, k=1)
         max_eigenvalue_directive = eigenvalue_by_power_iteration(
@@ -89,7 +89,7 @@ class TestEigenvalues(unittest.TestCase):
         WtW = 0.0
         for mult, dm in zip(self.dmiscombo.multipliers, self.dmiscombo.objfcts):
             WtW += mult * dm.W**2
-        dmiscombo_matrix = self.G.T.dot(WtW.dot(self.G))
+        dmiscombo_matrix = 2 * self.G.T.dot(WtW.dot(self.G))
         max_eigenvalue_numpy, _ = eigsh(dmiscombo_matrix, k=1)
         max_eigenvalue_directive = eigenvalue_by_power_iteration(
             self.dmiscombo, self.true_model, n_pw_iter=30
@@ -110,7 +110,7 @@ class TestEigenvalues(unittest.TestCase):
 
     def test_combo_eigenvalue_by_power_iteration(self):
         reg_maxtrix = self.reg.deriv2(self.true_model)
-        dmis_matrix = self.G.T.dot((self.dmis.W**2).dot(self.G))
+        dmis_matrix = 2 * self.G.T.dot((self.dmis.W**2).dot(self.G))
         combo_matrix = dmis_matrix + self.beta * reg_maxtrix
         max_eigenvalue_numpy, _ = eigsh(combo_matrix, k=1)
         max_eigenvalue_directive = eigenvalue_by_power_iteration(


### PR DESCRIPTION
#### Summary
Remove the factor of 1/2 in front of data misfit and regularization terms. This has caused many headaches as outlined in #763. 

One important note:
- the Joint Total Variation never had a 1/2 in front. The documentation and the implementation did not match each other (the documentation stated there was a factor of 1/2, but in the code, there wasn't). So this will change _will_ require that scaling factors used in front of the joint total variation regularization be multiplied by a factor of 2 to obtain the same result if a fixed value was used (cc @jcapriot: I would appreciate a double-check from you on this if you don't mind!)  

#### Todos and input! 
- [x] I would appreciate input from @santisoler and / or @thast on the PGI updates 
- [x] @fourndo : the sparse norms were more straightforward, but I would still appreciate your eyes on this
- [x] if anyone is willing to run some inversion examples before / after this change, that would be a much appreciated test! We should still start at approximately the same beta when using the beta estimator. I will test out a few examples, but it would not hurt to have others test this out too! 

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
This will close #763 

#### What does this implement/fix?
- remove the factor of 1/2 in front of data misfit, regularization terms
- update the target misfit directive to also remove the factor of 1/2
- update documentation to remove factor of 1/2 
- update derivatives to now have a factor of 2
- update tests accordingly 

#### Summary for Squash and Merge

Remove the factor of 1/2 in front of data misfit and regularization terms. Add a factor of 2 to their derivatives. Update target misfit directives to account for the missing 1/2 factor. Update documentation to remove the factor of 1/2. Update tests accordingly (#1332 for PGI).

