### PR TITLE
Class parameter documentation inheritance

### DIFF
--- a/simpeg/base/pde_simulation.py
+++ b/simpeg/base/pde_simulation.py
@@ -4,6 +4,7 @@ from discretize.utils import Zero, TensorType
 from ..simulation import BaseSimulation
 from .. import props
 from scipy.constants import mu_0
+from ..utils.doc_utils import doc_inherit
 
 
 def __inner_mat_mul_op(M, u, v=None, adjoint=False):
@@ -491,7 +492,23 @@ class BasePDESimulation(BaseSimulation):
 
 @with_property_mass_matrices("sigma")
 @with_property_mass_matrices("rho")
+@doc_inherit()
 class BaseElectricalPDESimulation(BasePDESimulation):
+    """A simulation containing the electrical physical properties sigma and rho.
+
+    Parameters
+    ----------
+    %(super.mesh)
+    sigma, rho : (mesh.n_cells) array_like, optional
+        Conductivity and resitivity properties. These are linked to each
+        other as inverses and at most one can be set.
+    sigmaMap, rhoMap : simpeg.IdentityMap, optional
+        Relationship between the `model` and conductivity or resistivity.
+        These are linked to each other as inverses and at most one can be set.
+    **kwargs
+        keyword arguments passed to the parent class.
+    """
+
     sigma, sigmaMap, sigmaDeriv = props.Invertible("Electrical conductivity (S/m)")
     rho, rhoMap, rhoDeriv = props.Invertible("Electrical resistivity (Ohm m)")
     props.Reciprocal(sigma, rho)
@@ -500,8 +517,12 @@ class BaseElectricalPDESimulation(BasePDESimulation):
         self, mesh, sigma=None, sigmaMap=None, rho=None, rhoMap=None, **kwargs
     ):
         super().__init__(mesh=mesh, **kwargs)
+        if sigma and rho:
+            raise TypeError("Cannot set both sigma and rho.")
         self.sigma = sigma
         self.rho = rho
+        if sigmaMap and rhoMap:
+            raise TypeError("Cannot set both sigmaMap and rhoMap.")
         self.sigmaMap = sigmaMap
         self.rhoMap = rhoMap
 

--- a/simpeg/electromagnetics/static/resistivity/simulation.py
+++ b/simpeg/electromagnetics/static/resistivity/simulation.py
@@ -14,16 +14,33 @@ from .survey import Survey
 from .fields import Fields3DCellCentered, Fields3DNodal
 from .utils import _mini_pole_pole
 from discretize.utils import make_boundary_bool
+from ....utils.doc_utils import doc_inherit
 
 
+@doc_inherit()
 class BaseDCSimulation(BaseElectricalPDESimulation):
     """
     Base DC Problem
+
+    Parameters
+    ----------
+    %(super.mesh)
+    survey : .resistivity.Survey, optional
+        The resistivity survey containing all of the electrode sources
+        and receivers.
+    storeJ : bool, optional
+        Whether to create and store the jacobian matrix. This could require
+        a large amount of memory, as an array of size (n_data, n_model) is
+        stored.
+    miniaturize : bool, optional
+        Whether to internally represent the `survey` as a potentially smaller
+        version to speed up computation and reduce the size of the fields object.
+    surface_faces : (n_bf, ) numpy.ndarray of bool, optional
+        Which faces on the mesh to interpret as belonging to the surface. Nuemann
+        boundary conditions are set on these surfaces. Required for tetrahedral meshes.
+    **kwargs
+        keyword arguments passed to the parent class.
     """
-
-    _mini_survey = None
-
-    Ainv = None
 
     def __init__(
         self,
@@ -35,6 +52,10 @@ class BaseDCSimulation(BaseElectricalPDESimulation):
         **kwargs,
     ):
         super().__init__(mesh=mesh, survey=survey, **kwargs)
+
+        self._mini_survey = None
+
+        self.Ainv = None
         self.storeJ = storeJ
         self.surface_faces = surface_faces
         # Do stuff to simplify the forward and JTvec operation if number of dipole
@@ -313,9 +334,22 @@ class BaseDCSimulation(BaseElectricalPDESimulation):
         return out
 
 
