### PR TITLE
Fix call to private method in GaussianMixtureWithPrior

### DIFF
--- a/simpeg/utils/pgi_utils.py
+++ b/simpeg/utils/pgi_utils.py
@@ -1170,7 +1170,16 @@ class GaussianMixtureWithPrior(WeightedGaussianMixture):
                     self.converged_ = True
                     break
 
-            self._print_verbose_msg_init_end(lower_bound)
+            # Use try-except to maintain support for older (scikit-learn<1.5.0)
+            # versions of this private method
+            try:
+                self._print_verbose_msg_init_end(lower_bound, init_has_converged=True)
+            except TypeError as exception:
+                # In scikit-learn<1.5.0, the method has a single argument
+                match = "got an unexpected keyword argument 'init_has_converged'"
+                if match not in str(exception):
+                    raise
+                self._print_verbose_msg_init_end(lower_bound)
 
             if lower_bound > max_lower_bound or max_lower_bound == -np.inf:
                 max_lower_bound = lower_bound

--- a/simpeg/utils/pgi_utils.py
+++ b/simpeg/utils/pgi_utils.py
@@ -1170,16 +1170,7 @@ class GaussianMixtureWithPrior(WeightedGaussianMixture):
                     self.converged_ = True
                     break
 
-            # Use try-except to maintain support for older (scikit-learn<1.5.0)
-            # versions of this private method
-            try:
-                self._print_verbose_msg_init_end(lower_bound, init_has_converged=True)
-            except TypeError as exception:
-                # In scikit-learn<1.5.0, the method has a single argument
-                match = "got an unexpected keyword argument 'init_has_converged'"
-                if match not in str(exception):
-                    raise
-                self._print_verbose_msg_init_end(lower_bound)
+            self._custom_print_verbose_msg_init_end(lower_bound)
 
             if lower_bound > max_lower_bound or max_lower_bound == -np.inf:
                 max_lower_bound = lower_bound
@@ -1201,6 +1192,22 @@ class GaussianMixtureWithPrior(WeightedGaussianMixture):
         self.lower_bound_ = max_lower_bound
 
         return self
+
+    def _custom_print_verbose_msg_init_end(self, ll):
+        """
+        Wrapper for the upstream _print_verbose_msg_init_end
+
+        This method was created to provide support of older versions
+        (scikit-learn<1.5.0) of this private method.
+        """
+        try:
+            self._print_verbose_msg_init_end(ll, init_has_converged=True)
+        except TypeError as exception:
+            # In scikit-learn<1.5.0, the method has a single argument
+            match = "got an unexpected keyword argument 'init_has_converged'"
+            if match not in str(exception):
+                raise
+            self._print_verbose_msg_init_end(ll)
 
 
 class GaussianMixtureWithNonlinearRelationships(WeightedGaussianMixture):

--- a/tests/utils/test_gmm_utils.py
+++ b/tests/utils/test_gmm_utils.py
@@ -338,7 +338,7 @@ class TestCustomPrintMethod:
 
     @pytest.mark.parametrize("gmm_class", (MockGMMLatest, MockGMMOlder))
     def test_custom_print_verbose_method(self, gmmref, gmm_class):
-        """Test against latest signature of the method: with two arguments."""
+        """Test custom method against older and latest signature of the upstream one."""
         gmm = gmm_class(gmmref=gmmref)
         # Run the custom private method: it should not raise any error
         gmm._custom_print_verbose_msg_init_end(3)


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Update call of `_print_verbose_msg_init_end` in `GaussianMixtureWithPrior`: since `scikit-learn>=1.5.0` it requires two positional arguments. Use a `try-except` block to maintain support for older versions of `scikit-learn`. Create a new private method for the `GaussianMixtureWithPrior` class to wrap the `_print_verbose_msg_init_end` method including the `try-except` block. Add tests.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Fix #1475

#### Additional information
<!--Any additional information you think is important.-->

<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
