### PR TITLE
Add `random_seed` to the `test` method of maps

### DIFF
--- a/simpeg/maps.py
+++ b/simpeg/maps.py
@@ -1,3 +1,5 @@
+from __future__ import annotations  # needed to use type operands in Python 3.8
+
 from collections import namedtuple
 import warnings
 import discretize
@@ -32,6 +34,7 @@ from .utils import (
     validate_active_indices,
     validate_list_of_types,
 )
+from .typing import RandomSeed
 
 
 class IdentityMap:
@@ -189,7 +192,7 @@ class IdentityMap:
             return sp.identity(self.nP)
         return Identity()
 
-    def test(self, m=None, num=4, random_seed=None, **kwargs):
+    def test(self, m=None, num=4, random_seed: RandomSeed | None = None, **kwargs):
         """Derivative test for the mapping.
 
         This test validates the mapping by performing a convergence test.
@@ -200,7 +203,7 @@ class IdentityMap:
             Starting vector of model parameters for the derivative test
         num : int
             Number of iterations for the derivative test
-        random_seed : {None, RandomSeed}, optional
+        random_seed : None or :class:`~simpeg.typing.RandomSeed`, optional
             Random seed used for generating a random array for ``m`` if it's
             None. It can either be an int, a predefined Numpy random number
             generator, or any valid input to ``numpy.random.default_rng``.

--- a/simpeg/maps.py
+++ b/simpeg/maps.py
@@ -189,7 +189,7 @@ class IdentityMap:
             return sp.identity(self.nP)
         return Identity()
 
-    def test(self, m=None, num=4, **kwargs):
+    def test(self, m=None, num=4, random_seed=None, **kwargs):
         """Derivative test for the mapping.
 
         This test validates the mapping by performing a convergence test.
@@ -200,6 +200,10 @@ class IdentityMap:
             Starting vector of model parameters for the derivative test
         num : int
             Number of iterations for the derivative test
+        random_seed : {None, RandomSeed}, optional
+            Random seed used for generating a random array for ``m`` if it's
+            None. It can either be an int, a predefined Numpy random number
+            generator, or any valid input to ``numpy.random.default_rng``.
         kwargs: dict
             Keyword arguments and associated values in the dictionary must
             match those used in :meth:`discretize.tests.check_derivative`
