### PR TITLE
Ravel instead of flatten

### DIFF
--- a/SimPEG/regularization/regularization_mesh.py
+++ b/SimPEG/regularization/regularization_mesh.py
@@ -1,9 +1,9 @@
 import numpy as np
 import scipy.sparse as sp
+
 from SimPEG.utils.code_utils import deprecate_property, validate_active_indices
 
-from .. import props
-from .. import utils
+from .. import props, utils
 
 ###############################################################################
 #                                                                             #
@@ -553,7 +553,7 @@ class RegularizationMesh(props.BaseSimPEG):
         if getattr(self, "_cell_distances_x", None) is None:
             self._cell_distances_x = self.cell_gradient_x.max(
                 axis=1
-            ).toarray().flatten() ** (-1.0)
+            ).toarray().ravel() ** (-1.0)
 
         return self._cell_distances_x
 
@@ -569,7 +569,7 @@ class RegularizationMesh(props.BaseSimPEG):
         if getattr(self, "_cell_distances_y", None) is None:
             self._cell_distances_y = self.cell_gradient_y.max(
                 axis=1
-            ).toarray().flatten() ** (-1.0)
+            ).toarray().ravel() ** (-1.0)
 
         return self._cell_distances_y
 
@@ -585,7 +585,7 @@ class RegularizationMesh(props.BaseSimPEG):
         if getattr(self, "_cell_distances_z", None) is None:
             self._cell_distances_z = self.cell_gradient_z.max(
                 axis=1
-            ).toarray().flatten() ** (-1.0)
+            ).toarray().ravel() ** (-1.0)
 
         return self._cell_distances_z
 


### PR DESCRIPTION
`ravel` will avoid returning a new copy of the array; since a new array is already being created w/ toarray this is safe.

Thanks @jedman for  bringing this to my attention.