### PR TITLE
Replace deprecated refine_tree_xyz across tests

### DIFF
--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -5,7 +5,7 @@ import pytest
 import scipy.sparse as sp
 
 from simpeg import maps, models, utils
-from discretize.utils import mesh_builder_xyz, refine_tree_xyz, active_from_xyz
+from discretize.utils import mesh_builder_xyz, active_from_xyz
 import inspect
 
 TOL = 1e-14
@@ -524,14 +524,11 @@ class MapTests(unittest.TestCase):
             local_mesh = mesh_builder_xyz(
                 rxLocs, h, padding_distance=padDist, mesh_type="tree"
             )
-            local_mesh = refine_tree_xyz(
-                local_mesh,
-                rxLocs[ii, :].reshape((1, -1)),
-                method="radial",
-                octree_levels=[1],
+            local_mesh.refine_points(
+                points=rxLocs[ii, :].reshape((1, -1)),
+                padding_cells_by_level=[1],
                 finalize=True,
             )
-
             local_meshes.append(local_mesh)
 
         mesh = mesh_builder_xyz(rxLocs, h, padding_distance=padDist, mesh_type="tree")

--- a/tests/dask/test_mag_MVI_Octree.py
+++ b/tests/dask/test_mag_MVI_Octree.py
@@ -12,7 +12,7 @@ from simpeg import (
 )
 
 
-from discretize.utils import mesh_builder_xyz, refine_tree_xyz, active_from_xyz
+from discretize.utils import mesh_builder_xyz, active_from_xyz
 import numpy as np
 from simpeg.potential_fields import magnetics as mag
 import shutil
@@ -62,9 +62,7 @@ class MVIProblemTest(unittest.TestCase):
         mesh = mesh_builder_xyz(
             xyzLoc, h, padding_distance=padDist, depth_core=100, mesh_type="tree"
         )
-        mesh = refine_tree_xyz(
-            mesh, topo, method="surface", octree_levels=[4, 4], finalize=True
-        )
+        mesh.refine_surface(topo, padding_cells_by_level=[4, 4], finalize=True)
         self.mesh = mesh
         # Define an active cells from topo
         actv = active_from_xyz(mesh, topo)

--- a/tests/dask/test_mag_inversion_linear_Octree.py
+++ b/tests/dask/test_mag_inversion_linear_Octree.py
@@ -73,14 +73,7 @@ class MagInvLinProblemTest(unittest.TestCase):
             mesh_type="TREE",
         )
 
-        self.mesh = mesh_utils.refine_tree_xyz(
-            self.mesh,
-            topo,
-            method="surface",
-            octree_levels=nCpad,
-            octree_levels_padding=nCpad,
-            finalize=True,
-        )
+        self.mesh.refine_surface(topo, padding_cells_by_level=nCpad, finalize=True)
 
         # Define an active cells from topo
         actv = active_from_xyz(self.mesh, topo)

