### PR TITLE
Remove cellDiff properties of RegularizationMesh

### DIFF
--- a/SimPEG/regularization/regularization_mesh.py
+++ b/SimPEG/regularization/regularization_mesh.py
@@ -521,24 +521,21 @@ class RegularizationMesh(props.BaseSimPEG):
         "cellDiffx",
         "cell_gradient_x",
         "0.19.0",
-        error=False,
-        future_warn=True,
+        error=True,
     )
     cellDiffy = deprecate_property(
         cell_gradient_y,
         "cellDiffy",
         "cell_gradient_y",
         "0.19.0",
-        error=False,
-        future_warn=True,
+        error=True,
     )
     cellDiffz = deprecate_property(
         cell_gradient_z,
         "cellDiffz",
         "cell_gradient_z",
         "0.19.0",
-        error=False,
-        future_warn=True,
+        error=True,
     )
 
     @property

--- a/tests/base/test_regularization.py
+++ b/tests/base/test_regularization.py
@@ -396,14 +396,14 @@ class RegularizationTests(unittest.TestCase):
         ]
         [self.assertTrue(reg.mapping is fct.mapping) for fct in reg.objfcts]
 
-        D = reg.regularization_mesh.cellDiffx
+        D = reg.regularization_mesh.cell_gradient_x
         reg.regularization_mesh._cell_gradient_x = 4 * D
         v = np.random.rand(D.shape[1])
         [
             self.assertTrue(
                 np.all(
                     reg.regularization_mesh._cell_gradient_x * v
-                    == fct.regularization_mesh.cellDiffx * v
+                    == fct.regularization_mesh.cell_gradient_x * v
                 )
             )
             for fct in reg.objfcts


### PR DESCRIPTION

<!--
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing/pull-requests.html

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary

Remove the `cellDiffx`, `cellDiffy`, and `cellDiffz` properties of
`RegularizationMesh`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Part of the solution for #1302

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

Most of these changes were cherry-picked from #1306

<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
