### PR TITLE
Fix validate_ndarray_with_shape

### DIFF
--- a/simpeg/utils/code_utils.py
+++ b/simpeg/utils/code_utils.py
@@ -1036,7 +1036,7 @@ def validate_ndarray_with_shape(property_name, var, shape=None, dtype=float):
     for dtype in dtypes:
         try:
             if isinstance(var, np.ndarray):
-                var = var.astype(dtype, casting='safe', copy=False)
+                var = var.astype(dtype, casting="safe", copy=False)
             else:
                 var = np.asarray(var, dtype=dtype)
             bad_type = False

--- a/simpeg/utils/code_utils.py
+++ b/simpeg/utils/code_utils.py
@@ -1033,20 +1033,17 @@ def validate_ndarray_with_shape(property_name, var, shape=None, dtype=float):
         dtypes = (dtype,)
     else:
         dtypes = dtype
-
-    # If var is already a numpy array of an allowed dtype, all good
-    if isinstance(var, np.ndarray) and var.dtype in dtypes:
-        bad_type = False
-    # Else, loop over dtypes and try to cast.
-    else:
-        for dtype in dtypes:
-            try:
+    for dtype in dtypes:
+        try:
+            if isinstance(var, np.ndarray):
+                var = var.astype(dtype, casting='safe', copy=False)
+            else:
                 var = np.asarray(var, dtype=dtype)
-                bad_type = False
-                break
-            except (TypeError, ValueError) as err:
-                bad_type = True
-                raised_err = err
+            bad_type = False
+            break
+        except (TypeError, ValueError) as err:
+            bad_type = True
+            raised_err = err
 
     if bad_type:
         raise TypeError(

--- a/simpeg/utils/code_utils.py
+++ b/simpeg/utils/code_utils.py
@@ -1033,14 +1033,20 @@ def validate_ndarray_with_shape(property_name, var, shape=None, dtype=float):
         dtypes = (dtype,)
     else:
         dtypes = dtype
-    for dtype in dtypes:
-        try:
-            var = np.asarray(var, dtype=dtype)
-            bad_type = False
-            break
-        except (TypeError, ValueError) as err:
-            bad_type = True
-            raised_err = err
+
+    # If var is already a numpy array of an allowed dtype, all good
+    if isinstance(var, np.ndarray) and var.dtype in dtypes:
+        bad_type = False
+    # Else, loop over dtypes and try to cast.
+    else:
+        for dtype in dtypes:
+            try:
+                var = np.asarray(var, dtype=dtype)
+                bad_type = False
+                break
+            except (TypeError, ValueError) as err:
+                bad_type = True
+                raised_err = err
 
     if bad_type:
         raise TypeError(

--- a/tests/base/test_validators.py
+++ b/tests/base/test_validators.py
@@ -224,7 +224,7 @@ def test_ndarray_validation():
     np.testing.assert_equal(out, np.array([3.0j, 4.0j, 5.0j]))
 
     out = validate_ndarray_with_shape(
-        "array_prop", np.array(["3j", "4j", "5j"]), dtype=(float, complex)
+        "array_prop", np.array([3j, 4j, 5j]), dtype=(float, complex)
     )
     assert np.issubdtype(out.dtype, complex)
     np.testing.assert_equal(out, np.array([3.0j, 4.0j, 5.0j]))

--- a/tests/base/test_validators.py
+++ b/tests/base/test_validators.py
@@ -223,6 +223,12 @@ def test_ndarray_validation():
     assert np.issubdtype(out.dtype, complex)
     np.testing.assert_equal(out, np.array([3.0j, 4.0j, 5.0j]))
 
+    out = validate_ndarray_with_shape(
+        "array_prop", np.array(["3j", "4j", "5j"]), dtype=(float, complex)
+    )
+    assert np.issubdtype(out.dtype, complex)
+    np.testing.assert_equal(out, np.array([3.0j, 4.0j, 5.0j]))
+
     # Valid any shaped arrays
     assert validate_ndarray_with_shape(
         "NDarrayProperty", np.random.rand(3, 3, 3), ("*", "*", "*"), float


### PR DESCRIPTION
#### Summary

The current implementation of `simpeg.utils.code_utils.validate_ndarray_with_shape` works for numbers or lists, but fails for `np.ndarray`'s.

Example
```python
import numpy as np
from simpeg.utils.code_utils import validate_ndarray_with_shape
``` 

First a list, all as expected, it returns a complex numpy array.
```python
validate_ndarray_with_shape('Test 1', [1+1j, 2+2j], '*', (float, complex))
```
```
array([1.+1.j, 2.+2.j])
```

Now directly for a complex  numpy array: It casts the array to the first provided dtypes, here floats, and raises a warning if that casting has some side-effects, here that it casts complex values to real values. Not what was wanted.
```python
validate_ndarray_with_shape('Test 1', np.array([1+1j, 2+2j]), '*', (float, complex))
```
```
/simpeg/utils/code_utils.py:1044: ComplexWarning: Casting complex values to real discards the imaginary part
  var = np.asarray(var, dtype=dtype)
array([1., 2.])
```

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

@simpeg/simpeg-developers - small fix, should be ready.