+@doc_inherit()
 class Simulation3DCellCentered(BaseDCSimulation):
     """
     3D cell centered DC problem
+
+    Parameters
+    ----------
+    %(super.mesh)
+    %(super.survey)
+    bc_type : {"Robin", "Dirichlet", "Neumann"}
+    %(super.sigma, rho)
+    %(super.sigmaMap, rhoMap)
+
+    Other Parameters
+    ----------------
+    %(super.*)
     """
 
     _solutionType = "phiSolution"

--- a/simpeg/electromagnetics/static/resistivity/simulation.py
+++ b/simpeg/electromagnetics/static/resistivity/simulation.py
@@ -346,6 +346,7 @@ class Simulation3DCellCentered(BaseDCSimulation):
     bc_type : {"Robin", "Dirichlet", "Neumann"}
     %(super.sigma, rho)
     %(super.sigmaMap, rhoMap)
+    %(super.model)
 
     Other Parameters
     ----------------
@@ -509,9 +510,23 @@ class Simulation3DCellCentered(BaseDCSimulation):
         self.Grad = self.Grad - B
 
 
+@doc_inherit()
 class Simulation3DNodal(BaseDCSimulation):
     """
-    3D nodal DC problem
+    3D Nodal DC problem
+
+    Parameters
+    ----------
+    %(super.mesh)
+    %(super.survey)
+    bc_type : {"Robin", "Dirichlet", "Neumann"}
+    %(super.sigma, rho)
+    %(super.sigmaMap, rhoMap)
+    %(super.model)
+
+    Other Parameters
+    ----------------
+    %(super.*)
     """
 
     _solutionType = "phiSolution"

--- a/simpeg/props.py
+++ b/simpeg/props.py
@@ -272,7 +272,24 @@ def Reciprocal(prop1, prop2):
 
 
 class BaseSimPEG:
-    """"""
+    """Base class for simpeg classes."""
+
+    # Developer note:
+    # This class is mostly used to identify simpeg classes
+    # and to catch any leftover keyword arguments before calling
+    # object.__init__() (if that was the next class on the mro above
+    # this one). If there are any leftover arguments, it throws a TypeError
+    # with an appropriate message reference the class that was initialized.
+    def __init__(self, **kwargs):
+        mro = type(self).__mro__
+        super_class = mro[mro.index(__class__) + 1]
+        if super_class is object:
+            if len(kwargs):
+                for key in kwargs:
+                    raise TypeError(
+                        f"{type(self).__name__} got an unexpected keyword argument '{key}'."
+                    )
+        super().__init__(**kwargs)
 
 
 class PhysicalPropertyMetaclass(type):
@@ -335,6 +352,17 @@ class PhysicalPropertyMetaclass(type):
 
 
 class HasModel(BaseSimPEG, metaclass=PhysicalPropertyMetaclass):
+    """Class containing a `model` property optionally linked to `PhysicalProperties`
+
+    Parameters
+    ----------
+    model : (n_m,) array_like, optional
+        The parameter model, often used to descibe the model in an inversion.
+        If there are any physical property maps assigned, those physical properties
+        will be linked to this model through the map, and accessing them will require
+        a model to be set.
+    """
+
     def __init__(self, model=None, **kwargs):
         self.model = model
         super().__init__(**kwargs)

--- a/simpeg/simulation.py
+++ b/simpeg/simulation.py
@@ -27,6 +27,7 @@ from .utils import (
     validate_string,
     validate_integer,
 )
+from .utils.doc_utils import doc_inherit
 
 try:
     from pymatsolver import Pardiso as DefaultSolver
@@ -72,7 +73,7 @@ class BaseSimulation(props.HasModel):
         Path to directory where sensitivity file is stored.
     counter : None or simpeg.utils.Counter
         SimPEG ``Counter`` object to store iterations and run-times.
-    verbose : bool, optional
+    verbose : bool, default: False
         Verbose progress printout.
     """
 
@@ -713,6 +714,7 @@ class BaseTimeSimulation(BaseSimulation):
 ##############################################################################
 
 
+@doc_inherit(star_excludes=["solver", "solver_opts"])
 class LinearSimulation(BaseSimulation):
     r"""Linear forward simulation class.
 
