### PR TITLE
Improve imports in natural source utils

### DIFF
--- a/simpeg/electromagnetics/natural_source/utils/plot_data_types.py
+++ b/simpeg/electromagnetics/natural_source/utils/plot_data_types.py
@@ -1,4 +1,6 @@
-from matplotlib import pyplot as plt, colors, numpy as np
+import numpy as np
+from matplotlib import colors
+from matplotlib import pyplot as plt
 
 
 def plotIsoFreqNSimpedance(


### PR DESCRIPTION
#### Summary

Make them less prone to failing by splitting the imports, so we don't rely on matplotib importing numpy in its base `__init__.py`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Fixes #1502

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
