### PR TITLE
Fix extraction of files in some examples

### DIFF
--- a/examples/20-published/plot_booky_1D_time_freq_inv.py
+++ b/examples/20-published/plot_booky_1D_time_freq_inv.py
@@ -57,11 +57,19 @@ def download_and_unzip_data(
     Download the data from the storage bucket, unzip the tar file, return
     the directory where the data are
     """
+    from pathlib import Path
+
     # download the data
     downloads = utils.download(url)
 
     # directory where the downloaded files are
-    directory = downloads.split(".")[0]
+    fname = Path(downloads)
+    if fname.name.endswith(".tar.gz"):
+        n_chars = len(".tar.gz")
+        subfolder = fname.name[:-n_chars]
+    else:
+        raise TypeError(f"Download file '{fname}' is not a tar.gz archive.")
+    directory = str(fname.parent / subfolder)
 
     # unzip the tarfile
     tar = tarfile.open(downloads, "r")

--- a/examples/20-published/plot_booky_1Dstitched_resolve_inv.py
+++ b/examples/20-published/plot_booky_1Dstitched_resolve_inv.py
@@ -53,11 +53,19 @@ def download_and_unzip_data(
     Download the data from the storage bucket, unzip the tar file, return
     the directory where the data are
     """
+    from pathlib import Path
+
     # download the data
     downloads = utils.download(url)
 
     # directory where the downloaded files are
-    directory = downloads.split(".")[0]
+    fname = Path(downloads)
+    if fname.name.endswith(".tar.gz"):
+        n_chars = len(".tar.gz")
+        subfolder = fname.name[:-n_chars]
+    else:
+        raise TypeError(f"Download file '{fname}' is not a tar.gz archive.")
+    directory = str(fname.parent / subfolder)
 
     # unzip the tarfile
     tar = tarfile.open(downloads, "r")

--- a/examples/20-published/plot_laguna_del_maule_inversion.py
+++ b/examples/20-published/plot_laguna_del_maule_inversion.py
@@ -35,17 +35,25 @@ from simpeg.utils.drivers.gravity_driver import GravityDriver_Inv
 def run(plotIt=True, cleanAfterRun=True):
     # Start by downloading files from the remote repository
     # directory where the downloaded files are
+    from pathlib import Path
 
     url = "https://storage.googleapis.com/simpeg/Chile_GRAV_4_Miller/Chile_GRAV_4_Miller.tar.gz"
     downloads = download(url, overwrite=True)
-    basePath = downloads.split(".")[0]
+
+    fname = Path(downloads)
+    if fname.name.endswith(".tar.gz"):
+        n_chars = len(".tar.gz")
+        subfolder = fname.name[:-n_chars]
+    else:
+        raise TypeError(f"Download file '{fname}' is not a tar.gz archive.")
+    basePath = str(fname.parent / subfolder)
 
     # unzip the tarfile
     tar = tarfile.open(downloads, "r")
     tar.extractall()
     tar.close()
 
-    input_file = basePath + os.path.sep + "LdM_input_file.inp"
+    input_file = basePath / "LdM_input_file.inp"
     # %% User input
     # Plotting parameters, max and min densities in g/cc
     vmin = -0.6

--- a/examples/20-published/plot_laguna_del_maule_inversion.py
+++ b/examples/20-published/plot_laguna_del_maule_inversion.py
@@ -46,14 +46,14 @@ def run(plotIt=True, cleanAfterRun=True):
         subfolder = fname.name[:-n_chars]
     else:
         raise TypeError(f"Download file '{fname}' is not a tar.gz archive.")
-    basePath = str(fname.parent / subfolder)
+    basePath = fname.parent / subfolder
 
     # unzip the tarfile
     tar = tarfile.open(downloads, "r")
     tar.extractall()
     tar.close()
 
-    input_file = basePath / "LdM_input_file.inp"
+    input_file = str(basePath / "LdM_input_file.inp")
     # %% User input
     # Plotting parameters, max and min densities in g/cc
     vmin = -0.6

--- a/examples/20-published/plot_load_booky.py
+++ b/examples/20-published/plot_load_booky.py
@@ -36,11 +36,19 @@ def download_and_unzip_data(
     Download the data from the storage bucket, unzip the tar file, return
     the directory where the data are
     """
+    from pathlib import Path
+
     # download the data
     downloads = utils.download(url)
 
     # directory where the downloaded files are
-    directory = downloads.split(".")[0]
+    fname = Path(downloads)
+    if fname.name.endswith(".tar.gz"):
+        n_chars = len(".tar.gz")
+        subfolder = fname.name[:-n_chars]
+    else:
+        raise TypeError(f"Download file '{fname}' is not a tar.gz archive.")
+    directory = str(fname.parent / subfolder)
 
     # unzip the tarfile
     tar = tarfile.open(downloads, "r")


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Fix how the tar.gz archives that get downloaded are extracted in a few different examples. The previous code was getting the folder where files are extracted by splitting the full path of the downloaded .tar.gz archive using a `"."`. This causes issues when any parent folder contains a dot: the directory that is returned is not the correct one.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
