### PR TITLE
Exponential Sinusoids Simulation

### DIFF
--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -668,7 +668,6 @@ class ExponentialSinusoidSimulation(LinearSimulation):
             G_nodes = np.empty((self.mesh.n_nodes, self.n_kernels))
 
             for i in range(self.n_kernels):
-                print(self.g(i).shape)
                 G_nodes[:, i] = self.g(i)
 
             self._G = (self.mesh.average_node_to_cell @ G_nodes).T @ sdiag(

--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -665,12 +665,13 @@ class ExponentialSinusoidSimulation(LinearSimulation):
         Matrix whose rows are the kernel functions
         """
         if getattr(self, "_G", None) is None:
-            G = np.empty((self.mesh.nC, self.n_kernels))
+            G_nodes = np.empty((self.mesh.n_nodes, self.n_kernels))
 
             for i in range(self.n_kernels):
-                G[:, i] = self.g(i)
+                print(self.g(i).shape)
+                G_nodes[:, i] = self.g(i)
 
-            self._G = (
-                sdiag(self.mesh.cell_volumes) @ (self.mesh.average_node_to_cell @ G).T
+            self._G = (self.mesh.average_node_to_cell @ G_nodes).T @ sdiag(
+                self.mesh.cell_volumes
             )
         return self._G

--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -557,11 +557,20 @@ class LinearSimulation(BaseSimulation):
 class ExponentialSinusoidSimulation(LinearSimulation):
     r"""
     This is the simulation class for the linear problem consisting of
-    exponentially decaying sinusoids. The rows of the G matrix are
+    exponentially decaying sinusoids. The kernel functions take the form:
 
     .. math::
 
         \int_x e^{p j_k x} \cos(\pi q j_k x) \quad, j_k \in [j_0, ..., j_n]
+
+    The model is defined at cell centers while the kernel functions are defined on nodes.
+    The trapezoid rule is used to evaluate the integral
+
+    .. math::
+
+        d_j = \int g_j(x) m(x) dx
+
+    to define our data.
     """
 
     def __init__(self, n_kernels=20, p=-0.25, q=0.25, j0=0.0, jn=60.0, **kwargs):

--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -567,6 +567,14 @@ class ExponentialSinusoidSimulation(LinearSimulation):
         \int_x e^{p j_k x} \cos(\pi q j_k x) \quad, j_k \in [j_0, ..., j_n]
     """
 
+    def __init__(self, n_kernels=20, p=-0.25, q=0.25, j0=0.0, jn=60.0, **kwargs):
+        self.n_kernels = n_kernels
+        self.p = p
+        self.q = q
+        self.j0 = j0
+        self.jn = jn
+        super(ExponentialSinusoidSimulation, self).__init__(**kwargs)
+
     @property
     def n_kernels(self):
         """The number of kernels for the linear problem
@@ -637,14 +645,6 @@ class ExponentialSinusoidSimulation(LinearSimulation):
     def jn(self, value):
         self._jn = validate_float("jn", value)
 
-    def __init__(self, n_kernels=20, p=-0.25, q=0.25, j0=0.0, jn=60.0, **kwargs):
-        self.n_kernels = n_kernels
-        self.p = p
-        self.q = q
-        self.j0 = j0
-        self.jn = jn
-        super(ExponentialSinusoidSimulation, self).__init__(**kwargs)
-
     @property
     def jk(self):
         """
@@ -658,8 +658,8 @@ class ExponentialSinusoidSimulation(LinearSimulation):
         """
         Kernel functions for the decaying oscillating exponential functions.
         """
-        return np.exp(self.p * self.jk[k] * self.mesh.cell_centers_x) * np.cos(
-            np.pi * self.q * self.jk[k] * self.mesh.cell_centers_x
+        return np.exp(self.p * self.jk[k] * self.mesh.nodes_x) * np.cos(
+            np.pi * self.q * self.jk[k] * self.mesh.nodes_x
         )
 
     @property
@@ -671,7 +671,9 @@ class ExponentialSinusoidSimulation(LinearSimulation):
             G = np.empty((self.n_kernels, self.mesh.nC))
 
             for i in range(self.n_kernels):
-                G[i, :] = self.g(i) * self.mesh.h[0]
+                G[i, :] = self.mesh.cell_volumes * (
+                    self.mesh.average_node_to_cell @ self.g(i)
+                )
 
             self._G = G
         return self._G

--- a/SimPEG/simulation.py
+++ b/SimPEG/simulation.py
@@ -8,7 +8,7 @@ import warnings
 
 from discretize.base import BaseMesh
 from discretize import TensorMesh
-from discretize.utils import unpack_widths
+from discretize.utils import unpack_widths, sdiag
 
 from . import props
 from .data import SyntheticData, Data
@@ -668,12 +668,12 @@ class ExponentialSinusoidSimulation(LinearSimulation):
         Matrix whose rows are the kernel functions
         """
         if getattr(self, "_G", None) is None:
-            G = np.empty((self.n_kernels, self.mesh.nC))
+            G = np.empty((self.mesh.nC, self.n_kernels))
 
             for i in range(self.n_kernels):
-                G[i, :] = self.mesh.cell_volumes * (
-                    self.mesh.average_node_to_cell @ self.g(i)
-                )
+                G[:, i] = self.g(i)
 
-            self._G = G
+            self._G = (
+                sdiag(self.mesh.cell_volumes) @ (self.mesh.average_node_to_cell @ G).T
+            )
         return self._G

--- a/tests/base/test_simulation.py
+++ b/tests/base/test_simulation.py
@@ -19,32 +19,6 @@ class TestLinearSimulation(unittest.TestCase):
 
         self.mtrue = mtrue
 
-    def test_forward(self):
-        data = np.r_[
-            7.50000000e-02,
-            5.34102961e-02,
-            5.26315566e-03,
-            -3.92235199e-02,
-            -4.22361894e-02,
-            -1.29419602e-02,
-            1.30060891e-02,
-            1.73572943e-02,
-            7.78056876e-03,
-            -1.49689823e-03,
-            -4.50212858e-03,
-            -3.14559131e-03,
-            -9.55761370e-04,
-            3.53963158e-04,
-            7.24902205e-04,
-            6.06022770e-04,
-            3.36635644e-04,
-            7.48637479e-05,
-            -1.10094573e-04,
-            -1.84905476e-04,
-        ]
-
-        assert np.allclose(data, self.sim.dpred(self.mtrue))
-
     def test_make_synthetic_data(self):
         dclean = self.sim.dpred(self.mtrue)
         data = self.sim.make_synthetic_data(self.mtrue)


### PR DESCRIPTION
### Summary
- define the kernel functions at cell nodes rather than at cell centers 
- also move the __init__ from the middle of the class to the top of the class definition

### Reasoning 
- kernel functions should be defined on nodes as we think of them being piecewise linear (rather than discontinuous as we talk about at cell centers). This makes it more in line with other physical simulations
- this then also introduces techniques for discrete integration (eg Gaussian quadrature) 
- both of these things are important for teaching purposes

### Notes
- [x] there is one test where we manually check the output of the data. This will fail currently. We should decide whether we want to keep this test and update it or simply remove it. 