### PR TITLE
Remove deprecated modelType in mag simulation

### DIFF
--- a/SimPEG/potential_fields/magnetics/simulation.py
+++ b/SimPEG/potential_fields/magnetics/simulation.py
@@ -122,7 +122,7 @@ class Simulation3DIntegral(BasePFSimulation):
         return self._G
 
     modelType = deprecate_property(
-        model_type, "modelType", "model_type", removal_version="0.18.0"
+        model_type, "modelType", "model_type", removal_version="0.18.0", error=True
     )
 
     @property

--- a/tests/pf/test_forward_Mag_Linear.py
+++ b/tests/pf/test_forward_Mag_Linear.py
@@ -1,3 +1,4 @@
+import pytest
 import unittest
 
 import discretize
@@ -495,6 +496,21 @@ def test_ana_mag_amp_forward():
     d_amp = np.linalg.norm(d, axis=1)
 
     np.testing.assert_allclose(data, d_amp)
+
+
+def test_removed_modeltype():
+    """Test if accesing removed modelType property raises error."""
+    h = [[(2, 2)], [(2, 2)], [(2, 2)]]
+    mesh = discretize.TensorMesh(h)
+    receiver_location = np.array([[0, 0, 100]])
+    receiver = mag.Point(receiver_location, components="tmi")
+    background_field = mag.UniformBackgroundField(receiver_list=[receiver])
+    survey = mag.Survey(background_field)
+    mapping = maps.IdentityMap(mesh, nP=mesh.n_cells)
+    sim = mag.Simulation3DIntegral(mesh, survey=survey, chiMap=mapping)
+    message = "modelType has been removed, please use model_type."
+    with pytest.raises(NotImplementedError, match=message):
+        sim.modelType
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Remove the deprecated `modelType` property in the magnetic simulation and add test function checking that error is raised when trying to access it.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Part of the solution to #1302

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
