### PR TITLE
Ensure the queue's are joined when the meta simulation is joined.

### DIFF
--- a/simpeg/meta/multiprocessing.py
+++ b/simpeg/meta/multiprocessing.py
@@ -26,7 +26,12 @@ class SimpleFuture:
 
     def __del__(self):
         # Tell the child process that this object is no longer needed in its cache.
-        self.t_queue.put(("del_item", (self.item_id,)))
+        try:
+            self.t_queue.put(("del_item", (self.item_id,)))
+        except ValueError:
+            # if the queue was already closed it will throw a value error
+            # so catch it here gracefully and continue on.
+            pass
 
 
 class _SimulationProcess(Process):
@@ -170,9 +175,12 @@ class _SimulationProcess(Process):
         return self.result_queue.get()
 
     def join(self, timeout=None):
+        self._check_closed()
         self.task_queue.put(None)
-        self.result_queue.join(timeout=timeout)
-        self.task_queue.join(timeout=timeout)
+        self.task_queue.close()
+        self.result_queue.close()
+        self.task_queue.join_thread()
+        self.result_queue.join_thread()
         super().join(timeout=timeout)
 
 
@@ -199,11 +207,11 @@ class MultiprocessingMetaSimulation(MetaSimulation):
     ...     sim = MultiprocessingMetaSimulation(...)
     ...     sim.dpred(model)
 
-    You must also be sure to call sim.close() before discarding
+    You must also be sure to call `sim.join()` before discarding
     this worker to kill the subprocesses that are created, as you would with
-    any other multiprocessing queue.
+    any other multiprocessing process.
 
-    >>> sim.close()
+    >>> sim.join()
 
     Parameters
     ----------

--- a/simpeg/meta/multiprocessing.py
+++ b/simpeg/meta/multiprocessing.py
@@ -169,6 +169,12 @@ class _SimulationProcess(Process):
         self._check_closed()
         return self.result_queue.get()
 
+    def join(self, timeout=None):
+        self.task_queue.put(None)
+        self.result_queue.join(timeout=timeout)
+        self.task_queue.join(timeout=timeout)
+        super().join(timeout=timeout)
+
 
 class MultiprocessingMetaSimulation(MetaSimulation):
     """Multiprocessing version of simulation of simulations.
@@ -344,7 +350,6 @@ class MultiprocessingMetaSimulation(MetaSimulation):
     def join(self, timeout=None):
         for p in self._sim_processes:
             if p.is_alive():
-                p.task_queue.put(None)
                 p.join(timeout=timeout)
 
 


### PR DESCRIPTION

#### Summary
Join's the multiprocessing queues in the `MultiprocessingMetaSimulation` when the simulation is joined.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### What does this implement/fix?
Likely caused the broken pipe errors in the testing environment.
