### PR TITLE
Minor fixes to disclaimer in `pgi_utils.py`

### DIFF
--- a/simpeg/utils/pgi_utils.py
+++ b/simpeg/utils/pgi_utils.py
@@ -24,10 +24,10 @@ from simpeg.maps import IdentityMap
 
 ###############################################################################
 # Disclaimer: the following classes built upon the GaussianMixture class      #
-# from Scikit-Learn. New functionalitie are added, as well as modifications to#
-# existing functions, to serve the purposes pursued within SimPEG.            #
+# from Scikit-Learn. New functionalities are added, as well as modifications  #
+# to existing functions, to serve the purposes pursued within SimPEG.         #
 # This use is allowed by the Scikit-Learn licensing (BSD-3-Clause License)    #
-# and we are grateful for their contributions to the open-source community.   #                                                   #
+# and we are grateful for their contributions to the open-source community.   #
 ###############################################################################
 
 


### PR DESCRIPTION
Fix typo and update ASCII style of a comment block in `pgi_utils.py`.
Small non-controversial take-out from https://github.com/simpeg/simpeg/pull/1075

@simpeg/simpeg-developers - ready for review