### PR TITLE
Fix bug in GMM's `_check_weights`

### DIFF
--- a/simpeg/utils/pgi_utils.py
+++ b/simpeg/utils/pgi_utils.py
@@ -230,7 +230,7 @@ class WeightedGaussianMixture(GaussianMixture if sklearn else object):
             _check_shape(weights, (n_components,), "weights")
 
         # check range
-        if any(np.less(weights, 0.0)) or any(np.greater(weights, 1.0)):
+        if (weights < 0.0).any() or (weights > 1.0).any():
             raise ValueError(
                 "The parameter 'weights' should be in the range "
                 "[0, 1], but got max value %.5f, min value %.5f"

--- a/simpeg/utils/pgi_utils.py
+++ b/simpeg/utils/pgi_utils.py
@@ -212,10 +212,12 @@ class WeightedGaussianMixture(GaussianMixture if sklearn else object):
             The proportions of components of each mixture.
         n_components : int
             Number of components.
+        n_samples : int or None
+            Number of samples.
 
         Returns
         -------
-        weights : array, shape (n_components,)
+        weights : (n_components,) or (n_samples, n_components) numpy.ndarray
         """
 
         if len(weights.shape) == 2:

--- a/simpeg/utils/pgi_utils.py
+++ b/simpeg/utils/pgi_utils.py
@@ -219,7 +219,7 @@ class WeightedGaussianMixture(GaussianMixture if sklearn else object):
         -------
         weights : (n_components,) or (n_samples, n_components) numpy.ndarray
         """
-
+        weights = np.asarray(weights)
         if len(weights.shape) == 2:
             weights = check_array(
                 weights, dtype=[np.float64, np.float32], ensure_2d=True

--- a/tests/base/regularizations/test_pgi_regularization.py
+++ b/tests/base/regularizations/test_pgi_regularization.py
@@ -485,16 +485,7 @@ def test_removed_mref():
 
 
 class TestCheckWeights:
-    """Test the ``WeightedGaussianMixture._check_weights`` method.
-
-    Test:
-    * Valid 1d and 2d weights
-    * Invalid weights (for 1d and 2d):
-        * with wrong shape
-        * with weights <0
-        * with weights >0
-        * normalization?
-    """
+    """Test the ``WeightedGaussianMixture._check_weights`` method."""
 
     VALID_ARGS = {
         "1d-array": (np.array([0.5, 0.2, 0.3]), 3, None),

--- a/tests/base/regularizations/test_pgi_regularization.py
+++ b/tests/base/regularizations/test_pgi_regularization.py
@@ -484,5 +484,94 @@ def test_removed_mref():
         pgi.mref
 
 
+class TestCheckWeights:
+    """Test the ``WeightedGaussianMixture._check_weights`` method.
+
+    Test:
+    * Valid 1d and 2d weights
+    * Invalid weights (for 1d and 2d):
+        * with wrong shape
+        * with weights <0
+        * with weights >0
+        * normalization?
+    """
+
+    VALID_ARGS = {
+        "1d-array": (np.array([0.5, 0.2, 0.3]), 3, None),
+        "2d-array": (np.array([[0.5, 0.2, 0.3], [0.25, 0.70, 0.05]]), 3, 2),
+        "1d-list": ([0.5, 0.2, 0.3], 3, None),
+        "2d-list": ([[0.5, 0.2, 0.3], [0.25, 0.70, 0.05]], 3, 2),
+    }
+    INVALID_SHAPE = {
+        "1d-array": (np.array([0.5, 0.2, 0.3]), 5, None),
+        "2d-array": (np.array([[0.5, 0.2, 0.3], [0.25, 0.70, 0.05]]), 5, 13),
+        "1d-list": ([0.5, 0.2, 0.3], 5, None),
+        "2d-list": ([[0.5, 0.2, 0.3], [0.25, 0.70, 0.05]], 5, 13),
+    }
+    INVALID_RANGE = {
+        "1d-greater": (np.array([10.5, 0.2, 0.3]), 3, None),
+        "1d-lower": (np.array([-1.0, 0.2, 0.3]), 3, None),
+        "2d-greater": (np.array([[0.5, 0.2, 0.3], [10.25, 0.70, 0.05]]), 3, 2),
+        "2d-lower": (np.array([[0.5, 0.2, 0.3], [0.25, -0.70, 0.05]]), 3, 2),
+    }
+    INVALID_NORM = {
+        "1d-lower": (np.array([0.001, 0.2, 0.3]), 3, None),
+        "1d-greater": (np.array([0.99, 0.2, 0.3]), 3, None),
+        "2d-lower": (np.array([[0.001, 0.2, 0.3], [0.25, 0.70, 0.05]]), 3, 2),
+        "2d-greater": (np.array([[0.99, 0.2, 0.3], [0.25, 0.70, 0.05]]), 3, 2),
+    }
+
+    @pytest.fixture
+    def mesh(self):
+        mesh = discretize.TensorMesh([2, 2, 2])
+        return mesh
+
+    @pytest.mark.parametrize("args", VALID_ARGS.values(), ids=VALID_ARGS.keys())
+    def test_valid_arguments(self, mesh, args):
+        """
+        Check if method doesn't fail if arguments are valid.
+        """
+        weights, n_components, n_samples = args
+        WeightedGaussianMixture(n_components=1, mesh=mesh)._check_weights(
+            weights, n_components, n_samples
+        )
+
+    @pytest.mark.parametrize("args", INVALID_SHAPE.values(), ids=INVALID_SHAPE.keys())
+    def test_invalid_shape(self, mesh, args):
+        """
+        Check if method raise error upon weights with invalid shape.
+        """
+        weights, n_components, n_samples = args
+        msg = "The parameter 'weights' should have the shape of"
+        with pytest.raises(ValueError, match=msg):
+            WeightedGaussianMixture(n_components=1, mesh=mesh)._check_weights(
+                weights, n_components, n_samples
+            )
+
+    @pytest.mark.parametrize("args", INVALID_RANGE.values(), ids=INVALID_RANGE.keys())
+    def test_invalid_range(self, mesh, args):
+        """
+        Check if method raise error upon weights with invalid range.
+        """
+        weights, n_components, n_samples = args
+        msg = r"The parameter 'weights' should be in the range \[0, 1\]"
+        with pytest.raises(ValueError, match=msg):
+            WeightedGaussianMixture(n_components=1, mesh=mesh)._check_weights(
+                weights, n_components, n_samples
+            )
+
+    @pytest.mark.parametrize("args", INVALID_NORM.values(), ids=INVALID_NORM.keys())
+    def test_non_normalized(self, mesh, args):
+        """
+        Check if method raise error upon non-normalized weights.
+        """
+        weights, n_components, n_samples = args
+        msg = r"The parameter 'weights' should be normalized"
+        with pytest.raises(ValueError, match=msg):
+            WeightedGaussianMixture(n_components=1, mesh=mesh)._check_weights(
+                weights, n_components, n_samples
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#### Summary

Fix bug while checking range of 2d weights. Use Numpy's `a.any()` method instead of Python built-in `any()` function to check if the `weights` is within the `[0, 1]` range. The `any()` function doesn't work with 2d arrays of bools. Convert weights to array before checking shape to allow array-like `weights`. Update method's docstring. Add tests that catch the bug. Include more tests for the `_check_weights` method to extend coverage and cover different scenarios.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Fixes bug reported in https://simpeg.discourse.group/t/error-in-inversion-algorithm-for-pgi-inversion-when-setting-gmm-update-true/603

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