--- a/tests/dask/test_mag_nonLinear_Amplitude.py
+++ b/tests/dask/test_mag_nonLinear_Amplitude.py
@@ -14,7 +14,7 @@ from simpeg import (
 from simpeg.potential_fields import magnetics
 from simpeg import utils
 from simpeg.utils import mkvc
-from discretize.utils import mesh_builder_xyz, refine_tree_xyz, active_from_xyz
+from discretize.utils import mesh_builder_xyz, active_from_xyz
 import unittest
 import shutil
 
@@ -65,9 +65,7 @@ class AmpProblemTest(unittest.TestCase):
         mesh = mesh_builder_xyz(
             rxLoc, h, padding_distance=padDist, depth_core=100, mesh_type="tree"
         )
-        mesh = refine_tree_xyz(
-            mesh, topo, method="surface", octree_levels=[4, 4], finalize=True
-        )
+        mesh.refine_surface(topo, padding_cells_by_level=[4, 4], finalize=True)
 
         # Define an active cells from topo
         actv = active_from_xyz(mesh, topo)

--- a/tests/pf/test_mag_MVI_Octree.py
+++ b/tests/pf/test_mag_MVI_Octree.py
@@ -11,7 +11,7 @@ from simpeg import (
 )
 
 
-from discretize.utils import mesh_builder_xyz, refine_tree_xyz, active_from_xyz
+from discretize.utils import mesh_builder_xyz, active_from_xyz
 import numpy as np
 from simpeg.potential_fields import magnetics as mag
 import shutil
@@ -61,8 +61,8 @@ class MVIProblemTest(unittest.TestCase):
         mesh = mesh_builder_xyz(
             xyzLoc, h, padding_distance=padDist, depth_core=100, mesh_type="tree"
         )
-        mesh = refine_tree_xyz(
-            mesh, topo, method="surface", octree_levels=[4, 4], finalize=True
+        mesh.refine_surface(
+            topo, method="surface", padding_cells_by_level=[4, 4], finalize=True
         )
         self.mesh = mesh
         # Define an active cells from topo

--- a/tests/pf/test_mag_inversion_linear_Octree.py
+++ b/tests/pf/test_mag_inversion_linear_Octree.py
@@ -2,7 +2,7 @@ import shutil
 import unittest
 import numpy as np
 
-from discretize.utils import mesh_builder_xyz, refine_tree_xyz, active_from_xyz
+from discretize.utils import mesh_builder_xyz, active_from_xyz
 from simpeg import (
     directives,
     maps,
@@ -71,14 +71,7 @@ class MagInvLinProblemTest(unittest.TestCase):
             mesh_type="TREE",
         )
 
-        self.mesh = refine_tree_xyz(
-            self.mesh,
-            topo,
-            method="surface",
-            octree_levels=nCpad,
-            octree_levels_padding=nCpad,
-            finalize=True,
-        )
+        self.mesh.refine_surface(topo, padding_cells_by_level=nCpad, finalize=True)
 
         # Define an active cells from topo
         actv = active_from_xyz(self.mesh, topo)

--- a/tests/pf/test_mag_nonLinear_Amplitude.py
+++ b/tests/pf/test_mag_nonLinear_Amplitude.py
@@ -13,7 +13,7 @@ from simpeg import (
 from simpeg.potential_fields import magnetics
 from simpeg import utils
 from simpeg.utils import mkvc
-from discretize.utils import mesh_builder_xyz, refine_tree_xyz, active_from_xyz
+from discretize.utils import mesh_builder_xyz, active_from_xyz
 import unittest
 import shutil
 
@@ -64,9 +64,7 @@ class AmpProblemTest(unittest.TestCase):
         mesh = mesh_builder_xyz(
             rxLoc, h, padding_distance=padDist, depth_core=100, mesh_type="tree"
         )
-        mesh = refine_tree_xyz(
-            mesh, topo, method="surface", octree_levels=[4, 4], finalize=True
-        )
+        mesh.refine_surface(topo, padding_cells_by_level=[4, 4], finalize=True)
 
         # Define an active cells from topo
         actv = active_from_xyz(mesh, topo)

--- a/tests/pf/test_mag_vector_amplitude.py
+++ b/tests/pf/test_mag_vector_amplitude.py
@@ -11,7 +11,7 @@ from simpeg import (
 )
 
 
-from discretize.utils import mesh_builder_xyz, refine_tree_xyz, active_from_xyz
+from discretize.utils import mesh_builder_xyz, active_from_xyz
 import numpy as np
 from simpeg.potential_fields import magnetics as mag
 import shutil
@@ -61,9 +61,7 @@ class MVIProblemTest(unittest.TestCase):
         mesh = mesh_builder_xyz(
             xyzLoc, h, padding_distance=padDist, depth_core=100, mesh_type="tree"
         )
-        mesh = refine_tree_xyz(
-            mesh, topo, method="surface", octree_levels=[4, 4], finalize=True
-        )
+        mesh.refine_surface(topo, padding_cells_by_level=[4, 4], finalize=True)
         self.mesh = mesh
         # Define an active cells from topo
         actv = active_from_xyz(mesh, topo)

--- a/tests/pf/test_pf_quadtree_inversion_linear.py
+++ b/tests/pf/test_pf_quadtree_inversion_linear.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 from discretize import TensorMesh
-from discretize.utils import mesh_builder_xyz, mkvc, refine_tree_xyz
+from discretize.utils import mesh_builder_xyz, mkvc
 
 from simpeg import (
     data_misfit,
@@ -50,20 +50,15 @@ class QuadTreeLinProblemTest(unittest.TestCase):
             padDist = np.ones((2, 2)) * 100
             nCpad = [2, 4]
 
-            mesh = mesh_builder_xyz(
+            self.mesh = mesh_builder_xyz(
                 topo[:, :2],
                 h,
                 padding_distance=padDist,
                 mesh_type="TREE",
             )
 
-            self.mesh = refine_tree_xyz(
-                mesh,
-                data[:, :2],
-                method="radial",
-                octree_levels=nCpad,
-                octree_levels_padding=nCpad,
-                finalize=True,
+            self.mesh.refine_points(
+                data[:, :2], padding_cells_by_level=nCpad, finalize=True
             )
 
             # elevations are Nx2 array of [bottom-southwest, top-northeast] corners


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Replace usage of the deprecated `refine_tree_xyz` function from discretize for their latest equivalent methods of the `TreeMesh`: `refine_surface` and `refine_points`. Apply these replacements across simpeg tests.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
