### PR TITLE
Simplify a few gravity simulation tests

### DIFF
--- a/tests/pf/test_forward_Grav_Linear.py
+++ b/tests/pf/test_forward_Grav_Linear.py
@@ -1,6 +1,6 @@
-from unittest.mock import patch
 import pytest
 import discretize
+import SimPEG
 from SimPEG import maps
 from SimPEG.potential_fields import gravity
 from geoana.gravity import Prism
@@ -314,87 +314,38 @@ class TestsGravitySimulation:
             assert simulation.sensitivity_dtype is np.float32
 
     @pytest.mark.parametrize("invalid_dtype", (float, np.float16))
-    def test_invalid_sensitivity_dtype_assignment(
-        self, simple_mesh, receivers_locations, invalid_dtype
-    ):
+    def test_invalid_sensitivity_dtype_assignment(self, simple_mesh, invalid_dtype):
         """
         Test invalid sensitivity_dtype assignment
         """
-        # Create survey
-        receivers = gravity.Point(receivers_locations, components="gz")
-        sources = gravity.SourceField([receivers])
-        survey = gravity.Survey(sources)
-        # Create reduced identity map for Linear Problem
-        active_cells = np.ones(simple_mesh.n_cells, dtype=bool)
-        idenMap = maps.IdentityMap(nP=simple_mesh.n_cells)
-        # Create simulation
         simulation = gravity.Simulation3DIntegral(
             simple_mesh,
-            survey=survey,
-            rhoMap=idenMap,
-            ind_active=active_cells,
         )
         # Check if error is raised
         msg = "sensitivity_dtype must be either np.float32 or np.float64."
         with pytest.raises(TypeError, match=msg):
             simulation.sensitivity_dtype = invalid_dtype
 
-    def test_invalid_engine(self, simple_mesh, receivers_locations):
+    def test_invalid_engine(self, simple_mesh):
         """Test if error is raised after invalid engine."""
-        # Create survey
-        receivers = gravity.Point(receivers_locations, components="gz")
-        sources = gravity.SourceField([receivers])
-        survey = gravity.Survey(sources)
-        # Create reduced identity map for Linear Problem
-        active_cells = np.ones(simple_mesh.n_cells, dtype=bool)
-        idenMap = maps.IdentityMap(nP=simple_mesh.n_cells)
-        # Check if error is raised after an invalid engine is passed
         engine = "invalid engine"
         with pytest.raises(ValueError, match=f"Invalid engine '{engine}'"):
-            gravity.Simulation3DIntegral(
-                simple_mesh,
-                survey=survey,
-                rhoMap=idenMap,
-                ind_active=active_cells,
-                engine=engine,
-            )
+            gravity.Simulation3DIntegral(simple_mesh, engine=engine)
 
-    def test_choclo_and_n_proceesses(self, simple_mesh, receivers_locations):
+    def test_choclo_and_n_proceesses(self, simple_mesh):
         """Check if warning is raised after passing n_processes with choclo engine."""
-        # Create survey
-        receivers = gravity.Point(receivers_locations, components="gz")
-        sources = gravity.SourceField([receivers])
-        survey = gravity.Survey(sources)
-        # Create reduced identity map for Linear Problem
-        active_cells = np.ones(simple_mesh.n_cells, dtype=bool)
-        idenMap = maps.IdentityMap(nP=simple_mesh.n_cells)
-        # Check if warning is raised
         msg = "The 'n_processes' will be ignored when selecting 'choclo'"
         with pytest.warns(UserWarning, match=msg):
             simulation = gravity.Simulation3DIntegral(
-                simple_mesh,
-                survey=survey,
-                rhoMap=idenMap,
-                ind_active=active_cells,
-                engine="choclo",
-                n_processes=2,
+                simple_mesh, engine="choclo", n_processes=2
             )
         # Check if n_processes was overwritten and set to None
         assert simulation.n_processes is None
 
-    def test_choclo_and_sensitivity_path_as_dir(
-        self, simple_mesh, receivers_locations, tmp_path
-    ):
+    def test_choclo_and_sensitivity_path_as_dir(self, simple_mesh, tmp_path):
         """
         Check if error is raised when sensitivity_path is a dir with choclo engine.
         """
-        # Create survey
-        receivers = gravity.Point(receivers_locations, components="gz")
-        sources = gravity.SourceField([receivers])
-        survey = gravity.Survey(sources)
-        # Create reduced identity map for Linear Problem
-        active_cells = np.ones(simple_mesh.n_cells, dtype=bool)
-        idenMap = maps.IdentityMap(nP=simple_mesh.n_cells)
         # Create a sensitivity_path directory
         sensitivity_path = tmp_path / "sensitivity_dummy"
         sensitivity_path.mkdir()
@@ -403,36 +354,21 @@ class TestsGravitySimulation:
         with pytest.raises(ValueError, match=msg):
             gravity.Simulation3DIntegral(
                 simple_mesh,
-                survey=survey,
-                rhoMap=idenMap,
-                ind_active=active_cells,
                 store_sensitivities="disk",
                 sensitivity_path=str(sensitivity_path),
                 engine="choclo",
             )
 
-    @patch("SimPEG.potential_fields.gravity.simulation.choclo", None)
-    def test_choclo_missing(self, simple_mesh, receivers_locations):
+    def test_choclo_missing(self, simple_mesh, monkeypatch):
         """
         Check if error is raised when choclo is missing and chosen as engine.
         """
-        # Create survey
-        receivers = gravity.Point(receivers_locations, components="gz")
-        sources = gravity.SourceField([receivers])
-        survey = gravity.Survey(sources)
-        # Create reduced identity map for Linear Problem
-        active_cells = np.ones(simple_mesh.n_cells, dtype=bool)
-        idenMap = maps.IdentityMap(nP=simple_mesh.n_cells)
+        # Monkeypatch choclo in SimPEG.potential_fields.base
+        monkeypatch.setattr(SimPEG.potential_fields.gravity.simulation, "choclo", None)
         # Check if error is raised
         msg = "The choclo package couldn't be found."
         with pytest.raises(ImportError, match=msg):
-            gravity.Simulation3DIntegral(
-                simple_mesh,
-                survey=survey,
-                rhoMap=idenMap,
-                ind_active=active_cells,
-                engine="choclo",
-            )
+            gravity.Simulation3DIntegral(simple_mesh, engine="choclo")
 
 
 class TestConversionFactor:


### PR DESCRIPTION
#### Summary

Remove some unneeded lines in gravity simulation tests, particularly the ones that tests warnings and errors being raised. Replace `unittest.mock.patch` with `pytest`'s Monkeypatch to fake `choclo` not being installed.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
