### PR TITLE
Fix contour colors in gravity plot in User Guide

### DIFF
--- a/tutorials/03-gravity/plot_1a_gravity_anomaly.py
+++ b/tutorials/03-gravity/plot_1a_gravity_anomaly.py
@@ -214,14 +214,16 @@ dpred = simulation.dpred(model)
 # Plot
 fig = plt.figure(figsize=(7, 5))
 
+v_max = np.max(np.abs(dpred))
+
 ax1 = fig.add_axes([0.1, 0.1, 0.75, 0.85])
-plot2Ddata(receiver_list[0].locations, dpred, ax=ax1, contourOpts={"cmap": "bwr"})
+plot2Ddata(receiver_list[0].locations, dpred, clim=(-v_max,v_max), ax=ax1, contourOpts={"cmap": "bwr"})
 ax1.set_title("Gravity Anomaly (Z-component)")
 ax1.set_xlabel("x (m)")
 ax1.set_ylabel("y (m)")
 
 ax2 = fig.add_axes([0.82, 0.1, 0.03, 0.85])
-norm = mpl.colors.Normalize(vmin=-np.max(np.abs(dpred)), vmax=np.max(np.abs(dpred)))
+norm = mpl.colors.Normalize(vmin=-v_max, vmax=v_max)
 cbar = mpl.colorbar.ColorbarBase(
     ax2, norm=norm, orientation="vertical", cmap=mpl.cm.bwr, format="%.1e"
 )

--- a/tutorials/03-gravity/plot_1a_gravity_anomaly.py
+++ b/tutorials/03-gravity/plot_1a_gravity_anomaly.py
@@ -217,7 +217,13 @@ fig = plt.figure(figsize=(7, 5))
 v_max = np.max(np.abs(dpred))
 
 ax1 = fig.add_axes([0.1, 0.1, 0.75, 0.85])
-plot2Ddata(receiver_list[0].locations, dpred, clim=(-v_max, v_max), ax=ax1, contourOpts={"cmap": "bwr"})
+plot2Ddata(
+    receiver_list[0].locations, 
+    dpred, 
+    clim=(-v_max, v_max), 
+    ax=ax1, 
+    contourOpts={"cmap": "bwr"}
+)
 ax1.set_title("Gravity Anomaly (Z-component)")
 ax1.set_xlabel("x (m)")
 ax1.set_ylabel("y (m)")

--- a/tutorials/03-gravity/plot_1a_gravity_anomaly.py
+++ b/tutorials/03-gravity/plot_1a_gravity_anomaly.py
@@ -218,11 +218,11 @@ v_max = np.max(np.abs(dpred))
 
 ax1 = fig.add_axes([0.1, 0.1, 0.75, 0.85])
 plot2Ddata(
-    receiver_list[0].locations, 
-    dpred, 
-    clim=(-v_max, v_max), 
-    ax=ax1, 
-    contourOpts={"cmap": "bwr"}
+    receiver_list[0].locations,
+    dpred,
+    clim=(-v_max, v_max),
+    ax=ax1,
+    contourOpts={"cmap": "bwr"},
 )
 ax1.set_title("Gravity Anomaly (Z-component)")
 ax1.set_xlabel("x (m)")

--- a/tutorials/03-gravity/plot_1a_gravity_anomaly.py
+++ b/tutorials/03-gravity/plot_1a_gravity_anomaly.py
@@ -217,7 +217,7 @@ fig = plt.figure(figsize=(7, 5))
 v_max = np.max(np.abs(dpred))
 
 ax1 = fig.add_axes([0.1, 0.1, 0.75, 0.85])
-plot2Ddata(receiver_list[0].locations, dpred, clim=(-v_max,v_max), ax=ax1, contourOpts={"cmap": "bwr"})
+plot2Ddata(receiver_list[0].locations, dpred, clim=(-v_max, v_max), ax=ax1, contourOpts={"cmap": "bwr"})
 ax1.set_title("Gravity Anomaly (Z-component)")
 ax1.set_xlabel("x (m)")
 ax1.set_ylabel("y (m)")


### PR DESCRIPTION
#### Summary
Correcting contour colors in User Guide: Gravity: plot 1a

**Squash and Merge Summary**

Correcting contour colors in a gravity plot in the User Guide for a gravity plot: correctly use the color limits both in the contours and while building the custom color bar.


#### Issue found

In the last figure of the User Guide: Gravity: plot 1a, the plotted contour colors do not correspond to the correct gravity anomaly value indicated in the colorbar on the right.

Relevant section:
https://docs.simpeg.xyz/content/tutorials/03-gravity/plot_1a_gravity_anomaly.html#simulation-gravity-anomaly-data-on-tensor-mesh

### Identifying the problem

There appears to me a mismatch between the plotted contour colors of gravity anomaly and the colorbar on the right.

Currently, the figure displays like this:
![gravity-original](https://github.com/simpeg/simpeg/assets/38541020/2c19d2cb-56e6-4f5c-b085-8d0985e40a22)

However it should plot like this:
![gravity-fixed](https://github.com/simpeg/simpeg/assets/38541020/1cf4a9de-7a1b-4b11-959e-b85e20a4852c)

The mismatch can be viewed in a more noticeable form if we change the model to only have a positive density anomaly:

![altered-density](https://github.com/simpeg/simpeg/assets/38541020/a9152197-f212-44a1-bdf2-9288fe506115)

In this new scenario, the original plotting script in the documentation produces a highly misleading figure:

![altered-gravity-original](https://github.com/simpeg/simpeg/assets/38541020/e4b8ac7f-165f-41fd-9cb1-718fba93e2c6)

Whereas it should actually plot like this:

![altered-gravity-fixed](https://github.com/simpeg/simpeg/assets/38541020/985fbd84-d351-406d-be12-068bf6e48aa2)

#### Diagnosing the problem

The error arrises because the color limits were mistakenly left out of the call to `plot2Ddata`, in the following line:

https://github.com/simpeg/simpeg/blob/cbd200b6774b201f2e6f60cda8b35b4118d512cd/tutorials/03-gravity/plot_1a_gravity_anomaly.py#L218

#### My fix for the problem

The corrected call to `plot2Ddata` should be:

```python
v_max = np.max(np.abs(dpred))
plot2Ddata(receiver_list[0].locations, dpred, clim=(-v_max, v_max), ax=ax1, contourOpts={"cmap": "bwr"})
```

#### Reference issue

No issue to reference.

#### What does this implement/fix?

My change fixes the plotted contours in the last figure of the User Guide: Gravity: plot 1a. In the previous implementation the contour colors did not correspond to the correct gravity anomaly value indicated in the colorbar on the right. In my new implementation, the contour colors now correspond to the correct gravity anomaly value indicated in the colorbar on the right.

#### Additional information

There may be more instances in the documentation where this error is present. My change here is the only one I've found so far.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

