### PR TITLE
Safely run reviewdog on `pull_request_target` events

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,25 +1,32 @@
 name : Reviewdog PR Annotations
-on: [pull_request]
-permissions:
-  contents: read
-  pull-requests: write
+on: [pull_request_target]
 
 jobs:
   flake8:
     runs-on: ubuntu-latest
     name: Flake8 check
     steps:
-      - name: Checkout source repository
+      - name: Checkout target repository source
         uses: actions/checkout@v4
+
       - name: Setup Python env
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Install dependencies to run the flake8 checks
         run: pip install -r requirements_style.txt
+
+      - name: checkout pull request source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr_source
+
       - name: flake8 review
         uses: reviewdog/action-flake8@v3
         with:
+          workdir: pr_source
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
 
@@ -27,15 +34,25 @@ jobs:
     name: Black check
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source repository
+      - name: Checkout target repository source
         uses: actions/checkout@v4
+
       - name: Setup Python env
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install dependencies to run the black checks
+
+      - name: Install dependencies to run the flake8 checks
         run: pip install -r requirements_style.txt
+
+      - name: checkout pull request source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: 'pr_source'
+
       - uses: reviewdog/action-black@v3
         with:
+          workdir: 'pr_source'
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install dependencies to run the flake8 checks
+      - name: Install dependencies to run the black checks
         run: pip install -r requirements_style.txt
 
       - name: checkout pull request source

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,9 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     name: Flake8 check
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v4
@@ -23,6 +26,9 @@ jobs:
   black:
     name: Black check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,13 +1,13 @@
 name : Reviewdog PR Annotations
 on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   flake8:
     runs-on: ubuntu-latest
     name: Flake8 check
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v4
@@ -26,9 +26,6 @@ jobs:
   black:
     name: Black check
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - name: Checkout source repository
         uses: actions/checkout@v4


### PR DESCRIPTION
#### Summary
Updates permissions for reviewdog actions.

Looks like it explicitly needs to be given read permissions for the contents, and write permissions for the pull-requests to modify PR's from public forks.