### PR TITLE
Replace SimPEG for simpeg in deprecation messages

### DIFF
--- a/simpeg/utils/code_utils.py
+++ b/simpeg/utils/code_utils.py
@@ -538,9 +538,9 @@ def deprecate_class(
         if error:
             message = f"{my_name} has been removed, please use {parent_name}."
         elif removal_version is not None:
-            message += f" It will be removed in version {removal_version} of SimPEG."
+            message += f" It will be removed in version {removal_version} of simpeg."
         else:
-            message += " It will be removed in a future version of SimPEG."
+            message += " It will be removed in a future version of simpeg."
 
         # stash the original initialization of the class
         cls._old__init__ = cls.__init__
@@ -587,7 +587,7 @@ def deprecate_module(
     elif removal_version is not None:
         message += f" It will be removed in version {removal_version} of SimPEG"
     else:
-        message += " It will be removed in a future version of SimPEG."
+        message += " It will be removed in a future version of simpeg."
     message += " Please update your code accordingly."
     if future_warn:
         warnings.warn(message, FutureWarning, stacklevel=2)
@@ -634,9 +634,9 @@ def deprecate_property(
     if error:
         message = f"{old_name} has been removed, please use {new_name}."
     elif removal_version is not None:
-        message += f" It will be removed in version {removal_version} of SimPEG."
+        message += f" It will be removed in version {removal_version} of simpeg."
     else:
-        message += " It will be removed in a future version of SimPEG."
+        message += " It will be removed in a future version of simpeg."
 
     def get_dep(self):
         if future_warn:
@@ -693,9 +693,9 @@ def deprecate_method(
     if error:
         message = f"{old_name} has been removed, please use {new_name}."
     elif removal_version is not None:
-        message += f" It will be removed in version {removal_version} of SimPEG."
+        message += f" It will be removed in version {removal_version} of simpeg."
     else:
-        message += " It will be removed in a future version of SimPEG."
+        message += " It will be removed in a future version of simpeg."
 
     def new_method(*args, **kwargs):
         if future_warn:
@@ -747,9 +747,9 @@ def deprecate_function(
     if error:
         message = f"{old_name} has been removed, please use {new_name}."
     elif removal_version is not None:
-        message += f" It will be removed in version {removal_version} of SimPEG."
+        message += f" It will be removed in version {removal_version} of simpeg."
     else:
-        message += " It will be removed in a future version of SimPEG."
+        message += " It will be removed in a future version of simpeg."
 
     def dep_function(*args, **kwargs):
         if future_warn:


### PR DESCRIPTION

<!--
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing/pull-requests.html

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
<!-- Add a summary of this Pull Request -->

Use simpeg instead of SimPEG in the messages that deprecation decorators
raise.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
