### PR TITLE
Remove the parameters argument from docstring

### DIFF
--- a/SimPEG/potential_fields/magnetics/sources.py
+++ b/SimPEG/potential_fields/magnetics/sources.py
@@ -12,9 +12,6 @@ class UniformBackgroundField(BaseSrc):
     Parameters
     ----------
     receiver_list : list of SimPEG.potential_fields.magnetics.Point
-    parameters : tuple of (amplitude, inclutation, declination), optional
-        Deprecated input for the function, provided in this position for backwards
-        compatibility
     amplitude : float, optional
         amplitude of the inducing backgound field, usually this is in units of nT.
     inclination : float, optional


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing/pull-requests.html

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
<!-- Add a summary of this Pull Request -->

Remove the old `parameters` argument from the docstrings of the `UniformBackgroundField` class.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
