### PR TITLE
Remove link to "twitter"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -268,11 +268,6 @@ try:
                 "url": "https://www.youtube.com/c/geoscixyz",
                 "icon": "fab fa-youtube",
             },
-            {
-                "name": "Twitter",
-                "url": "https://twitter.com/simpegpy",
-                "icon": "fab fa-twitter",
-            },
         ],
         "use_edit_page_button": False,
         "collapse_navigation": True,


### PR DESCRIPTION
#### Summary
Remove link to twitter from documentation.

#### Reference issue
closes #1402 

#### What does this implement/fix?
Doesn't link to our unused "twitter"

#### Additional information
We all know the baggage associated with it. Unless someone has a good reason to keep the link, I suggest we remove it.
