### PR TITLE
Fix partial derivatives in regularization docs

### DIFF
--- a/SimPEG/regularization/correspondence.py
+++ b/SimPEG/regularization/correspondence.py
@@ -185,10 +185,10 @@ class LinearCorrespondence(BaseSimilarityMeasure):
         .. math::
             \frac{\partial^2 \phi}{\partial \mathbf{m}^2} =
             \begin{bmatrix}
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_1}^2} &
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_1} \partial \mathbf{m_2}} \\
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_2} \partial \mathbf{m_1}} &
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_2}^2}
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_1}^2} &
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_1} \partial \mathbf{m_2}} \\
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_2} \partial \mathbf{m_1}} &
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_2}^2}
             \end{bmatrix}
 
         When a vector :math:`(\mathbf{v})` is supplied, the method returns the Hessian

--- a/SimPEG/regularization/cross_gradient.py
+++ b/SimPEG/regularization/cross_gradient.py
@@ -310,10 +310,10 @@ class CrossGradient(BaseSimilarityMeasure):
         .. math::
             \frac{\partial^2 \phi}{\partial \mathbf{m}^2} =
             \begin{bmatrix}
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_1}^2} &
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_1} \partial \mathbf{m_2}} \\
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_2} \partial \mathbf{m_1}} &
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_2}^2}
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_1}^2} &
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_1} \partial \mathbf{m_2}} \\
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_2} \partial \mathbf{m_1}} &
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_2}^2}
             \end{bmatrix}
 
         When a vector :math:`(\mathbf{v})` is supplied, the method returns the Hessian

--- a/SimPEG/regularization/jtv.py
+++ b/SimPEG/regularization/jtv.py
@@ -256,11 +256,11 @@ class JointTotalVariation(BaseSimilarityMeasure):
         .. math::
             \frac{\partial^2 \phi}{\partial \mathbf{m}^2} =
             \begin{bmatrix}
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_1}^2} &
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_1} \partial \mathbf{m_2}} &
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_1}^2} &
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_1} \partial \mathbf{m_2}} &
             \cdots \\
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_2} \partial \mathbf{m_1}} &
-            \dfrac{\partial \phi^2}{\partial \mathbf{m_2}^2} & \; \\
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_2} \partial \mathbf{m_1}} &
+            \dfrac{\partial^2 \phi}{\partial \mathbf{m_2}^2} & \; \\
             \vdots & \; & \ddots
             \end{bmatrix}
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing/pull-requests.html

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
<!-- Add a summary of this Pull Request -->

Fix LaTeX in second order partial derivatives shown in regularization docstrings. Replace $\frac{\partial \phi^2}{\partial m^2}$ for $\frac{\partial^2 \phi}{\partial m^2}$.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
