### PR TITLE
Add release notes after v0.22.2

### DIFF
--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -4,10 +4,15 @@
         "url": "https://docs.simpeg.xyz/dev/"
     },
     {
-        "name": "v0.22.1 (latest)",
-        "version": "0.22.1",
-        "url": "https://docs.simpeg.xyz/v0.22.1/",
+        "name": "v0.22.2 (latest)",
+        "version": "0.22.2",
+        "url": "https://docs.simpeg.xyz/v0.22.2/",
         "preferred": true
+    },
+    {
+        "name": "v0.22.1",
+        "version": "0.22.1",
+        "url": "https://docs.simpeg.xyz/v0.22.1/"
     },
     {
         "name": "v0.22.0",

--- a/docs/content/release/0.22.2-notes.rst
+++ b/docs/content/release/0.22.2-notes.rst
@@ -1,0 +1,41 @@
+.. _0.22.2_notes:
+
+===========================
+SimPEG 0.22.2 Release Notes
+===========================
+
+September 11th, 2024
+
+.. contents:: Highlights
+    :depth: 2
+
+Updates
+=======
+
+This patch release includes a few fixes: SciPy solvers can now be used
+with newer versions of SciPy (``>=1.14``), we fixed a bug in one of the methods
+of the Gaussian Mixture Models used in PGI, we included a fix on one of the
+internal validation functions, and we also applied some minor improvements to
+the documentation pages.
+
+Contributors
+============
+
+- `@prisae <https://github.com/prisae>`__
+- `@santisoler <https://github.com/santisoler>`__
+
+Pull Requests
+=============
+
+-  Minor fixes to disclaimer in ``pgi_utils.py`` by `@prisae <https://github.com/prisae>`__ in
+   https://github.com/simpeg/simpeg/pull/1512
+-  Fix misuse of the ``requires`` decorator in ``code_utils.py`` by
+   `@prisae <https://github.com/prisae>`__ in https://github.com/simpeg/simpeg/pull/1513
+-  Use lowercase simpeg in a few missing docstrings by `@santisoler <https://github.com/santisoler>`__ in
+   https://github.com/simpeg/simpeg/pull/1519
+-  Pass ``rtol`` to SciPy solvers for SciPy>=1.12 by `@prisae <https://github.com/prisae>`__ in
+   https://github.com/simpeg/simpeg/pull/1517
+-  Fix ``validate_ndarray_with_shape`` by `@prisae <https://github.com/prisae>`__ in
+   https://github.com/simpeg/simpeg/pull/1523
+-  Fix bug in GMM’s ``_check_weights`` by `@santisoler <https://github.com/santisoler>`__ in
+   https://github.com/simpeg/simpeg/pull/1526

--- a/docs/content/release/index.rst
+++ b/docs/content/release/index.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 2
 
+    0.22.2 <0.22.2-notes>
     0.22.1 <0.22.1-notes>
     0.22.0 <0.22.0-notes>
     0.21.1 <0.21.1-notes>


### PR DESCRIPTION
#### Summary

Bring in the release notes of `v0.22.2` from the `maintenance/v0.22.x` branch. Add `v0.22.2` to `versions.json`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
