### PR TITLE
Simplify check for invalid multipliers

### DIFF
--- a/tests/base/test_objective_function.py
+++ b/tests/base/test_objective_function.py
@@ -5,6 +5,8 @@ import unittest
 
 from SimPEG import utils, maps
 from SimPEG import objective_function
+from SimPEG.objective_function import _validate_multiplier
+from SimPEG.utils import Zero
 
 np.random.seed(130)
 
@@ -442,6 +444,41 @@ def test_invalid_objfcts_in_combo():
     msg = "Unrecognized objective function type Dummy in 'objfcts'."
     with pytest.raises(TypeError, match=msg):
         objective_function.ComboObjectiveFunction(objfcts=[phi, invalid_phi])
+
+
+class TestMultiplierValidation:
+    """
+    Test the _validate_multiplier private function.
+    """
+
+    @pytest.mark.parametrize(
+        "multiplier",
+        (
+            3.14,
+            1,
+            np.float64(-15.3),
+            np.float32(-10.2),
+            np.int64(10),
+            np.int32(33),
+            Zero(),
+        ),
+    )
+    def test_valid_multipliers(self, multiplier):
+        """
+        Test function against valid multipliers
+        """
+        _validate_multiplier(multiplier)
+
+    @pytest.mark.parametrize(
+        "multiplier",
+        (np.array([1, 3.14]), np.array(3), [1, 2, 3], "string", True, None),
+    )
+    def test_invalid_multipliers(self, multiplier):
+        """
+        Test function against invalid multipliers
+        """
+        with pytest.raises(TypeError, match="Invalid multiplier"):
+            _validate_multiplier(multiplier)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary

Simplify the check for invalid multipliers in `ComboObjectiveFunction`. Move private methods used for validation of arguments to private functions since they didn't need any other attribute of the class. Add tests for the new checks for invalid multipliers.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
