### PR TITLE
ISSUE-1341: Set parent of objective functions

### DIFF
--- a/SimPEG/objective_function.py
+++ b/SimPEG/objective_function.py
@@ -388,9 +388,6 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
 
         super().__init__(nP=nP)
 
-        for fct in objfcts:
-            fct.parent = self
-
         self.objfcts = objfcts
         self._multipliers = multipliers
         self._unpack_on_add = unpack_on_add
@@ -543,6 +540,8 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
                     f"{function.__class__.__name__} in 'objfcts'. "
                     "All objective functions must inherit from BaseObjectiveFunction."
                 )
+            function.parent = self
+
         number_of_parameters = [f.nP for f in objective_functions if f.nP != "*"]
         if number_of_parameters:
             all_equal = all(np.equal(number_of_parameters, number_of_parameters[0]))

--- a/SimPEG/objective_function.py
+++ b/SimPEG/objective_function.py
@@ -390,9 +390,6 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
 
         super().__init__(nP=nP)
 
-        for fun in objfcts:
-            fun.parent = self
-
         self.objfcts = objfcts
         self._multipliers = multipliers
         self._unpack_on_add = unpack_on_add

--- a/SimPEG/objective_function.py
+++ b/SimPEG/objective_function.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import scipy.sparse as sp
 

--- a/SimPEG/objective_function.py
+++ b/SimPEG/objective_function.py
@@ -360,7 +360,12 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
 
     _multiplier_types = (float, None, Zero, np.float64, int, np.integer)
 
-    def __init__(self, objfcts=None, multipliers=None, unpack_on_add=True):
+    def __init__(
+        self,
+        objfcts: list[BaseObjectiveFunction] | None = None,
+        multipliers=None,
+        unpack_on_add=True,
+    ):
         # Define default lists if None
         if objfcts is None:
             objfcts = []
@@ -380,6 +385,10 @@ class ComboObjectiveFunction(BaseObjectiveFunction):
             nP = None
 
         super().__init__(nP=nP)
+
+        for fct in objfcts:
+            fct.parent = self
+
         self.objfcts = objfcts
         self._multipliers = multipliers
         self._unpack_on_add = unpack_on_add

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -71,7 +71,7 @@ class BaseRegularization(BaseObjectiveFunction):
         if (key := "indActive") in kwargs:
             if active_cells is not None:
                 raise ValueError(
-                    f"Cannot simultanously pass 'active_cells' and '{key}'. "
+                    f"Cannot simultaneously pass 'active_cells' and '{key}'. "
                     "Pass 'active_cells' only."
                 )
             warnings.warn(
@@ -86,7 +86,7 @@ class BaseRegularization(BaseObjectiveFunction):
         if (key := "cell_weights") in kwargs:
             if weights is not None:
                 raise ValueError(
-                    f"Cannot simultanously pass 'weights' and '{key}'. "
+                    f"Cannot simultaneously pass 'weights' and '{key}'. "
                     "Pass 'weights' only."
                 )
             warnings.warn(
@@ -1588,7 +1588,7 @@ class WeightedLeastSquares(ComboObjectiveFunction):
         if (key := "indActive") in kwargs:
             if active_cells is not None:
                 raise ValueError(
-                    f"Cannot simultanously pass 'active_cells' and '{key}'. "
+                    f"Cannot simultaneously pass 'active_cells' and '{key}'. "
                     "Pass 'active_cells' only."
                 )
             warnings.warn(

--- a/SimPEG/regularization/base.py
+++ b/SimPEG/regularization/base.py
@@ -1665,8 +1665,13 @@ class WeightedLeastSquares(ComboObjectiveFunction):
             objfcts = kwargs.pop("objfcts")
 
         super().__init__(objfcts=objfcts, unpack_on_add=False, **kwargs)
+
+        for fun in objfcts:
+            fun.parent = self
+
         if active_cells is not None:
             self.active_cells = active_cells
+
         self.mapping = mapping
         self.reference_model = reference_model
         self.reference_model_in_smooth = reference_model_in_smooth

--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -664,6 +664,11 @@ class TestParent:
         with pytest.raises(TypeError, match=msg):
             regularization.parent = invalid_parent
 
+    def test_default_parent(self, regularization):
+        """Test setting a default parent class to a BaseRegularization."""
+        parent = ComboObjectiveFunction(objfcts=[regularization])
+        assert regularization.parent is parent
+
 
 class TestWeightsKeys:
     """

--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -682,7 +682,8 @@ class TestParent:
 
     def test_default_parent(self, regularization):
         """Test setting default parent class to a BaseRegularization."""
-        parent = ComboObjectiveFunction(objfcts=[regularization])
+        mesh = discretize.TensorMesh([3, 4, 5])
+        parent = WeightedLeastSquares(mesh, objfcts=[regularization])
         assert regularization.parent is parent
 
 

--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -665,7 +665,7 @@ class TestParent:
             regularization.parent = invalid_parent
 
     def test_default_parent(self, regularization):
-        """Test setting a default parent class to a BaseRegularization."""
+        """Test setting default parent class to a BaseRegularization."""
         parent = ComboObjectiveFunction(objfcts=[regularization])
         assert regularization.parent is parent
 

--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -757,7 +757,7 @@ class TestDeprecatedArguments:
     def test_active_cells(self, mesh, regularization_class):
         """Test indActive and active_cells arguments."""
         active_cells = np.ones(len(mesh), dtype=bool)
-        msg = "Cannot simultanously pass 'active_cells' and 'indActive'."
+        msg = "Cannot simultaneously pass 'active_cells' and 'indActive'."
         with pytest.raises(ValueError, match=msg):
             regularization_class(
                 mesh, active_cells=active_cells, indActive=active_cells
@@ -766,7 +766,7 @@ class TestDeprecatedArguments:
     def test_weights(self, mesh):
         """Test cell_weights and weights."""
         weights = np.ones(len(mesh))
-        msg = "Cannot simultanously pass 'weights' and 'cell_weights'."
+        msg = "Cannot simultaneously pass 'weights' and 'cell_weights'."
         with pytest.raises(ValueError, match=msg):
             BaseRegularization(mesh, weights=weights, cell_weights=weights)
 


### PR DESCRIPTION
#### Summary
Assign the parent on the list of  `ComboObjectiveFunction.objfcts`, such that a child function can navigate up the tree and interact with its siblings. 

We could eventually apply the same mechanics to the `BaseObjectiveFunction`, such that the misfits can also have parental relationships, but that's beyond scope.

#### Reference issue
Closes #1341 

#### What does this implement/fix?
The parent on the objective function was never set, and prevented the Sparse amplitude to apply the `gradient_type = "total"`