@@ -739,15 +741,14 @@ class LinearSimulation(BaseSimulation):
 
     Parameters
     ----------
-    mesh : discretize.BaseMesh, optional
-        Mesh on which the forward problem is discretized. This is not necessarily
-        the same as the mesh on which the simulation is defined.
+    %(super.mesh)
     model_map : simpeg.maps.BaseMap
         Mapping from the model parameters to vector that the linear operator acts on.
     G : (n_data, n_param) numpy.ndarray or scipy.sparse.csr_matrx
         The linear operator. For a ``model_map`` that maps within the same vector space
         (e.g. the identity map), the dimension ``n_param`` equals the number of model parameters.
         If not, the dimension ``n_param`` of the linear operator will depend on the mapping.
+    %(super.*)
     """
 
     linear_model, model_map, model_deriv = props.Invertible(
@@ -755,10 +756,12 @@ class LinearSimulation(BaseSimulation):
     )
 
     def __init__(self, mesh=None, linear_model=None, model_map=None, G=None, **kwargs):
+
         super().__init__(mesh=mesh, **kwargs)
         self.linear_model = linear_model
         self.model_map = model_map
         self.solver = None
+
         if G is not None:
             self.G = G
 

--- a/simpeg/utils/doc_utils.py
+++ b/simpeg/utils/doc_utils.py
@@ -1,0 +1,243 @@
+import re
+import inspect
+import itertools
+import importlib
+from ..props import BaseSimPEG
+
+__all__ = ["class_arg_doc_dict", "doc_inherit"]
+
+REPLACE_REGEX = re.compile(r"%\((?P<replace_key>.*)\)")
+_numpydoc_sections = [
+    "Parameters",
+    "Returns",
+    "Yields",
+    "Receives",
+    "Other Parameters",
+    "Raises",
+    "Warns",
+    "See Also",
+    "Notes",
+    "References",
+    "Examples",
+]
+_section_regexs = []
+for section in _numpydoc_sections:
+    section_regex = rf"(?:(?:^|\n\n){section}\n-{{{len(section)}}}\n(?P<{section.lower().replace(' ', '_')}>[\s\S]*?))"
+    _section_regexs.append(section_regex)
+
+KV_REGEX = re.compile(r"^[^\s].*$", flags=re.M)
+NUMPY_SECTION_REGEX = re.compile(
+    rf"^(?P<summary>[\s\S]+?)??{'?'.join(_section_regexs)}?$"
+)
+ARG_TYPE_SEP_REGEX = re.compile(r"\s*:\s*")
+ARG_SPLIT_REGEX = re.compile(r"\s*,\s*")
+NUMPY_ARG_TYPE_REGEX = re.compile(
+    r"^(?P<arg_name>\S.*?)(?:\s*:\s*(?P<type>.*?))?$", re.MULTILINE
+)
+
+__cached_class_arg_dicts = {}
+
+
+def _pairwise(iterable):
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return itertools.zip_longest(a, b, fillvalue=None)
+
+
+def _parse_numpydoc_parameters(doc):
+    doc_sections = NUMPY_SECTION_REGEX.search(doc).groupdict()
+    parameters = doc_sections.get("parameters")
+    if parameters is None:
+        parameters = ""
+
+    others = doc_sections.get("other_parameters")
+    if others is not None:
+        parameters += "\n" + others
+    return parameters
+
+
+def class_arg_doc_dict(this_class):
+    if not issubclass(this_class, BaseSimPEG):
+        # don't do anything to classes not from simpeg
+        return {}
+    if this_class.__doc__ is None:
+        return {}
+    if __cached_class_arg_dicts.get(this_class, None) is not None:
+        return __cached_class_arg_dicts[this_class]
+
+    doc = inspect.cleandoc(this_class.__doc__)
+    parameters = _parse_numpydoc_parameters(doc)
+
+    # get the classes call signature:
+    call_signature = inspect.signature(this_class.__init__)
+
+    arg_dict = {}
+    for match, next_match in _pairwise(KV_REGEX.finditer(parameters)):
+        arg_type = match.group()
+        split = ARG_TYPE_SEP_REGEX.split(arg_type, 1)
+        arg = split[0]
+        type_string = split[1] if len(split) > 1 else None
+
+        # skip over values that are to be replaced (if there are any left)
+        # and skip of **kwargs
+        if not REPLACE_REGEX.match(arg) and arg != "**kwargs":
+            # +1 removes the newline character at the end of the argument : type_name match
+            start = match.end() + 1
+            # -1 removes the newline character at the start of the argument : type_name match (if there was one).
+            end = next_match.start() - 1 if next_match is not None else None
+            description = parameters[start:end]
+            arg_dict[arg] = {
+                "type_string": type_string,
+                "description": description,
+                "parameters": [
+                    call_signature.parameters[parg]
+                    for parg in ARG_SPLIT_REGEX.split(arg)
+                ],
+            }
+    # cache this for future lookups
+    __cached_class_arg_dicts[this_class] = arg_dict
+    return arg_dict
+
+
+def doc_inherit(star_excludes=None):
+    if star_excludes is None:
+        star_excludes = set()
+    else:
+        star_excludes = set(star_excludes)
+
+    def doc_decorator(this_class):
+        # a list of arguments and the class they would resolve to.
+        # search through my docstring and figure out what to replace.
+        doc = inspect.cleandoc(this_class.__doc__)
+        # replacement items in doc
+        args_to_insert = [
+            match.group("replace_key").rsplit(".", 1)
+            for match in REPLACE_REGEX.finditer(doc)
+        ]
+
+        # grab the current call signature parameters
+        # will append items insert using the replacement.
+        call_signature_parameters = []
+        call_signature_arg_names = []
+        add_kwargs_param_signature = False
+        this_call_sign = inspect.signature(this_class.__init__)
+        for name, parameter in this_call_sign.parameters.items():
+            if parameter.kind != inspect.Parameter.VAR_KEYWORD:
+                call_signature_arg_names.append(name)
+                call_signature_parameters.append(parameter)
+            else:
+                add_kwargs_param_signature = True
+
+        super_doc_dict = None
+        do_star_replace = False
+        for class_name, arg in args_to_insert:
+            if class_name == "super" and super_doc_dict is None:
+                # build the super_doc_dict if it will be needed.
+                super_doc_dict = {}
+                for cls in this_class.__mro__[1:-1]:
+                    cls_doc_dict = class_arg_doc_dict(cls)
+                    super_doc_dict = cls_doc_dict | super_doc_dict
+            if arg != "*":
+                if class_name == "super":
+                    replacement = super_doc_dict[arg]
+                else:
+                    # import the class and get it's arg_dict
+                    module_name, m_class_name = class_name.rsplit(".", 1)
+                    target_cls = getattr(
+                        importlib.import_module(module_name), m_class_name
+                    )
+                    replacement = class_arg_doc_dict(target_cls)[arg]
+                # build the replacement string
+                replace_string = arg
+                if replacement["type_string"] is not None:
+                    replace_string += " : " + replacement["type_string"]
+                if replacement["description"] != "":
+                    replace_string += "\n" + replacement["description"]
+                doc = doc.replace(f"%({class_name}.{arg})", replace_string)
+                for param in replacement["parameters"]:
+                    if param.name not in call_signature_arg_names:
+                        # This meant it was supposed to be caught by **kwargs.
+                        # and must be a KEYWORD_ONLY type parameter.
+                        # We create a new `Parameter`, because we can't change the
+                        # `kind` of a previously created `Parameter`.
+                        call_signature_arg_names.append(param.name)
+                        call_signature_parameters.append(
+                            inspect.Parameter(
+                                param.name,
+                                inspect.Parameter.KEYWORD_ONLY,
+                                default=param.default,
+                                annotation=param.annotation,
+                            )
+                        )
+            else:
+                do_star_replace = True
+
+        if do_star_replace:
+            parameters = _parse_numpydoc_parameters(doc)
+
+            exclusions = set()
+            for match in NUMPY_ARG_TYPE_REGEX.finditer(parameters):
+                # this also matches the replacement regex, but that
+                # should never match anything else anyways...
+                arg = match.group("arg_name")
+                exclusions.add(arg)
+            exclusions.update(star_excludes)
+
+            # search through again, but this time only deal with the "*" replacements.
+            # add any added items to the exclusions and assume the order things are listed
+            # in the documentation represents the precedence of "*" replacements.
+            for class_name, arg in args_to_insert:
+                if arg == "*":
+                    star_arg_dict = None
+                    if class_name == "super":
+                        star_arg_dict = super_doc_dict
+                        # if we're getting everything, don't add **kwargs to the signature?
+                        add_kwargs_param_signature = False
+                    else:
+                        # import the class and get it's arg_dict
+                        module_name, class_name = class_name.rsplit(".", 1)
+                        target_cls = getattr(
+                            importlib.import_module(module_name), class_name
+                        )
+                        star_arg_dict = class_arg_doc_dict(target_cls)
+                    # grab everything in star_arg_dict
+                    replacements = []
+                    for s_arg, replacement in star_arg_dict.items():
+                        if s_arg not in exclusions:
+                            replace_string = s_arg
+                            if replacement["type_string"] is not None:
+                                replace_string += " : " + replacement["type_string"]
+                            if replacement["description"] != "":
+                                replace_string += "\n" + replacement["description"]
+                            replacements.append(replace_string)
+                            exclusions.add(s_arg)
+                            for param in replacement["parameters"]:
+                                if param.name not in call_signature_arg_names:
+                                    # This meant it was supposed to be caught by **kwargs.
+                                    # and must be a KEYWORD_ONLY type parameter.
+                                    # We create a new `Parameter`, because we can't change the
+                                    # `kind` of a previously created `Parameter`.
+                                    call_signature_arg_names.append(param.name)
+                                    call_signature_parameters.append(
+                                        inspect.Parameter(
+                                            param.name,
+                                            inspect.Parameter.KEYWORD_ONLY,
+                                            default=param.default,
+                                            annotation=param.annotation,
+                                        )
+                                    )
+
+                    replace_string = "\n".join(replacements)
+                    doc = doc.replace(f"%({class_name}.{arg})", replace_string)
+        if add_kwargs_param_signature:
+            call_signature_parameters.append(
+                inspect.Parameter("kwargs", inspect.Parameter.VAR_KEYWORD)
+            )
+
+        this_class.__doc__ = doc
+        this_class.__init__.__signature__ = inspect.Signature(
+            parameters=call_signature_parameters
+        )
+        return this_class
+
+    return doc_decorator

--- a/simpeg/utils/doc_utils.py
+++ b/simpeg/utils/doc_utils.py
@@ -72,14 +72,11 @@ def class_arg_doc_dict(this_class):
     call_signature = inspect.signature(this_class.__init__)
 
     arg_dict = {}
-    for match, next_match in _pairwise(KV_REGEX.finditer(parameters)):
-        arg_type = match.group()
-        split = ARG_TYPE_SEP_REGEX.split(arg_type, 1)
-        arg = split[0]
-        type_string = split[1] if len(split) > 1 else None
+    for match, next_match in _pairwise(NUMPY_ARG_TYPE_REGEX.finditer(parameters)):
+        arg, type_string = match.groups()
 
         # skip over values that are to be replaced (if there are any left)
-        # and skip of **kwargs
+        # and skip over **kwargs
         if not REPLACE_REGEX.match(arg) and arg != "**kwargs":
             # +1 removes the newline character at the end of the argument : type_name match
             start = match.end() + 1


### PR DESCRIPTION
#### Summary
Adds the ability to inherit information from a parent class's documentation and correspondingly update the class's call signature.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
Relevant to #1420

#### What does this implement/fix?

##### Documentation implementation

Adds a mechanism to inherit documentation descriptions from parent classes. This avoids us having to copy and paste documentation code for each parameter into every single subclass. For example, we can write the description of the `mesh` parameter in one place, then make use of that in every child class. Or, we can access all of the other parameters that are less likely to be used from a parent class. It also then updates the call signature of the class's `__init__` function to match the description in the documentation.

 As of right now, my proposed syntax for this is demonstrated in the few classes I've added this to.

The docstring for `LinearSimulation` as coded:
https://github.com/jcapriot/simpeg/blob/17f934d7b25e7669dd483788f50f366b63ad224c/simpeg/simulation.py#L717-L758

Essentially the `%(....)` triggers a replacement on the docstring when the `@doc_inherit()` decorator is attached to the class. Specifically a `%(super.item)` triggers a lookup for the description of an argument named `item` in the next class that describes `item` in the class's inheritance tree. `%(module.ClassName.item)` would trigger a lookup for `item` specifically in the importable class `module.ClassName`, and `%(super.*)` would trigger an inclusion of every parameter from the class's inheritance tree (that is not already documented on this class already (you could also trigger this from a specific class as `%(module.ClassName.*)`). There is also an option to specifically exclude parameters from the star include operation, as seen in the `LinearSimulation` excluding the `solver` and `solver_opts` parameters.

After the replacements the `LinearSimulation` docstring looks like:
```
"""Linear forward simulation class.

