### PR TITLE
Fix bug on arguments of beta estimator directives

### DIFF
--- a/simpeg/directives/directives.py
+++ b/simpeg/directives/directives.py
@@ -355,9 +355,7 @@ class BaseBetaEstimator(InversionDirective):
     def __init__(
         self,
         beta0_ratio=1.0,
-        n_pw_iter=4,
         seed=None,
-        method="power_iteration",
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/simpeg/directives/directives.py
+++ b/simpeg/directives/directives.py
@@ -452,7 +452,7 @@ class BetaEstimateMaxDerivative(BaseBetaEstimator):
     """
 
     def __init__(self, beta0_ratio=1.0, seed=None, **kwargs):
-        super().__init__(beta0_ratio, seed, **kwargs)
+        super().__init__(beta0_ratio=beta0_ratio, seed=seed, **kwargs)
 
     def initialize(self):
         if self.seed is not None:
@@ -522,7 +522,7 @@ class BetaEstimate_ByEig(BaseBetaEstimator):
     """
 
     def __init__(self, beta0_ratio=1.0, n_pw_iter=4, seed=None, **kwargs):
-        super().__init__(beta0_ratio, seed, **kwargs)
+        super().__init__(beta0_ratio=beta0_ratio, seed=seed, **kwargs)
         self.n_pw_iter = n_pw_iter
 
     @property

--- a/tests/base/test_directives.py
+++ b/tests/base/test_directives.py
@@ -397,5 +397,33 @@ class TestUpdateSensitivityNormalization:
             d_temp.normalization_method = normalization_method
 
 
+class TestBetaEstimatorArguments:
+    """
+    Test if arguments are assigned in beta estimator directives.
+    """
+
+    def test_beta_estimate_by_eig(self):
+        """Test on directives.BetaEstimate_ByEig."""
+        beta0_ratio = 3.0
+        n_pw_iter = 3
+        seed = 42
+        directive = directives.BetaEstimate_ByEig(
+            beta0_ratio=beta0_ratio, n_pw_iter=n_pw_iter, seed=seed
+        )
+        assert directive.beta0_ratio == beta0_ratio
+        assert directive.n_pw_iter == n_pw_iter
+        assert directive.seed == seed
+
+    def test_beta_estimate_max_derivative(self):
+        """Test on directives.BetaEstimateMaxDerivative."""
+        beta0_ratio = 3.0
+        seed = 42
+        directive = directives.BetaEstimateMaxDerivative(
+            beta0_ratio=beta0_ratio, seed=seed
+        )
+        assert directive.beta0_ratio == beta0_ratio
+        assert directive.seed == seed
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/base/test_directives.py
+++ b/tests/base/test_directives.py
@@ -400,6 +400,8 @@ class TestUpdateSensitivityNormalization:
 class TestBetaEstimatorArguments:
     """
     Test if arguments are assigned in beta estimator directives.
+    
+    These tests catch the bug described and fixed in #1460.
     """
 
     def test_beta_estimate_by_eig(self):

--- a/tests/base/test_directives.py
+++ b/tests/base/test_directives.py
@@ -400,7 +400,6 @@ class TestUpdateSensitivityNormalization:
 class TestBetaEstimatorArguments:
     """
     Test if arguments are assigned in beta estimator directives.
-    
     These tests catch the bug described and fixed in #1460.
     """
 


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Fix bug in the constructor of beta estimator directive classes: the `seed` argument was being passed as a positional argument to the parent's constructor, which would assign it to the `n_pw_iter` attribute instead to the `seed`, leading to unwanted behaviours. Pass the arguments to the constructor through keywords to make it more explicit and less prone to errors. Add tests that would fail without this bugfix. Remove the `n_pw_iter` and the `method` arguments from the constructor of `BaseBetaEstimator`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Related to #1290 

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
