### PR TITLE
Use Numpy rng in TDEM tests

### DIFF
--- a/tests/em/tdem/test_TDEM_DerivAdjoint.py
+++ b/tests/em/tdem/test_TDEM_DerivAdjoint.py
@@ -67,8 +67,9 @@ class Base_DerivAdjoint_Test(unittest.TestCase):
         mapping = get_mapping(mesh)
         self.survey = get_survey()
         self.prob = get_prob(mesh, mapping, self.formulation, survey=self.survey)
-        self.m = np.log(1e-1) * np.ones(self.prob.sigmaMap.nP) + 1e-3 * np.random.randn(
-            self.prob.sigmaMap.nP
+        rng = np.random.default_rng(seed=42)
+        self.m = np.log(1e-1) * np.ones(self.prob.sigmaMap.nP) + 1e-3 * rng.normal(
+            size=self.prob.sigmaMap.nP
         )
         print("Solving Fields for problem {}".format(self.formulation))
         t = time.time()
@@ -103,7 +104,6 @@ class Base_DerivAdjoint_Test(unittest.TestCase):
                 src.receiver_list = rxlist
 
     def JvecTest(self, rxcomp):
-        np.random.seed(10)
         self.set_receiver_list(rxcomp)
 
         def derChk(m):
@@ -117,17 +117,18 @@ class Base_DerivAdjoint_Test(unittest.TestCase):
                 prbtype=self.formulation, rxcomp=rxcomp
             )
         )
+        np.random.seed(10)  # use seed for check_derivative
         tests.check_derivative(derChk, self.m, plotIt=False, num=2, eps=1e-20)
 
     def JvecVsJtvecTest(self, rxcomp):
-        np.random.seed(10)
         self.set_receiver_list(rxcomp)
         print(
             "\nAdjoint Testing Jvec, Jtvec prob {}, {}".format(self.formulation, rxcomp)
         )
 
-        m = np.random.rand(self.prob.sigmaMap.nP)
-        d = np.random.randn(self.prob.survey.nD)
+        rng = np.random.default_rng(seed=42)
+        m = rng.uniform(size=self.prob.sigmaMap.nP)
+        d = rng.normal(size=self.prob.survey.nD)
         V1 = d.dot(self.prob.Jvec(self.m, m, f=self.fields))
         V2 = m.dot(self.prob.Jtvec(self.m, d, f=self.fields))
         tol = TOL * (np.abs(V1) + np.abs(V2)) / 2.0
@@ -146,8 +147,9 @@ class TDEM_Fields_B_Pieces(Base_DerivAdjoint_Test):
 
         print("\n Testing eDeriv_m Adjoint")
 
-        m = np.random.rand(len(self.m))
-        e = np.random.randn(prb.mesh.nE)
+        rng = np.random.default_rng(seed=42)
+        m = rng.uniform(size=len(self.m))
+        e = rng.normal(size=prb.mesh.nE)
         V1 = e.dot(f._eDeriv_m(1, prb.survey.source_list[0], m))
         V2 = m.dot(f._eDeriv_m(1, prb.survey.source_list[0], e, adjoint=True))
         tol = TOL * (np.abs(V1) + np.abs(V2)) / 2.0
@@ -162,8 +164,9 @@ class TDEM_Fields_B_Pieces(Base_DerivAdjoint_Test):
         prb = self.prob
         f = self.fields
 
-        b = np.random.rand(prb.mesh.nF)
-        e = np.random.randn(prb.mesh.nE)
+        rng = np.random.default_rng(seed=42)
+        b = rng.uniform(size=prb.mesh.nF)
+        e = rng.normal(size=prb.mesh.nE)
         V1 = e.dot(f._eDeriv_u(1, prb.survey.source_list[0], b))
         V2 = b.dot(f._eDeriv_u(1, prb.survey.source_list[0], e, adjoint=True))
         tol = TOL * (np.abs(V1) + np.abs(V2)) / 2.0

--- a/tests/em/tdem/test_TDEM_DerivAdjoint_RawWaveform.py
+++ b/tests/em/tdem/test_TDEM_DerivAdjoint_RawWaveform.py
@@ -72,14 +72,14 @@ class Base_DerivAdjoint_Test(unittest.TestCase):
         time_steps = [(1e-3, 5), (1e-4, 5), (5e-5, 10), (5e-5, 10), (1e-4, 10)]
         t_mesh = discretize.TensorMesh([time_steps])
         times = t_mesh.nodes_x
