### PR TITLE
Removed deprecated properties of UpdateSensitivityWeights

### DIFF
--- a/SimPEG/directives/directives.py
+++ b/SimPEG/directives/directives.py
@@ -2535,33 +2535,20 @@ class UpdateSensitivityWeights(InversionDirective):
         normalization_method="maximum",
         **kwargs,
     ):
-        if "everyIter" in kwargs.keys():
-            warnings.warn(
-                "'everyIter' property is deprecated and will be removed in SimPEG 0.20.0."
-                "Please use 'every_iteration'.",
-                stacklevel=2,
+        # Raise errors on deprecated arguments
+        if (key := "everyIter") in kwargs.keys():
+            raise TypeError(
+                f"'{key}' property has been removed. Please use 'every_iteration'.",
             )
-            every_iteration = kwargs.pop("everyIter")
-
-        if "threshold" in kwargs.keys():
-            warnings.warn(
-                "'threshold' property is deprecated and will be removed in SimPEG 0.20.0."
-                "Please use 'threshold_value'.",
-                stacklevel=2,
+        if (key := "threshold") in kwargs.keys():
+            raise TypeError(
+                f"'{key}' property has been removed. Please use 'threshold_value'.",
             )
-            threshold_value = kwargs.pop("threshold")
-
-        if "normalization" in kwargs.keys():
-            warnings.warn(
-                "'normalization' property is deprecated and will be removed in SimPEG 0.20.0."
+        if (key := "normalization") in kwargs.keys():
+            raise TypeError(
+                f"'{key}' property has been removed. "
                 "Please define normalization using 'normalization_method'.",
-                stacklevel=2,
             )
-            normalization_method = kwargs.pop("normalization")
-            if normalization_method is True:
-                normalization_method = "maximum"
-            else:
-                normalization_method = None
 
         super().__init__(**kwargs)
 
@@ -2588,7 +2575,11 @@ class UpdateSensitivityWeights(InversionDirective):
         self._every_iteration = validate_type("every_iteration", value, bool)
 
     everyIter = deprecate_property(
-        every_iteration, "everyIter", "every_iteration", removal_version="0.20.0"
+        every_iteration,
+        "everyIter",
+        "every_iteration",
+        removal_version="0.20.0",
+        error=True,
     )
 
     @property
@@ -2617,7 +2608,11 @@ class UpdateSensitivityWeights(InversionDirective):
         self._threshold_value = validate_float("threshold_value", value, min_val=0.0)
 
     threshold = deprecate_property(
-        threshold_value, "threshold", "threshold_value", removal_version="0.20.0"
+        threshold_value,
+        "threshold",
+        "threshold_value",
+        removal_version="0.20.0",
+        error=True,
     )
 
     @property
@@ -2667,18 +2662,6 @@ class UpdateSensitivityWeights(InversionDirective):
     def normalization_method(self, value):
         if value is None:
             self._normalization_method = value
-
-        elif isinstance(value, bool):
-            warnings.warn(
-                "Boolean type for 'normalization_method' is deprecated and will be removed in 0.20.0."
-                "Please use None, 'maximum' or 'minimum'.",
-                stacklevel=2,
-            )
-            if value:
-                self._normalization_method = "maximum"
-            else:
-                self._normalization_method = None
-
         else:
             self._normalization_method = validate_string(
                 "normalization_method", value, string_list=["minimum", "maximum"]
@@ -2689,6 +2672,7 @@ class UpdateSensitivityWeights(InversionDirective):
         "normalization",
         "normalization_method",
         removal_version="0.20.0",
+        error=True,
     )
 
     def initialize(self):

--- a/examples/02-gravity/plot_inv_grav_tiled.py
+++ b/examples/02-gravity/plot_inv_grav_tiled.py
@@ -243,7 +243,7 @@ update_IRLS = directives.Update_IRLS(
 )
 saveDict = directives.SaveOutputEveryIteration(save_txt=False)
 update_Jacobi = directives.UpdatePreconditioner()
-sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
 inv = inversion.BaseInversion(
     invProb,
     directiveList=[update_IRLS, sensitivity_weights, betaest, update_Jacobi, saveDict],

--- a/examples/_archived/plot_inv_grav_linear.py
+++ b/examples/_archived/plot_inv_grav_linear.py
@@ -127,7 +127,7 @@ def run(plotIt=True):
     )
     saveDict = directives.SaveOutputEveryIteration(save_txt=False)
     update_Jacobi = directives.UpdatePreconditioner()
-    sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+    sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
     inv = inversion.BaseInversion(
         invProb,
         directiveList=[

--- a/examples/_archived/plot_inv_mag_linear.py
+++ b/examples/_archived/plot_inv_mag_linear.py
@@ -131,7 +131,7 @@ def run(plotIt=True):
     saveDict = directives.SaveOutputEveryIteration(save_txt=False)
     update_Jacobi = directives.UpdatePreconditioner()
     # Add sensitivity weights
-    sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+    sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
 
     inv = inversion.BaseInversion(
         invProb,

--- a/tests/base/test_directives.py
+++ b/tests/base/test_directives.py
@@ -133,21 +133,12 @@ class ValidationInInversion(unittest.TestCase):
             inv = inversion.BaseInversion(invProb)
             inv.directiveList = [update_Jacobi, sensitivity_weights]
 
-    def test_sensitivity_weighting_warnings(self):
-        # Test setter warnings
-        d_temp = directives.UpdateSensitivityWeights()
-        d_temp.normalization_method = True
-        self.assertTrue(d_temp.normalization_method == "maximum")
-
-        d_temp.normalization_method = False
-        self.assertTrue(d_temp.normalization_method is None)
-
     def test_sensitivity_weighting_global(self):
         test_inputs = {
-            "everyIter": False,
-            "threshold": 1e-12,
+            "every_iteration": False,
+            "threshold_value": 1e-12,
             "threshold_method": "global",
-            "normalization": False,
+            "normalization_method": None,
         }
 
         # Compute test weights
@@ -155,7 +146,7 @@ class ValidationInInversion(unittest.TestCase):
             np.sqrt(np.sum((self.dmis.W * self.sim.G) ** 2, axis=0))
             / self.mesh.cell_volumes
         )
-        test_weights = sqrt_diagJtJ + test_inputs["threshold"]
+        test_weights = sqrt_diagJtJ + test_inputs["threshold_value"]
         test_weights *= self.mesh.cell_volumes
 
         # Test directive
@@ -182,7 +173,7 @@ class ValidationInInversion(unittest.TestCase):
             "every_iteration": True,
             "threshold_value": 1,
             "threshold_method": "percentile",
-            "normalization": True,
+            "normalization_method": "maximum",
         }
 
         # Compute test weights
@@ -301,6 +292,83 @@ def test_save_output_dict(RegClass):
         assert "SparseSmallness.norm" in out_dict
         assert "x SparseSmoothness.irls_threshold" in out_dict
         assert "x SparseSmoothness.norm" in out_dict
+
+
+class TestUpdateSensitivityWeightsRemovedArgs:
+    """
+    Test if `UpdateSensitivityWeights` raises errors after passing removed arguments.
+    """
+
+    def test_every_iter(self):
+        """
+        Test if `UpdateSensitivityWeights` raises error after passing `everyIter`.
+        """
+        msg = "'everyIter' property has been removed. Please use 'every_iteration'."
+        with pytest.raises(TypeError, match=msg):
+            directives.UpdateSensitivityWeights(everyIter=True)
+
+    def test_threshold(self):
+        """
+        Test if `UpdateSensitivityWeights` raises error after passing `threshold`.
+        """
+        msg = "'threshold' property has been removed. Please use 'threshold_value'."
+        with pytest.raises(TypeError, match=msg):
+            directives.UpdateSensitivityWeights(threshold=True)
+
+    def test_normalization(self):
+        """
+        Test if `UpdateSensitivityWeights` raises error after passing `normalization`.
+        """
+        msg = (
+            "'normalization' property has been removed. "
+            "Please define normalization using 'normalization_method'."
+        )
+        with pytest.raises(TypeError, match=msg):
+            directives.UpdateSensitivityWeights(normalization=True)
+
+
+class TestUpdateSensitivityNormalization:
+    """
+    Test the `normalization` property and setter in `UpdateSensitivityWeights`
+    """
+
+    @pytest.mark.parametrize("normalization_method", (None, "maximum", "minimum"))
+    def test_normalization_method_setter_valid(self, normalization_method):
+        """
+        Test if the setter method for normalization_method in
+        `UpdateSensitivityWeights` works as expected on valid values.
+
+        The `normalization_method` must be a string or a None. This test was
+        included as part of the removal process of the old `normalization`
+        property.
+        """
+        d_temp = directives.UpdateSensitivityWeights()
+        # Use the setter method to assign a value to normalization_method
+        d_temp.normalization_method = normalization_method
+        assert d_temp.normalization_method == normalization_method
+
+    @pytest.mark.parametrize("normalization_method", (True, False, "an invalid method"))
+    def test_normalization_method_setter_invalid(self, normalization_method):
+        """
+        Test if the setter method for normalization_method in
+        `UpdateSensitivityWeights` raises error on invalid values.
+
+        The `normalization_method` must be a string or a None. This test was
+        included as part of the removal process of the old `normalization`
+        property.
+        """
+        d_temp = directives.UpdateSensitivityWeights()
+        if isinstance(normalization_method, bool):
+            error_type = TypeError
+            msg = "'normalization_method' must be a str. Got"
+        else:
+            error_type = ValueError
+            msg = (
+                r"'normalization_method' must be in \['minimum', 'maximum'\]. "
+                f"Got '{normalization_method}'"
+            )
+        with pytest.raises(error_type, match=msg):
+            d_temp.normalization_method = normalization_method
 
 
 if __name__ == "__main__":

--- a/tests/dask/test_grav_inversion_linear.py
+++ b/tests/dask/test_grav_inversion_linear.py
@@ -105,7 +105,7 @@ class GravInvLinProblemTest(unittest.TestCase):
         # Here is where the norms are applied
         IRLS = directives.Update_IRLS(max_irls_iterations=20, chifact_start=2.0)
         update_Jacobi = directives.UpdatePreconditioner()
-        sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+        sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
         self.inv = inversion.BaseInversion(
             invProb, directiveList=[IRLS, sensitivity_weights, update_Jacobi]
         )

--- a/tests/dask/test_mag_MVI_Octree.py
+++ b/tests/dask/test_mag_MVI_Octree.py
@@ -152,7 +152,7 @@ class MVIProblemTest(unittest.TestCase):
 
         # Pre-conditioner
         update_Jacobi = directives.UpdatePreconditioner()
-        sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+        sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
         inv = inversion.BaseInversion(
             invProb, directiveList=[sensitivity_weights, IRLS, update_Jacobi, betaest]
         )

--- a/tests/pf/test_mag_MVI_Octree.py
+++ b/tests/pf/test_mag_MVI_Octree.py
@@ -149,7 +149,7 @@ class MVIProblemTest(unittest.TestCase):
 
         # Pre-conditioner
         update_Jacobi = directives.UpdatePreconditioner()
-        sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+        sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
         inv = inversion.BaseInversion(
             invProb, directiveList=[sensitivity_weights, IRLS, update_Jacobi, betaest]
         )

--- a/tests/pf/test_mag_inversion_linear.py
+++ b/tests/pf/test_mag_inversion_linear.py
@@ -119,7 +119,7 @@ class MagInvLinProblemTest(unittest.TestCase):
         # Here is where the norms are applied
         IRLS = directives.Update_IRLS(f_min_change=1e-4, minGNiter=1)
         update_Jacobi = directives.UpdatePreconditioner()
-        sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+        sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
         self.inv = inversion.BaseInversion(
             invProb, directiveList=[IRLS, sensitivity_weights, betaest, update_Jacobi]
         )

--- a/tests/pf/test_mag_vector_amplitude.py
+++ b/tests/pf/test_mag_vector_amplitude.py
@@ -141,7 +141,7 @@ class MVIProblemTest(unittest.TestCase):
 
         # Pre-conditioner
         update_Jacobi = directives.UpdatePreconditioner()
-        sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+        sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
         self.inv = inversion.BaseInversion(
             invProb, directiveList=[sensitivity_weights, IRLS, update_Jacobi, betaest]
         )

--- a/tutorials/02-linear_inversion/plot_inv_2_inversion_irls.py
+++ b/tutorials/02-linear_inversion/plot_inv_2_inversion_irls.py
@@ -172,7 +172,7 @@ inv_prob = inverse_problem.BaseInvProblem(dmis, reg, opt)
 #
 
 # Add sensitivity weights but don't update at each beta
-sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
 
 # Reach target misfit for L2 solution, then use IRLS until model stops changing.
 IRLS = directives.Update_IRLS(max_irls_iterations=40, minGNiter=1, f_min_change=1e-4)

--- a/tutorials/03-gravity/plot_inv_1a_gravity_anomaly.py
+++ b/tutorials/03-gravity/plot_inv_1a_gravity_anomaly.py
@@ -268,7 +268,7 @@ update_jacobi = directives.UpdatePreconditioner()
 target_misfit = directives.TargetMisfit(chifact=1)
 
 # Add sensitivity weights
-sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
 
 # The directives are defined as a list.
 directives_list = [

--- a/tutorials/03-gravity/plot_inv_1b_gravity_anomaly_irls.py
+++ b/tutorials/03-gravity/plot_inv_1b_gravity_anomaly_irls.py
@@ -274,7 +274,7 @@ save_iteration = directives.SaveOutputEveryIteration(save_txt=False)
 update_jacobi = directives.UpdatePreconditioner()
 
 # Add sensitivity weights
-sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
 
 # The directives are defined as a list.
 directives_list = [

--- a/tutorials/04-magnetics/plot_inv_2a_magnetics_induced.py
+++ b/tutorials/04-magnetics/plot_inv_2a_magnetics_induced.py
@@ -309,7 +309,7 @@ update_jacobi = directives.UpdatePreconditioner()
 target_misfit = directives.TargetMisfit(chifact=1)
 
 # Add sensitivity weights
-sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
 
 # The directives are defined as a list.
 directives_list = [

--- a/tutorials/06-ip/plot_inv_2_dcip2d.py
+++ b/tutorials/06-ip/plot_inv_2_dcip2d.py
@@ -567,7 +567,7 @@ ip_inverse_problem = inverse_problem.BaseInvProblem(
 # Here we define the directives in the same manner as the DC inverse problem.
 #
 
-update_sensitivity_weighting = directives.UpdateSensitivityWeights(threshold=1e-3)
+update_sensitivity_weighting = directives.UpdateSensitivityWeights(threshold_value=1e-3)
 starting_beta = directives.BetaEstimate_ByEig(beta0_ratio=1e1)
 beta_schedule = directives.BetaSchedule(coolingFactor=2, coolingRate=1)
 save_iteration = directives.SaveOutputEveryIteration(save_txt=False)

--- a/tutorials/06-ip/plot_inv_3_dcip3d.py
+++ b/tutorials/06-ip/plot_inv_3_dcip3d.py
@@ -633,7 +633,7 @@ ip_inverse_problem = inverse_problem.BaseInvProblem(
 # Here we define the directives in the same manner as the DC inverse problem.
 #
 
-update_sensitivity_weighting = directives.UpdateSensitivityWeights(threshold=1e-3)
+update_sensitivity_weighting = directives.UpdateSensitivityWeights(threshold_value=1e-3)
 starting_beta = directives.BetaEstimate_ByEig(beta0_ratio=1e2)
 beta_schedule = directives.BetaSchedule(coolingFactor=2.5, coolingRate=1)
 save_iteration = directives.SaveOutputEveryIteration(save_txt=False)

--- a/tutorials/13-joint_inversion/plot_inv_3_cross_gradient_pf.py
+++ b/tutorials/13-joint_inversion/plot_inv_3_cross_gradient_pf.py
@@ -365,7 +365,7 @@ joint_inv_dir = directives.SimilarityMeasureInversionDirective()
 
 stopping = directives.MovingAndMultiTargetStopping(tol=1e-6)
 
-sensitivity_weights = directives.UpdateSensitivityWeights(everyIter=False)
+sensitivity_weights = directives.UpdateSensitivityWeights(every_iteration=False)
 
 # Updating the preconditionner if it is model dependent.
 update_jacobi = directives.UpdatePreconditioner()


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Remove the `everyIter`, `threshold` and `normalization` properties of `UpdateSensitivityWeights`. Add tests to check if errors are being raised after passing removed arguments to its constructor. Update tests and examples using the removed arguments and properties.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Part of the solution for https://github.com/simpeg/simpeg/issues/1302

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

Most of these changes were cherry-picked from #1306

<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
