### PR TITLE
Hide type hints from signatures in documentation pages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -483,6 +483,8 @@ sphinx_gallery_conf = {
 
 autodoc_member_order = "bysource"
 
+# Don't show type hints in signatures
+autodoc_typehints = "none"
 
 # def supress_nonlocal_image_warn():
 #     import sphinx.environment


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Configure Sphinx autodoc to hide type hints from signatures of functions, methods and classes to improve readability. Expected types for each parameter should be listed in the docstring.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