The ``LinearSimulation`` class is used to define forward simulations of the form:

.. math::
    \mathbf{d} = \mathbf{G \, f}(\mathbf{m})

where :math:`\mathbf{m}` are the model parameters, :math:`\mathbf{f}` is a
mapping operator (optional) from the model space to a user-defined parameter space,
:math:`\mathbf{d}` is the predicted data vector, and :math:`\mathbf{G}` is an
``(n_data, n_param)`` linear operator.

The ``LinearSimulation`` class is generally used as a base class that is inherited by
other simulation classes within SimPEG. However, it can be used directly as a
simulation class if the :py:attr:`G` property is used to set the linear forward
operator directly.

By default, we assume the mapping operator :math:`\mathbf{f}` is the identity map,
and that the forward simulation reduces to:

.. math::
    \mathbf{d} = \mathbf{G \, m}

Parameters
----------
mesh : discretize.base.BaseMesh, optional
    Mesh on which the forward problem is discretized.
model_map : simpeg.maps.BaseMap
    Mapping from the model parameters to vector that the linear operator acts on.
G : (n_data, n_param) numpy.ndarray or scipy.sparse.csr_matrx
    The linear operator. For a ``model_map`` that maps within the same vector space
    (e.g. the identity map), the dimension ``n_param`` equals the number of model parameters.
    If not, the dimension ``n_param`` of the linear operator will depend on the mapping.
