### PR TITLE
Speed up sphinx documentation building

### DIFF
--- a/docs/_templates/autosummary/attribute.rst
+++ b/docs/_templates/autosummary/attribute.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/docs/_templates/autosummary/base.rst
+++ b/docs/_templates/autosummary/base.rst
@@ -1,0 +1,13 @@
+{% if objtype == 'property' %}
+:orphan:
+{% endif %}
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+{% if objtype == 'property' %}
+property
+{% endif %}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/docs/_templates/autosummary/base.rst
+++ b/docs/_templates/autosummary/base.rst
@@ -6,8 +6,4 @@
 
 .. currentmodule:: {{ module }}
 
-{% if objtype == 'property' %}
-property
-{% endif %}
-
 .. auto{{ objtype }}:: {{ objname }}

--- a/docs/_templates/autosummary/method.rst
+++ b/docs/_templates/autosummary/method.rst
@@ -1,0 +1,7 @@
+:orphan:
+
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. auto{{ objtype }}:: {{ objname }}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,9 +55,7 @@ extensions = [
 autosummary_generate = True
 
 numpydoc_attributes_as_param_list = False
-# This has to be set to false in order to make the doc build in a
-# reasonable amount of time.
-numpydoc_show_inherited_class_members = False
+numpydoc_show_inherited_class_members = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -274,6 +274,7 @@ try:
             },
         ],
         "use_edit_page_button": False,
+        "collapse_navigation": True,
     }
     html_logo = "images/simpeg-logo.png"
 


### PR DESCRIPTION


#### Summary
Stops the left sidebar from being completely expandable for every single item in the documentation.
https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/navigation.html#remove-reveal-buttons-for-sidebar-items

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
No number... but the docs take so long to build now....

#### What does this implement/fix?
Faster doc building (excluding the examples and tutorials)

#### Additional information
[<!--Any additional information you think is important.-->](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/performance.html)
