### PR TITLE
Fix script for new deployment of docs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,41 +26,6 @@ pr:
 
 stages:
 
-- stage: Experiment
-  displayName: "Experiment with the repo"
-  jobs:
-    - job:
-      displayName: Experiment with repo
-      pool:
-        vmImage: ubuntu-latest
-      timeoutInMinutes: 240
-      steps:
-
-        # Checkout simpeg repo, including tags.
-        # We need to sync tags and disable shallow depth in order to get the
-        # SimPEG version while building the docs.
-        - checkout: self
-          fetchDepth: 0
-          fetchTags: true
-          displayName: Checkout repository (including tags)
-
-        - script: |
-            pwd
-            git clone -b dev --depth 1 https://${GH_TOKEN}@github.com/simpeg/simpeg-doctest.git
-            cd simpeg-doctest
-            pwd
-            echo "Check dev branch"
-            echo "----------------"
-            git status
-            ls -l
-            echo "Check gh-pages branch"
-            echo "---------------------"
-            git fetch --depth 1 origin gh-pages:gh-pages
-            git switch gh-pages
-            git status
-            ls -l
-          displayName: Clone simpeg-doctest repo
-
 - stage: StyleChecks
   displayName: "Style Checks"
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ stages:
             ls -l
             echo "Check gh-pages branch"
             echo "---------------------"
-            git fetch --depth 1 origin gh-pages
+            git fetch --depth 1 origin gh-pages:gh-pages
             git switch gh-pages
             git status
             ls -l

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,40 @@ pr:
 
 stages:
 
+- stage: Experiment
+  displayName: "Experiment with the repo"
+  jobs:
+    - job:
+      displayName: Experiment with repo
+      pool:
+        vmImage: ubuntu-latest
+      timeoutInMinutes: 240
+      steps:
+
+        # Checkout simpeg repo, including tags.
+        # We need to sync tags and disable shallow depth in order to get the
+        # SimPEG version while building the docs.
+        - checkout: self
+          fetchDepth: 0
+          fetchTags: true
+          displayName: Checkout repository (including tags)
+
+        - script: |
+            pwd
+            git clone -b dev --depth 1 https://${GH_TOKEN}@github.com/simpeg/simpeg-doctest.git
+            cd simpeg-doctest
+            pwd
+            echo "Check dev branch"
+            echo "----------------"
+            git status
+            ls -l
+            echo "Check gh-pages branch"
+            echo "---------------------"
+            git switch gh-pages
+            git status
+            ls -l
+          displayName: Build package
+
 - stage: StyleChecks
   displayName: "Style Checks"
   jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,10 +55,11 @@ stages:
             ls -l
             echo "Check gh-pages branch"
             echo "---------------------"
+            git fetch --depth 1 origin gh-pages
             git switch gh-pages
             git status
             ls -l
-          displayName: Build package
+          displayName: Clone simpeg-doctest repo
 
 - stage: StyleChecks
   displayName: "Style Checks"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -241,7 +241,7 @@ stages:
             # Capture hash of last commit in simpeg
             commit=$(git rev-parse --short HEAD)
             # Clone the repo where we store the documentation (dev branch)
-            git clone -b dev --depth 1 https://${GH_TOKEN}@github.com/simpeg/simpeg-doctest.git
+            git clone -q --branch dev --depth 1 https://${GH_TOKEN}@github.com/simpeg/simpeg-doctest.git
             cd simpeg-doctest
             # Remove all files
             shopt -s dotglob  # configure bash to include dotfiles in * globs
@@ -365,7 +365,7 @@ stages:
             # Capture hash of last commit in simpeg
             commit=$(git rev-parse --short HEAD)
             # Clone the repo where we store the documentation
-            git clone --depth 1 https://${GH_TOKEN}@github.com/simpeg/simpeg-doctest.git
+            git clone -q --branch gh-pages --depth 1 https://${GH_TOKEN}@github.com/simpeg/simpeg-doctest.git
             cd simpeg-doctest
             # Move the built docs to a new dev folder
             cp -r $BUILD_SOURCESDIRECTORY/docs/_build/html "$version"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -274,7 +274,7 @@ stages:
             # Make the push quiet just in case there is anything that could
             # leak sensitive information.
             echo -e "\nPushing changes to simpeg/simpeg-doctest (gh-pages branch)."
-            git push -fq origin gh-pages 2>&1 >/dev/null
+            git push -q origin gh-pages 2>&1 >/dev/null
             echo -e "\nFinished updating submodule dev."
 
             # Unset dotglob

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -297,6 +297,9 @@ stages:
 
             # Update submodule
             # ----------------
+            # Need to fetch the gh-pages branch first (because we clone with
+            # shallow depth)
+            git fetch --depth 1 origin gh-pages:gh-pages
             # Switch to the gh-pages branch
             git switch gh-pages
             # Update the dev submodule


### PR DESCRIPTION
#### Summary

Fix issues in the new (experimental) scripts for deployment of docs to `simpeg-doctest`. Fetch the `gh-pages` before trying to checkout it. This is needed because we clone the repo with `--depth 1`. When passing this option, git appends the `--single-branch` option meaning the `dev` branch is the only branch that is being cloned. Improve how we clone the `simpeg-doctest` repo: clone quietly to reduce output lines, and specify the branch while deploying release docs (in case the default branch in the repo gets changed).

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