-        np.random.rand(412)
+        rng = np.random.default_rng(seed=42)
         self.survey = get_survey(times, self.t0)
 
         self.prob = get_prob(
             mesh, mapping, self.formulation, survey=self.survey, time_steps=time_steps
         )
         self.m = np.log(1e-1) * np.ones(self.prob.sigmaMap.nP)
-        self.m *= 0.25 * np.random.rand(*self.m.shape) + 1
+        self.m *= 0.25 * rng.uniform(size=self.m.shape) + 1
 
         print("Solving Fields for problem {}".format(self.formulation))
         t = time.time()
@@ -120,7 +120,6 @@ class Base_DerivAdjoint_Test(unittest.TestCase):
                 src.receiver_list = rxlist
 
     def JvecTest(self, rxcomp):
-        np.random.seed(4)
         self.set_receiver_list(rxcomp)
 
         def derChk(m):
@@ -134,17 +133,18 @@ class Base_DerivAdjoint_Test(unittest.TestCase):
                 prbtype=self.formulation, rxcomp=rxcomp
             )
         )
+        np.random.seed(4)  # set seed for check_derivative
         tests.check_derivative(derChk, self.m, plotIt=False, num=3, eps=1e-20)
 
     def JvecVsJtvecTest(self, rxcomp):
-        np.random.seed(4)
         self.set_receiver_list(rxcomp)
         print(
             "\nAdjoint Testing Jvec, Jtvec prob {}, {}".format(self.formulation, rxcomp)
         )
 
-        m = np.random.rand(self.prob.sigmaMap.nP)
-        d = np.random.randn(self.prob.survey.nD)
+        rng = np.random.default_rng(seed=4)
+        m = rng.uniform(size=self.prob.sigmaMap.nP)
+        d = rng.normal(size=self.prob.survey.nD)
         V1 = d.dot(self.prob.Jvec(self.m, m, f=self.fields))
         V2 = m.dot(self.prob.Jtvec(self.m, d, f=self.fields))
         tol = TOL * (np.abs(V1) + np.abs(V2)) / 2.0

--- a/tests/em/tdem/test_TDEM_DerivAdjoint_galvanic.py
+++ b/tests/em/tdem/test_TDEM_DerivAdjoint_galvanic.py
@@ -14,7 +14,6 @@ TOL = 0.5
 
 
 def setUp_TDEM(prbtype="ElectricField", rxcomp="ElectricFieldx", src_z=0.0):
-    np.random.seed(10)
     cs = 5.0
     ncx = 8
     ncy = 8
@@ -55,7 +54,8 @@ def setUp_TDEM(prbtype="ElectricField", rxcomp="ElectricFieldx", src_z=0.0):
 
     time_steps = [(1e-05, 10), (5e-05, 10), (2.5e-4, 10)]
 
