### PR TITLE
Configure version warning banner in Sphinx

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -110,6 +110,8 @@ Edit the `docs/_static/versions.json` file and:
 - [ ] Add an entry for the new version (below dev, above the current _latest_).
 - [ ] Make sure to set the new the version number in every field in the new entry.
 - [ ] Mark the new version as the `latest`, and remove `latest` from the previous one.
+- [ ] Set the new version as the `preferred` one.
+- [ ] Remove the `preferred` line from the older version.
 - [ ] Run `cat docs/_static/versions.json | python -m json.tool > /dev/null` to check if the syntax of the JSON file is correct. If no errors are prompted, then your file is OK.
 - [ ] Double-check the changes.
 - [ ] Commit the changes to the same branch.

--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -6,7 +6,8 @@
     {
         "name": "v0.22.0 (latest)",
         "version": "0.22.0",
-        "url": "https://docs.simpeg.xyz/v0.22.0/"
+        "url": "https://docs.simpeg.xyz/v0.22.0/",
+        "preferred": true
     },
     {
         "name": "v0.21.1",

--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -5,32 +5,32 @@
     },
     {
         "name": "v0.22.0 (latest)",
-        "version": "v0.22.0",
+        "version": "0.22.0",
         "url": "https://docs.simpeg.xyz/v0.22.0/"
     },
     {
         "name": "v0.21.1",
-        "version": "v0.21.1",
+        "version": "0.21.1",
         "url": "https://docs.simpeg.xyz/v0.21.1/"
     },
     {
-        "version": "v0.21.0",
+        "version": "0.21.0",
         "url": "https://docs.simpeg.xyz/v0.21.0/"
     },
     {
-        "version": "v0.20.0",
+        "version": "0.20.0",
         "url": "https://docs.simpeg.xyz/v0.20.0/"
     },
     {
-        "version": "v0.19.0",
+        "version": "0.19.0",
         "url": "https://docs.simpeg.xyz/v0.19.0/"
     },
     {
-        "version": "v0.18.1",
+        "version": "0.18.1",
         "url": "https://docs.simpeg.xyz/v0.18.1/"
     },
     {
-        "version": "v0.18.0",
+        "version": "0.18.0",
         "url": "https://docs.simpeg.xyz/v0.18.0/"
     }
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -250,7 +250,7 @@ simpeg_version = parse(simpeg.__version__)
 if simpeg_version.is_devrelease:
     switcher_version = "dev"
 else:
-    switcher_version = f"v{simpeg_version.public}"
+    switcher_version = simpeg_version.public
 
 # Use Pydata Sphinx theme
 html_theme = "pydata_sphinx_theme"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,6 +295,7 @@ html_theme_options = {
         "version_match": switcher_version,
         "json_url": "https://docs.simpeg.xyz/latest/_static/versions.json",
     },
+    "show_version_warning_banner": True,
 }
 
 html_logo = "images/simpeg-logo.png"


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Configure the version warning banner in Sphinx PyData theme. Set v0.22.0 as the preferred version in `versions.json`. Remove leading `v` in version numbers in `versions.json`. Remove leading `v` in the `switcher_version` variable defined in `docs/conf.py`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