model : (n_m,) array_like, optional
    The parameter model, often used to descibe the model in an inversion.
    If there are any physical property maps assigned, those physical properties
    will be linked to this model through the map, and accessing them will require
    a model to be set.
survey : simpeg.survey.BaseSurvey, optional
    The survey for the simulation.
sensitivity_path : str, optional
    Path to directory where sensitivity file is stored.
counter : None or simpeg.utils.Counter
    SimPEG ``Counter`` object to store iterations and run-times.
verbose : bool, default: False
    Verbose progress printout.
"""
```

Because we have included a `%(super.*)` lookup, it doesn't include a `**kwargs` description.

##### Call signatures
Updating the documentation is nice... But it doesn't enable tab completion on most editors, or type inference, and it doesn't make the default values for optional arguments shown in the call signature. But that's the key there, you can specifically set a function's `__signature__` property to change it's call signature.
So the next bit of this replacement appropriately updates the functions call signature to add the items that were included from elsewhere (that were not already part of it's call signature). This parameters are only allowed as keyword arguments, and are marked as such when added to the call signature. They are added in the order they are added to the documentation.

Now inspecting the loaded `LinearSimulation` class in a jupyter notebook we see it's description as:
![image](https://github.com/user-attachments/assets/c46f7299-c781-4a6d-a6df-60e94b02cca1)

Tab completion in a notebook shows all of the added parameters:
![image](https://github.com/user-attachments/assets/d012bcc5-2c63-43ba-b15f-87217d35a52b)

The generated documentation page:


#### Additional information

This relies on the classes implementing the `numpydoc` style doc strings. It will search for descriptions in parents that are described in either the `Paramaters` or `Other Parameters` sections.

This spirit of this was inspired by `matplotlib`, where they automatically populate their docstrings with the multitude of parameters that their classes take.


