### PR TITLE
Bump versions of flake8 and black and pin flake plugins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,14 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         language_version: python3
-        additional_dependencies: [flake8-bugbear, flake8-builtins, flake8-mutable, flake8-rst-docstrings, flake8-docstrings]
+        additional_dependencies: [
+          flake8-bugbear==23.12.2,
+          flake8-builtins==2.2.0,
+          flake8-mutable==1.2.0,
+          flake8-rst-docstrings==0.3.0,
+          flake8-docstrings==1.7.0,
+        ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,9 @@ repos:
     hooks:
       - id: flake8
         language_version: python3
-        additional_dependencies: [
-          flake8-bugbear==23.12.2,
-          flake8-builtins==2.2.0,
-          flake8-mutable==1.2.0,
-          flake8-rst-docstrings==0.3.0,
-          flake8-docstrings==1.7.0,
-        ]
+        additional_dependencies:
+          - flake8-bugbear==23.12.2
+          - flake8-builtins==2.2.0
+          - flake8-mutable==1.2.0
+          - flake8-rst-docstrings==0.3.0
+          - flake8-docstrings==1.7.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.12.1
     hooks:
       - id: black
         language_version: python3

--- a/environment_test.yml
+++ b/environment_test.yml
@@ -41,9 +41,9 @@ dependencies:
   # Linters and code style
   - pre-commit
   - black==23.12.1
-  - flake8
-  - flake8-bugbear
-  - flake8-builtins
-  - flake8-mutable
-  - flake8-rst-docstrings
-  - flake8-docstrings
+  - flake8==7.0.0
+  - flake8-bugbear==23.12.2
+  - flake8-builtins==2.2.0
+  - flake8-mutable==1.2.0
+  - flake8-rst-docstrings==0.3.0
+  - flake8-docstrings==1.7.0

--- a/environment_test.yml
+++ b/environment_test.yml
@@ -40,7 +40,7 @@ dependencies:
   - choclo
   # Linters and code style
   - pre-commit
-  - black==23.1.0
+  - black==23.12.1
   - flake8
   - flake8-bugbear
   - flake8-builtins

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,7 +19,7 @@ jupyter
 toolz
 empymod>=2.0.0
 scooby
-black==23.1.0
+black==23.12.1
 pre-commit
 twine
 memory_profiler

--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,4 +1,4 @@
-black==23.1.0
+black==23.12.1
 flake8
 flake8-bugbear
 flake8-builtins

--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,7 +1,7 @@
 black==23.12.1
-flake8
-flake8-bugbear
-flake8-builtins
-flake8-mutable
-flake8-rst-docstrings
-flake8-docstrings
+flake8==7.0.0
+flake8-bugbear==23.12.2,
+flake8-builtins==2.2.0
+flake8-mutable==1.2.0
+flake8-rst-docstrings==0.3.0
+flake8-docstrings==1.7.0

--- a/requirements_style.txt
+++ b/requirements_style.txt
@@ -1,6 +1,6 @@
 black==23.12.1
 flake8==7.0.0
-flake8-bugbear==23.12.2,
+flake8-bugbear==23.12.2
 flake8-builtins==2.2.0
 flake8-mutable==1.2.0
 flake8-rst-docstrings==0.3.0


### PR DESCRIPTION
#### Summary

Bump versions of `black`, `flake8` and flake plugins to their latest available versions in PyPI and in conda-forge. Pin versions of `flake8` and its plugins in the `requirements_style.txt`, `environment_test.yml` and `pre-commit` configuration files. This prevents inconsistencies between the Style Checks run in Azure and the ones run locally through `pre-commit` or `make flake`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
