### PR TITLE
Fix misuse of the `requires` decorator in `code_utils.py`

### DIFF
--- a/simpeg/utils/code_utils.py
+++ b/simpeg/utils/code_utils.py
@@ -5,6 +5,7 @@ from functools import wraps
 import warnings
 
 from discretize.utils import as_array_n_by_dim  # noqa: F401
+from discretize.utils import requires as module_requires
 
 # scooby is a soft dependency for simpeg
 try:
@@ -18,6 +19,11 @@ except ImportError:
                 "\n           Install it via `pip install scooby` or"
                 "\n           `conda install -c conda-forge scooby`.\n"
             )
+
+try:
+    import memory_profiler
+except ImportError:
+    memory_profiler = False
 
 
 def requires(var):
@@ -80,7 +86,7 @@ def requires(var):
     return requiresVar
 
 
-@requires("memory_profiler")
+@module_requires({"memory_profiler": memory_profiler})
 def mem_profile_class(input_class, *args):
     """Creates a new class from the target class with memory profiled methods.
 

--- a/simpeg/utils/code_utils.py
+++ b/simpeg/utils/code_utils.py
@@ -20,6 +20,7 @@ except ImportError:
                 "\n           `conda install -c conda-forge scooby`.\n"
             )
 
+
 try:
     import memory_profiler
 except ImportError:


### PR DESCRIPTION
Use the `discretize`'s `requires` to decorate `mem_profile_class`, instead of `simpeg.utils.code_utils.requires`, since the former is intended to be used for modules, while the latter should be used for attributes.

I completely missed in #1104 , that

- `simpeg.utils.code_utils.requires` for attributes is, and not like
- `discretize.utils.code_utils.requires` for modules.

Fixing this by using the discretize version for the `mem_profile_class` function.

@simpeg/simpeg-developers - ready for review