-    m = np.log(5e-1) * np.ones(mapping.nP) + 1e-3 * np.random.randn(mapping.nP)
+    rng = np.random.default_rng(seed=42)
+    m = np.log(5e-1) * np.ones(mapping.nP) + 1e-3 * rng.normal(size=mapping.nP)
 
     prb = getattr(tdem, "Simulation3D{}".format(prbtype))(
         mesh, survey=survey, time_steps=time_steps, sigmaMap=mapping
@@ -107,8 +107,9 @@ class TDEM_DerivTests(unittest.TestCase):
             print("\nAdjoint Testing Jvec, Jtvec prob {}, {}".format(prbtype, rxcomp))
 
             prb, m0, mesh = setUp_TDEM(prbtype, rxcomp, src_z)
-            m = np.random.rand(prb.sigmaMap.nP)
-            d = np.random.randn(prb.survey.nD)
+            rng = np.random.default_rng(seed=42)
+            m = rng.uniform(size=prb.sigmaMap.nP)
+            d = rng.normal(size=prb.survey.nD)
 
             print(m.shape, d.shape, m0.shape)
 

--- a/tests/em/tdem/test_TDEM_crosscheck.py
+++ b/tests/em/tdem/test_TDEM_crosscheck.py
@@ -16,7 +16,6 @@ def setUp_TDEM(
     prbtype="MagneticFluxDensity", rxcomp="bz", waveform="stepoff", src_type=None
 ):
     # set a seed so that the same conductivity model is used for all runs
-    np.random.seed(25)
     cs = 10.0
     ncx = 4
     ncy = 4
@@ -76,7 +75,10 @@ def setUp_TDEM(
     )
     prb.solver = Solver
 
-    m = np.log(1e-1) * np.ones(prb.sigmaMap.nP) + 1e-2 * np.random.rand(prb.sigmaMap.nP)
+    rng = np.random.default_rng(seed=42)
+    m = np.log(1e-1) * np.ones(prb.sigmaMap.nP) + 1e-2 * rng.uniform(
+        size=prb.sigmaMap.nP
+    )
 
     return prb, m, mesh
 

--- a/tests/em/tdem/test_TDEM_grounded.py
+++ b/tests/em/tdem/test_TDEM_grounded.py
@@ -93,7 +93,8 @@ class TestGroundedSourceTDEM_j(unittest.TestCase):
         print("Testing problem {} \n\n".format(self.prob_type))
 
     def derivtest(self, deriv_fct):
-        m0 = np.log(self.sigma) + np.random.rand(self.mesh.nC)
+        rng = np.random.default_rng(seed=42)
+        m0 = np.log(self.sigma) + rng.uniform(size=self.mesh.nC)
         self.prob.model = m0
 
         return tests.check_derivative(
@@ -131,22 +132,25 @@ class TestGroundedSourceTDEM_j(unittest.TestCase):
         self.derivtest(deriv_check)
 
     def test_adjoint_phi(self):
-        v = np.random.rand(self.mesh.nC)
-        w = np.random.rand(self.mesh.nC)
+        rng = np.random.default_rng(seed=42)
+        v = rng.uniform(size=self.mesh.nC)
+        w = rng.uniform(size=self.mesh.nC)
         a = w.T.dot(self.src._phiInitialDeriv(self.prob, v=v))
         b = v.T.dot(self.src._phiInitialDeriv(self.prob, v=w, adjoint=True))
         self.assertTrue(np.allclose(a, b))
 
     def test_adjoint_j(self):
-        v = np.random.rand(self.mesh.nC)
-        w = np.random.rand(self.mesh.nF)
+        rng = np.random.default_rng(seed=42)
+        v = rng.uniform(size=self.mesh.nC)
+        w = rng.uniform(size=self.mesh.nF)
         a = w.T.dot(self.src.jInitialDeriv(self.prob, v=v))
         b = v.T.dot(self.src.jInitialDeriv(self.prob, v=w, adjoint=True))
         self.assertTrue(np.allclose(a, b))
 
     def test_adjoint_h(self):
-        v = np.random.rand(self.mesh.nC)
-        w = np.random.rand(self.mesh.nE)
+        rng = np.random.default_rng(seed=42)
+        v = rng.uniform(size=self.mesh.nC)
+        w = rng.uniform(size=self.mesh.nE)
         a = w.T.dot(self.src.hInitialDeriv(self.prob, v=v))
         b = v.T.dot(self.src.hInitialDeriv(self.prob, v=w, adjoint=True))
         self.assertTrue(np.allclose(a, b))

--- a/tests/em/tdem/test_TDEM_inductive_permeable.py
+++ b/tests/em/tdem/test_TDEM_inductive_permeable.py
@@ -232,8 +232,9 @@ class TestInductiveSourcesPermeability(unittest.TestCase):
         assert all(passed)
 
         prob.sigma = 1e-4 * np.ones(mesh.nC)
-        v = utils.mkvc(np.random.rand(mesh.nE))
-        w = utils.mkvc(np.random.rand(mesh.nF))
+        rng = np.random.default_rng(seed=42)
+        v = utils.mkvc(rng.uniform(size=mesh.nE))
+        w = utils.mkvc(rng.uniform(size=mesh.nF))
         assert np.all(
             mesh.get_edge_inner_product(1e-4 * np.ones(mesh.nC)) * v == prob.MeSigma * v
         )
@@ -256,8 +257,9 @@ class TestInductiveSourcesPermeability(unittest.TestCase):
         )
 
         prob.rho = 1.0 / 1e-3 * np.ones(mesh.nC)
-        v = utils.mkvc(np.random.rand(mesh.nE))
-        w = utils.mkvc(np.random.rand(mesh.nF))
+        rng = np.random.default_rng(seed=42)
+        v = utils.mkvc(rng.uniform(size=mesh.nE))
+        w = utils.mkvc(rng.uniform(size=mesh.nF))
 
         np.testing.assert_allclose(
             mesh.get_edge_inner_product(1e-3 * np.ones(mesh.nC)) * v, prob.MeSigma * v


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Replace the usage of the deprecated functions in `numpy.random` module for the Numpy's random number generator class and its methods, in most of the TDEM tests.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
