### PR TITLE
Remove the debug argument from InversionDirective

### DIFF
--- a/SimPEG/directives/directives.py
+++ b/SimPEG/directives/directives.py
@@ -64,14 +64,13 @@ class InversionDirective:
     _dmisfitPair = [BaseDataMisfit, ComboObjectiveFunction]
 
     def __init__(self, inversion=None, dmisfit=None, reg=None, verbose=False, **kwargs):
+        # Raise error on deprecated arguments
+        if (key := "debug") in kwargs.keys():
+            raise TypeError(f"'{key}' property has been removed. Please use 'verbose'.")
         self.inversion = inversion
         self.dmisfit = dmisfit
         self.reg = reg
-        debug = kwargs.pop("debug", None)
-        if debug is not None:
-            self.debug = debug
-        else:
-            self.verbose = verbose
+        self.verbose = verbose
         set_kwargs(self, **kwargs)
 
     @property
@@ -89,7 +88,7 @@ class InversionDirective:
         self._verbose = validate_type("verbose", value, bool)
 
     debug = deprecate_property(
-        verbose, "debug", "verbose", removal_version="0.19.0", future_warn=True
+        verbose, "debug", "verbose", removal_version="0.19.0", error=True
     )
 
     @property

--- a/SimPEG/directives/sim_directives.py
+++ b/SimPEG/directives/sim_directives.py
@@ -248,7 +248,7 @@ class PairedBetaEstimate_ByEig(InversionDirective):
         if self.seed is not None:
             np.random.seed(self.seed)
 
-        if self.debug:
+        if self.verbose:
             print("Calculating the beta0 parameter.")
 
         m = self.invProb.model

--- a/tests/base/test_directives.py
+++ b/tests/base/test_directives.py
@@ -303,5 +303,19 @@ def test_save_output_dict(RegClass):
         assert "x SparseSmoothness.norm" in out_dict
 
 
+class TestDeprecatedArguments:
+    """
+    Test if directives raise errors after passing deprecated arguments.
+    """
+
+    def test_debug(self):
+        """
+        Test if InversionDirective raises error after passing 'debug'.
+        """
+        msg = "'debug' property has been removed. Please use 'verbose'."
+        with pytest.raises(TypeError, match=msg):
+            directives.InversionDirective(debug=True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Remove the `debug` argument and property from `InversionDirective`, add new test to check if it raises an error when passing it as argument. Update directive class using the `debug` property.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Part of the solution for https://github.com/simpeg/simpeg/issues/1302

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

Most of these changes were cherry-picked from https://github.com/simpeg/simpeg/pull/1306

<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
