### PR TITLE
Deploy to TestPyPI only on nightly builds

### DIFF
--- a/.ci/azure/pypi.yml
+++ b/.ci/azure/pypi.yml
@@ -43,7 +43,7 @@ jobs:
 
   - job: Deploy
     dependsOn: Build
-    condition: or(startsWith(variables['build.sourceBranch'], 'refs/tags/'), eq(variables['build.sourceBranch'], 'refs/heads/main'))
+    condition: or(startsWith(variables['build.sourceBranch'], 'refs/tags/'), eq(variables['Build.Reason'], 'Schedule'))
     pool:
       vmImage: ubuntu-latest
     steps:
@@ -68,7 +68,7 @@ jobs:
       - bash: |
           twine upload --repository testpypi dist/*
         displayName: "Upload to TestPyPI"
-        condition: eq(variables['build.sourceBranch'], 'refs/heads/main')
+        condition: eq(variables['Build.Reason'], 'Schedule')
         env:
           TWINE_USERNAME: $(twine.username)
           TWINE_PASSWORD: $(test.twine.password)


### PR DESCRIPTION
#### Summary

Configure the deploy job in the PyPI stage on Azure to only trigger after a release or a nightly run. This prevents trying to push the same release to TestPyPI multiple times.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
