### PR TITLE
Experiment with caching conda environment in Azure

### DIFF
--- a/.ci/azure/test.yml
+++ b/.ci/azure/test.yml
@@ -13,9 +13,38 @@ parameters:
          'tests/dask', # This must be ran on it's own to avoid modifying the code from any other tests.
          ]
 
+variables:
+  CONDA_CACHE_DIR: /usr/share/miniconda/envs
+
 jobs:
   - ${{ each os in parameters.os }}:
     - ${{ each py_vers in parameters.py_vers }}:
+
+      # -----------------------------------------------------------------------
+      # Create conda environment and cache it for future use
+      - job: SetupEnv${{ py_vers}}${{ os }}
+          displayName: Setup environment for ${{ os }} and Python ${{ py_vers }}
+          pool:
+            vmImage: ${{ os }}
+          steps:
+          - bash: echo "##vso[task.prependpath]$CONDA/bin"
+            displayName: Add conda to PATH
+
+          - bash: .ci/azure/setup_env.sh
+            displayName: Setup SimPEG environment
+
+          - bash: |
+              sudo chown -R $(whoami):$(id -ng) $(CONDA_CACHE_DIR)
+            displayName: Fix CONDA_CACHE_DIR directory permissions
+
+          - task: Cache@2
+            displayName: Use cached Anaconda environment
+            inputs:
+              key: 'conda | "${{ os }}" | "${{ py_vers }}"'
+              path: $(CONDA_CACHE_DIR)
+              cacheHitVar: CONDA_CACHE_RESTORED
+      # -----------------------------------------------------------------------
+
       - ${{ each test in parameters.test }}:
         - job:
           displayName: ${{ os }}_${{ py_vers }}_${{ test }}
@@ -40,6 +69,7 @@ jobs:
 
           - bash: .ci/azure/setup_env.sh
             displayName: Setup SimPEG environment
+            condition: eq(variables.CONDA_CACHE_RESTORED, 'false')
 
           - bash: .ci/azure/run_tests_with_coverage.sh
             displayName: 'Testing ${{ test }}'


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Experiment with caching the conda environment we need to create in Azure to
run simpeg tests. This way we could reduce the runtime of CI by reusing the
created environment.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