@@ -211,7 +215,8 @@ class IdentityMap:
         """
         print("Testing {0!s}".format(str(self)))
         if m is None:
-            m = abs(np.random.rand(self.nP))
+            rng = np.random.default_rng(seed=random_seed)
+            m = rng.uniform(size=self.nP)
         if "plotIt" not in kwargs:
             kwargs["plotIt"] = False
 

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -129,19 +129,19 @@ class MapTests(unittest.TestCase):
 
     def test_transforms2D(self):
         for M in self.maps2test2D:
-            self.assertTrue(M(self.mesh2).test())
+            self.assertTrue(M(self.mesh2).test(random_seed=42))
 
     def test_transforms2Dvec(self):
         for M in self.maps2test2D:
-            self.assertTrue(M(self.mesh2).test())
+            self.assertTrue(M(self.mesh2).test(random_seed=42))
 
     def test_transforms3D(self):
         for M in self.maps2test3D:
-            self.assertTrue(M(self.mesh3).test())
+            self.assertTrue(M(self.mesh3).test(random_seed=42))
 
     def test_transforms3Dvec(self):
         for M in self.maps2test3D:
-            self.assertTrue(M(self.mesh3).test())
+            self.assertTrue(M(self.mesh3).test(random_seed=42))
 
     def test_invtransforms2D(self):
         for M in self.maps2test2D:
@@ -184,14 +184,14 @@ class MapTests(unittest.TestCase):
     def test_ParametricCasingAndLayer(self):
         mapping = maps.ParametricCasingAndLayer(self.meshCyl)
         m = np.r_[-2.0, 1.0, 6.0, 2.0, -0.1, 0.2, 0.5, 0.2, -0.2, 0.2]
-        self.assertTrue(mapping.test(m))
+        self.assertTrue(mapping.test(m=m))
 
     def test_ParametricBlock2D(self):
         mesh = discretize.TensorMesh([np.ones(30), np.ones(20)], x0=np.array([-15, -5]))
         mapping = maps.ParametricBlock(mesh)
         # val_background,val_block, block_x0, block_dx, block_y0, block_dy
         m = np.r_[-2.0, 1.0, -5, 10, 5, 4]
-        self.assertTrue(mapping.test(m))
+        self.assertTrue(mapping.test(m=m))
 
     def test_transforms_logMap_reciprocalMap(self):
         # Note that log/reciprocal maps can be kinda finicky, so we are being
@@ -233,22 +233,22 @@ class MapTests(unittest.TestCase):
         ]
 
         mapping = maps.LogMap(self.mesh2)
-        self.assertTrue(mapping.test(v2, dx=dv2))
+        self.assertTrue(mapping.test(m=v2, dx=dv2))
         mapping = maps.LogMap(self.mesh3)
-        self.assertTrue(mapping.test(v3, dx=dv3))
+        self.assertTrue(mapping.test(m=v3, dx=dv3))
 
         mapping = maps.ReciprocalMap(self.mesh2)
-        self.assertTrue(mapping.test(v2, dx=dv2))
+        self.assertTrue(mapping.test(m=v2, dx=dv2))
         mapping = maps.ReciprocalMap(self.mesh3)
-        self.assertTrue(mapping.test(v3, dx=dv3))
+        self.assertTrue(mapping.test(m=v3, dx=dv3))
 
     def test_Mesh2MeshMap(self):
         mapping = maps.Mesh2Mesh([self.mesh22, self.mesh2])
-        self.assertTrue(mapping.test())
+        self.assertTrue(mapping.test(random_seed=42))
 
     def test_Mesh2MeshMapVec(self):
         mapping = maps.Mesh2Mesh([self.mesh22, self.mesh2])
-        self.assertTrue(mapping.test())
+        self.assertTrue(mapping.test(random_seed=42))
 
     def test_mapMultiplication(self):
         M = discretize.TensorMesh([2, 3])
@@ -335,7 +335,7 @@ class MapTests(unittest.TestCase):
         ]:
             # m2to3 = maps.Surject2Dto3D(M3, normal='X')
             m = np.arange(m2to3.nP)
-            self.assertTrue(m2to3.test())
+            self.assertTrue(m2to3.test(random_seed=42))
             self.assertTrue(
                 np.all(utils.mkvc((m2to3 * m).reshape(M3.vnC, order="F")[0, :, :]) == m)
             )
@@ -350,7 +350,7 @@ class MapTests(unittest.TestCase):
         ]:
             # m2to3 = maps.Surject2Dto3D(M3, normal='Y')
             m = np.arange(m2to3.nP)
-            self.assertTrue(m2to3.test())
+            self.assertTrue(m2to3.test(random_seed=42))
             self.assertTrue(
                 np.all(utils.mkvc((m2to3 * m).reshape(M3.vnC, order="F")[:, 0, :]) == m)
             )
@@ -365,7 +365,7 @@ class MapTests(unittest.TestCase):
         ]:
             # m2to3 = maps.Surject2Dto3D(M3, normal='Z')
             m = np.arange(m2to3.nP)
-            self.assertTrue(m2to3.test())
+            self.assertTrue(m2to3.test(random_seed=42))
             self.assertTrue(
                 np.all(utils.mkvc((m2to3 * m).reshape(M3.vnC, order="F")[:, :, 0]) == m)
             )
@@ -379,7 +379,7 @@ class MapTests(unittest.TestCase):
         M2 = discretize.TensorMesh([np.ones(10), np.ones(10)], "CN")
         x = M2.cell_centers_x
         mParamSpline = maps.ParametricSplineMap(M2, x, normal="Y", order=1)
-        self.assertTrue(mParamSpline.test())
+        self.assertTrue(mParamSpline.test(random_seed=42))
 
     def test_parametric_block(self):
         M1 = discretize.TensorMesh([np.ones(10)], "C")
@@ -471,8 +471,8 @@ class MapTests(unittest.TestCase):
 
         self.assertTrue(np.all(summap0 * m0 == summap1 * m0))
 
-        self.assertTrue(summap0.test(m0))
-        self.assertTrue(summap1.test(m0))
+        self.assertTrue(summap0.test(m=m0))
+        self.assertTrue(summap1.test(m=m0))
 
     def test_surject_units(self):
         M2 = discretize.TensorMesh([np.ones(10), np.ones(20)], "CC")
@@ -486,7 +486,7 @@ class MapTests(unittest.TestCase):
 
         self.assertTrue(np.all(m1[unit1] == 0))
         self.assertTrue(np.all(m1[unit2] == 1))
-        self.assertTrue(surject_units.test(m0))
+        self.assertTrue(surject_units.test(m=m0))
 
     def test_Projection(self):
         nP = 10
@@ -508,7 +508,7 @@ class MapTests(unittest.TestCase):
             maps.Projection(nP, np.r_[10]) * m
 
         mapping = maps.Projection(nP, np.r_[1, 2, 6, 1, 3, 5, 4, 9, 9, 8, 0])
-        mapping.test()
+        mapping.test(random_seed=42)
 
     def test_Tile(self):
         """
@@ -690,7 +690,7 @@ def test_LinearMapDerivs(A, b):
     y1 = mapping.deriv(m) @ v
     y2 = mapping.deriv(m, v=v)
     np.testing.assert_equal(y1, y2)
-    mapping.test()
+    mapping.test(random_seed=42)
 
 
 def test_LinearMap_errors():


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Add `random_seed` argument to `IdentityMap.test`. Add a new `random_seed` argument to the `test` method of `IdentityMap` to control the random state for creating the `m` array if it's not provided. Update tests to use the `random_seed`. If the `m` array is passed while running the `test()` method, specify the keyword for the argument to avoid relying only on its position.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->

**TODO:**

- [x] Add `from simpeg.typing import RandomSeed` after #1394 is merged
