### PR TITLE
Fix implementation of coterminal function

### DIFF
--- a/SimPEG/utils/mat_utils.py
+++ b/SimPEG/utils/mat_utils.py
@@ -409,7 +409,7 @@ def coterminal(theta):
         Coterminal angles
 
     """
-    coterminal = np.sign(theta) * (np.abs(theta) % np.pi)
+    coterminal = (theta + np.pi) % (2 * np.pi) - np.pi
     return coterminal
 
 

--- a/SimPEG/utils/mat_utils.py
+++ b/SimPEG/utils/mat_utils.py
@@ -396,7 +396,7 @@ def coterminal(theta):
         \theta = 2\pi N + \gamma
 
     and *N* is an integer, the function returns the value of :math:`\gamma`.
-    The coterminal angle :math:`\gamma` is within the range :math:`[-\pi , \pi]`.
+    The coterminal angle :math:`\gamma` is within the range :math:`[-\pi , \pi)`.
 
     Parameters
     ----------

--- a/SimPEG/utils/mat_utils.py
+++ b/SimPEG/utils/mat_utils.py
@@ -409,12 +409,8 @@ def coterminal(theta):
         Coterminal angles
 
     """
-    sub = theta[np.abs(theta) >= np.pi]
-    sub = -np.sign(sub) * (2 * np.pi - np.abs(sub))
-
-    theta[np.abs(theta) >= np.pi] = sub
-
-    return theta
+    coterminal = np.sign(theta) * (np.abs(theta) % np.pi)
+    return coterminal
 
 
 def define_plane_from_points(xyz1, xyz2, xyz3):

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -363,8 +363,8 @@ class TestCoterminalAngle:
 
     @pytest.mark.parametrize(
         "coterminal_angle",
-        (0, np.pi / 2, np.pi, -np.pi / 2),
-        ids=("0", "pi/2", "pi", "-pi/2"),
+        (0, np.pi / 2, -np.pi, -np.pi / 2),
+        ids=("0", "pi/2", "-pi", "-pi/2"),
     )
     def test_right_angles(self, coterminal_angle):
         """

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -344,14 +344,45 @@ class TestDownload(unittest.TestCase):
         shutil.rmtree(os.path.expanduser("./test_url"))
 
 
-@pytest.mark.parametrize(
-    "angle", [np.pi, -np.pi, 3 * np.pi, 1.25 * np.pi, -1.25 * np.pi]
-)
-def test_coterminal(angle):
-    coangle = coterminal(angle)
-    assert np.abs(coangle) < np.pi
-    if coangle != 0:
-        assert np.sign(coterminal(angle)) == np.sign(angle)
+class TestCoterminalAngle:
+    """
+    Tests for the coterminal function
+    """
+
+    @pytest.mark.parametrize(
+        "coterminal_angle",
+        (1 / 4 * np.pi, 3 / 4 * np.pi, -3 / 4 * np.pi, -1 / 4 * np.pi),
+        ids=("pi/4", "3/4 pi", "-3/4 pi", "-pi/4"),
+    )
+    def test_angles_in_quadrants(self, coterminal_angle):
+        """
+        Test coterminal for angles in each quadrant
+        """
+        angles = np.array([2 * n * np.pi + coterminal_angle for n in range(-3, 4)])
+        np.testing.assert_allclose(coterminal(angles), coterminal_angle)
+
+    @pytest.mark.parametrize(
+        "coterminal_angle",
+        (0, np.pi / 2, np.pi, -np.pi / 2),
+        ids=("0", "pi/2", "pi", "-pi/2"),
+    )
+    def test_right_angles(self, coterminal_angle):
+        """
+        Test coterminal for right angles
+        """
+        angles = np.array([2 * n * np.pi + coterminal_angle for n in range(-3, 4)])
+        np.testing.assert_allclose(coterminal(angles), coterminal_angle)
+
+    @pytest.mark.parametrize(
+        "angle",
+        [np.pi, -np.pi, 3 * np.pi, 1.25 * np.pi, -1.25 * np.pi],
+        ids=("pi", "-pi", "3 pi", "1.25 pi", "-1.25 pi"),
+    )
+    def test_sign_coterminal(self, angle):
+        coangle = coterminal(angle)
+        assert np.abs(coangle) < np.pi
+        if coangle != 0:
+            assert np.sign(coterminal(angle)) == np.sign(angle)
 
 
 if __name__ == "__main__":

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 import numpy as np
 import scipy.sparse as sp
 import os
@@ -22,6 +23,7 @@ from SimPEG.utils import (
     Counter,
     download,
     surface2ind_topo,
+    coterminal,
 )
 import discretize
 
@@ -340,6 +342,16 @@ class TestDownload(unittest.TestCase):
         # clean up
         shutil.rmtree(os.path.expanduser("./test_urls"))
         shutil.rmtree(os.path.expanduser("./test_url"))
+
+
+@pytest.mark.parametrize(
+    "angle", [np.pi, -np.pi, 3 * np.pi, 1.25 * np.pi, -1.25 * np.pi]
+)
+def test_coterminal(angle):
+    coangle = coterminal(angle)
+    assert np.abs(coangle) < np.pi
+    if coangle != 0:
+        assert np.sign(coterminal(angle)) == np.sign(angle)
 
 
 if __name__ == "__main__":

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -373,17 +373,6 @@ class TestCoterminalAngle:
         angles = np.array([2 * n * np.pi + coterminal_angle for n in range(-3, 4)])
         np.testing.assert_allclose(coterminal(angles), coterminal_angle)
 
-    @pytest.mark.parametrize(
-        "angle",
-        [np.pi, -np.pi, 3 * np.pi, 1.25 * np.pi, -1.25 * np.pi],
-        ids=("pi", "-pi", "3 pi", "1.25 pi", "-1.25 pi"),
-    )
-    def test_sign_coterminal(self, angle):
-        coangle = coterminal(angle)
-        assert np.abs(coangle) < np.pi
-        if coangle != 0:
-            assert np.sign(coterminal(angle)) == np.sign(angle)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix the implementation of the `coterminal` function: use the `mod` operator to ensure that the functions returns the correct coterminal angle defined in $[-\pi, \pi)$. Add more tests.

Fixes #1333

---

PR to address issue #1333 , where the sign of coterminal angles is not preserved. Also fixes potential issues with angle > $2 \pi$

Running the example/03-magnetics/plot_inv_mag_MVI_Sparse_TreeMesh

Before
![old](https://github.com/simpeg/simpeg/assets/55204635/5c8cfa8d-28f9-47d7-8918-bb57c180ad8f)



After
![new](https://github.com/simpeg/simpeg/assets/55204635/bbb7a89d-d49e-4c70-83ff-5928b821a370)

