### PR TITLE
Replace `indActive` and `actInd` for `active_cells` in maps

### DIFF
--- a/examples/04-dcip/plot_inv_dcip_dipoledipole_3Dinversion_twospheres.py
+++ b/examples/04-dcip/plot_inv_dcip_dipoledipole_3Dinversion_twospheres.py
@@ -153,7 +153,7 @@ survey = DC.Survey(survey1.source_list + survey2.source_list + survey3.source_li
 
 # Setup Problem with exponential mapping and Active cells only in the core mesh
 expmap = maps.ExpMap(mesh)
-mapactive = maps.InjectActiveCells(mesh=mesh, indActive=actind, valInactive=-5.0)
+mapactive = maps.InjectActiveCells(mesh=mesh, active_cells=actind, value_inactive=-5.0)
 mapping = expmap * mapactive
 problem = DC.Simulation3DCellCentered(
     mesh, survey=survey, sigmaMap=mapping, solver=Solver, bc_type="Neumann"

--- a/examples/06-tdem/plot_inv_tdem_1D.py
+++ b/examples/06-tdem/plot_inv_tdem_1D.py
@@ -56,7 +56,7 @@ def run(plotIt=True):
     data = simulation.make_synthetic_data(mtrue, relative_error=rel_err)
 
     dmisfit = data_misfit.L2DataMisfit(simulation=simulation, data=data)
-    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].indActive]])
+    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].active_cells]])
     reg = regularization.WeightedLeastSquares(regMesh, alpha_s=1e-2, alpha_x=1.0)
     opt = optimization.InexactGaussNewton(maxIter=5, LSshorten=0.5)
     invProb = inverse_problem.BaseInvProblem(dmisfit, reg, opt)

--- a/examples/06-tdem/plot_inv_tdem_1D_raw_waveform.py
+++ b/examples/06-tdem/plot_inv_tdem_1D_raw_waveform.py
@@ -80,7 +80,7 @@ def run(plotIt=True):
     data = prb.make_synthetic_data(mtrue, relative_error=0.02, noise_floor=1e-11)
 
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data)
-    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].indActive]])
+    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].active_cells]])
     reg = regularization.WeightedLeastSquares(regMesh)
     opt = optimization.InexactGaussNewton(maxIter=5, LSshorten=0.5)
     invProb = inverse_problem.BaseInvProblem(dmisfit, reg, opt)

--- a/examples/20-published/plot_booky_1D_time_freq_inv.py
+++ b/examples/20-published/plot_booky_1D_time_freq_inv.py
@@ -244,7 +244,7 @@ def run(plotIt=True, saveFig=False, cleanup=True):
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=data_resolve)
 
     # Regularization
-    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].indActive]])
+    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].active_cells]])
     reg = regularization.WeightedLeastSquares(
         regMesh, mapping=maps.IdentityMap(regMesh)
     )
@@ -360,7 +360,7 @@ def run(plotIt=True, saveFig=False, cleanup=True):
     dmisfit = data_misfit.L2DataMisfit(simulation=prob, data=data_sky)
 
     # Regularization
-    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].indActive]])
+    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].active_cells]])
     reg = regularization.WeightedLeastSquares(
         regMesh, mapping=maps.IdentityMap(regMesh)
     )

--- a/examples/20-published/plot_booky_1Dstitched_resolve_inv.py
+++ b/examples/20-published/plot_booky_1Dstitched_resolve_inv.py
@@ -125,7 +125,7 @@ def resolve_1Dinversions(
     dmisfit = data_misfit.L2DataMisfit(simulation=prb, data=dat)
 
     # regularization
-    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].indActive]])
+    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].active_cells]])
     reg = regularization.WeightedLeastSquares(regMesh)
     reg.reference_model = mref
 

--- a/examples/20-published/plot_heagyetal2017_casing.py
+++ b/examples/20-published/plot_heagyetal2017_casing.py
@@ -244,13 +244,13 @@ class PrimSecCasingExample(object):
             # inject casing parameters so they are included in the construction
             # of the layered background + casing
             injectCasingParams = maps.InjectActiveCells(
-                None, indActive=np.r_[0, 1, 4, 5], valInactive=valInactive, nC=10
+                None, active_cells=np.r_[0, 1, 4, 5], value_inactive=valInactive, nC=10
             )
 
             # maps a list of casing parameters to the cyl mesh (below the
             # subsurface)
             paramMapPrimary = maps.ParametricCasingAndLayer(
-                self.meshp, indActive=self.indActivePrimary, slopeFact=1e4
+                self.meshp, active_cells=self.indActivePrimary, slopeFact=1e4
             )
 
             # inject air cells
@@ -519,7 +519,7 @@ class PrimSecCasingExample(object):
         return self._meshs
 
     @property
-    def indActive(self):
+    def iindActivendActive(self):
         return self.meshs.gridCC[:, 2] <= 0.0  # air cells
 
     @property
@@ -538,7 +538,9 @@ class PrimSecCasingExample(object):
         # model on our mesh
         if getattr(self, "_mapping", None) is None:
             print("building secondary mapping")
-            paramMap = maps.ParametricBlockInLayer(self.meshs, indActive=self.indActive)
+            paramMap = maps.ParametricBlockInLayer(
+                self.meshs, active_cells=self.indActive
+            )
             self._mapping = (
                 self.expMap
                 * self.injActMap  # log sigma --> sigma
@@ -555,7 +557,7 @@ class PrimSecCasingExample(object):
             # block)
             print("Building primaryMap2meshs")
             paramMapPrimaryMeshs = maps.ParametricLayer(
-                self.meshs, indActive=self.indActive
+                self.meshs, active_cells=self.indActive
             )
 
             self._primaryMap2mesh = (

--- a/examples/20-published/plot_heagyetal2017_casing.py
+++ b/examples/20-published/plot_heagyetal2017_casing.py
@@ -519,7 +519,7 @@ class PrimSecCasingExample(object):
         return self._meshs
 
     @property
-    def iindActivendActive(self):
+    def indActive(self):
         return self.meshs.gridCC[:, 2] <= 0.0  # air cells
 
     @property

--- a/examples/20-published/plot_heagyetal2017_cyl_inversions.py
+++ b/examples/20-published/plot_heagyetal2017_cyl_inversions.py
@@ -102,7 +102,7 @@ def run(plotIt=True, saveFig=False):
     # FDEM inversion
     np.random.seed(1)
     dmisfit = data_misfit.L2DataMisfit(simulation=prbFD, data=dataFD)
-    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].indActive]])
+    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].active_cells]])
     reg = regularization.WeightedLeastSquares(regMesh)
     opt = optimization.InexactGaussNewton(maxIterCG=10)
     invProb = inverse_problem.BaseInvProblem(dmisfit, reg, opt)
@@ -148,7 +148,7 @@ def run(plotIt=True, saveFig=False):
 
     # TDEM inversion
     dmisfit = data_misfit.L2DataMisfit(simulation=prbTD, data=dataTD)
-    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].indActive]])
+    regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].active_cells]])
     reg = regularization.WeightedLeastSquares(regMesh)
     opt = optimization.InexactGaussNewton(maxIterCG=10)
     invProb = inverse_problem.BaseInvProblem(dmisfit, reg, opt)

--- a/examples/_archived/plot_inv_dcip_dipoledipole_2_5Dinversion_irls.py
+++ b/examples/_archived/plot_inv_dcip_dipoledipole_2_5Dinversion_irls.py
@@ -111,7 +111,9 @@ def run(plotIt=True, survey_type="dipole-dipole", p=0.0, qx=2.0, qz=2.0):
         plt.show()
 
     # Use Exponential Map: m = log(rho)
-    actmap = maps.InjectActiveCells(mesh, indActive=actind, valInactive=np.log(1e8))
+    actmap = maps.InjectActiveCells(
+        mesh, active_cells=actind, value_inactive=np.log(1e8)
+    )
     mapping = maps.ExpMap(mesh) * actmap
 
     # Generate mtrue

--- a/simpeg/electromagnetics/natural_source/utils/test_utils.py
+++ b/simpeg/electromagnetics/natural_source/utils/test_utils.py
@@ -242,7 +242,7 @@ def setupSimpegNSEM_tests_location_assign_list(
 
     # Set the mapping
     actMap = maps.InjectActiveCells(
-        mesh=mesh, indActive=active, valInactive=np.log(1e-8)
+        mesh=mesh, active_cells=active, value_inactive=np.log(1e-8)
     )
     mapping = maps.ExpMap(mesh) * actMap
     # print(survey_ns.source_list)
@@ -367,7 +367,7 @@ def setupSimpegNSEM_PrimarySecondary(inputSetup, freqs, comp="Imp", singleFreq=F
 
     # Set the mapping
     actMap = maps.InjectActiveCells(
-        mesh=mesh, indActive=active, valInactive=np.log(1e-8)
+        mesh=mesh, active_cells=active, value_inactive=np.log(1e-8)
     )
     mapping = maps.ExpMap(mesh) * actMap
     # print(survey_ns.source_list)

--- a/simpeg/electromagnetics/static/spectral_induced_polarization/run.py
+++ b/simpeg/electromagnetics/static/spectral_induced_polarization/run.py
@@ -41,12 +41,14 @@ def spectral_ip_mappings(
         indActive = np.ones(mesh.nC, dtype=bool)
 
     actmap_eta = maps.InjectActiveCells(
-        mesh, indActive=indActive, valInactive=inactive_eta
+        mesh, active_cells=indActive, value_inactive=inactive_eta
     )
     actmap_tau = maps.InjectActiveCells(
-        mesh, indActive=indActive, valInactive=inactive_tau
+        mesh, active_cells=indActive, value_inactive=inactive_tau
     )
-    actmap_c = maps.InjectActiveCells(mesh, indActive=indActive, valInactive=inactive_c)
+    actmap_c = maps.InjectActiveCells(
+        mesh, active_cells=indActive, value_inactive=inactive_c
+    )
 
     wires = maps.Wires(
         ("eta", indActive.sum()), ("tau", indActive.sum()), ("c", indActive.sum())

--- a/simpeg/maps/_injection.py
+++ b/simpeg/maps/_injection.py
@@ -6,6 +6,7 @@ import warnings
 import discretize
 import numpy as np
 import scipy.sparse as sp
+from numbers import Number
 
 from ..utils import (
     validate_type,
@@ -209,8 +210,8 @@ class InjectActiveCells(IdentityMap):
             active_cells = indActive
 
         # Deprecate valInactive argument
-        if valInactive != 0.0:
-            if value_inactive != 0.0:
+        if not isinstance(valInactive, Number) or valInactive != 0.0:
+            if not isinstance(value_inactive, Number) or value_inactive != 0.0:
                 raise TypeError(
                     "Cannot pass both 'value_inactive' and 'valInactive'."
                     "'valInactive' has been deprecated and will be removed in "
@@ -243,14 +244,13 @@ class InjectActiveCells(IdentityMap):
 
     @value_inactive.setter
     def value_inactive(self, value):
-        value = validate_float("value_inactive", value)
-
         n_inactive = self.nC - self.nP
-        value = np.full(n_inactive, value)
+        if isinstance(value, Number):
+            value = validate_float("value_inactive", value)
+            value = np.full(n_inactive, value)
         value = validate_ndarray_with_shape(
             "value_inactive", value, shape=(n_inactive,)
         )
-
         value_inactive = np.zeros(self.nC, dtype=float)
         value_inactive[~self.active_cells] = value
         self._value_inactive = value_inactive

--- a/simpeg/maps/_injection.py
+++ b/simpeg/maps/_injection.py
@@ -227,7 +227,7 @@ class InjectActiveCells(IdentityMap):
         self.active_cells = active_cells
         self._nP = np.sum(self.active_cells)
 
-        self.P = sp.eye(self.nC, format="csr")[:, self.indActive]
+        self.P = sp.eye(self.nC, format="csr")[:, self.active_cells]
 
         self.value_inactive = value_inactive
 
@@ -312,12 +312,12 @@ class InjectActiveCells(IdentityMap):
         int
             Number of parameters the model acts on; i.e. the number of active cells
         """
-        return int(self.indActive.sum())
+        return int(self.active_cells.sum())
 
     def _transform(self, m):
         if m.ndim > 1:
-            return self.P * m + self.valInactive[:, None]
-        return self.P * m + self.valInactive
+            return self.P * m + self.value_inactive[:, None]
+        return self.P * m + self.value_inactive
 
     def inverse(self, u):
         r"""Recover the model parameters (active cells) from a set of physical

--- a/simpeg/maps/_injection.py
+++ b/simpeg/maps/_injection.py
@@ -44,7 +44,7 @@ class Mesh2Mesh(IdentityMap):
             if active_cells is not None:
                 raise TypeError(
                     "Cannot pass both 'active_cells' and 'indActive'."
-                    "'ind_active' has been deprecated and will be removed in "
+                    "'indActive' has been deprecated and will be removed in "
                     " SimPEG v0.24.0, please use 'active_cells' instead.",
                 )
             warnings.warn(

--- a/simpeg/maps/_injection.py
+++ b/simpeg/maps/_injection.py
@@ -243,15 +243,14 @@ class InjectActiveCells(IdentityMap):
 
     @value_inactive.setter
     def value_inactive(self, value):
+        value = validate_float("value_inactive", value)
+
         n_inactive = self.nC - self.nP
-        try:
-            value = validate_float("value_inactive", value)
-            value = np.full(n_inactive, value)
-        except Exception:
-            pass
+        value = np.full(n_inactive, value)
         value = validate_ndarray_with_shape(
             "value_inactive", value, shape=(n_inactive,)
         )
+
         value_inactive = np.zeros(self.nC, dtype=float)
         value_inactive[~self.active_cells] = value
         self._value_inactive = value_inactive

--- a/simpeg/maps/_parametric.py
+++ b/simpeg/maps/_parametric.py
@@ -417,7 +417,7 @@ class ParametricPolyMap(IdentityMap):
             if active_cells is not None:
                 raise TypeError(
                     "Cannot pass both 'active_cells' and 'actInd'."
-                    "'ind_active' has been deprecated and will be removed in "
+                    "'actInd' has been deprecated and will be removed in "
                     " SimPEG v0.24.0, please use 'active_cells' instead.",
                 )
             warnings.warn(

--- a/tests/base/regularizations/test_regularization.py
+++ b/tests/base/regularizations/test_regularization.py
@@ -469,7 +469,7 @@ class RegularizationTests(unittest.TestCase):
         )
         mapping = maps.ExpMap(mesh) * maps.SurjectVertical1D(mesh) * actMap
 
-        regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].indActive]])
+        regMesh = discretize.TensorMesh([mesh.h[2][mapping.maps[-1].active_cells]])
         reg = regularization.WeightedLeastSquares(regMesh)
 
         self.assertTrue(reg._nC_residual == regMesh.nC)

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -781,7 +781,7 @@ def test_linearity():
 
 
 class DeprecatedIndActive:
-    """Base class to use to test deprecated ``actInd`` arguments in maps."""
+    """Base class to test deprecated ``actInd`` and ``indActive`` arguments in maps."""
 
     @pytest.fixture
     def mesh(self):

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -881,5 +881,92 @@ class TestMesh2Mesh(DeprecatedIndActive):
         np.testing.assert_allclose(mapping.active_cells, new_active_cells)
 
 
+class TestInjectActiveCells(DeprecatedIndActive):
+    """Test deprecated ``indActive`` and ``valInactive`` in ``InjectActiveCells``."""
+
+    def test_indactive_warning_argument(self, mesh, active_cells):
+        """
+        Test if warning is raised after passing ``indActive`` to the constructor.
+        """
+        msg = "'indActive' has been deprecated and will be removed in "
+        with pytest.warns(FutureWarning, match=msg):
+            maps.InjectActiveCells(mesh, indActive=active_cells)
+
+    def test_indactive_error_duplicated_argument(self, mesh, active_cells):
+        """
+        Test error after passing ``indActive`` and ``active_cells`` to the constructor.
+        """
+        msg = "Cannot pass both 'active_cells' and 'indActive'."
+        with pytest.raises(TypeError, match=msg):
+            maps.InjectActiveCells(
+                mesh, active_cells=active_cells, indActive=active_cells
+            )
+
+    def test_indactive_warning_accessing_property(self, mesh, active_cells):
+        """
+        Test warning when trying to access the ``indActive`` property.
+        """
+        mapping = maps.InjectActiveCells(mesh, active_cells=active_cells)
+        msg = "indActive has been deprecated, please use active_cells"
+        with pytest.warns(FutureWarning, match=msg):
+            old_act_ind = mapping.indActive
+        np.testing.assert_allclose(mapping.active_cells, old_act_ind)
+
+    def test_indactive_warning_setter(self, mesh, active_cells):
+        """
+        Test warning when trying to set the ``indActive`` property.
+        """
+        mapping = maps.InjectActiveCells(mesh, active_cells=active_cells)
+        # Define new active cells to pass to the setter
+        new_active_cells = active_cells.copy()
+        new_active_cells[-4:] = False
+        msg = "indActive has been deprecated, please use active_cells"
+        with pytest.warns(FutureWarning, match=msg):
+            mapping.indActive = new_active_cells
+        np.testing.assert_allclose(mapping.active_cells, new_active_cells)
+
+    def test_valinactive_warning_argument(self, mesh, active_cells):
+        """
+        Test if warning is raised after passing ``valInactive`` to the constructor.
+        """
+        msg = "'valInactive' has been deprecated and will be removed in "
+        with pytest.warns(FutureWarning, match=msg):
+            maps.InjectActiveCells(mesh, active_cells=active_cells, valInactive=3.14)
+
+    def test_valinactive_error_duplicated_argument(self, mesh, active_cells):
+        """
+        Test error after passing ``valInactive`` and ``value_inactive`` to the
+        constructor.
+        """
+        msg = "Cannot pass both 'value_inactive' and 'valInactive'."
+        with pytest.raises(TypeError, match=msg):
+            maps.InjectActiveCells(
+                mesh, active_cells=active_cells, value_inactive=3.14, valInactive=3.14
+            )
+
+    def test_valinactive_warning_accessing_property(self, mesh, active_cells):
+        """
+        Test warning when trying to access the ``valInactive`` property.
+        """
+        mapping = maps.InjectActiveCells(
+            mesh, active_cells=active_cells, value_inactive=3.14
+        )
+        msg = "valInactive has been deprecated, please use value_inactive"
+        with pytest.warns(FutureWarning, match=msg):
+            old_value = mapping.valInactive
+        np.testing.assert_allclose(mapping.value_inactive, old_value)
+
+    def test_valinactive_warning_setter(self, mesh, active_cells):
+        """
+        Test warning when trying to set the ``valInactive`` property.
+        """
+        mapping = maps.InjectActiveCells(
+            mesh, active_cells=active_cells, value_inactive=3.14
+        )
+        msg = "valInactive has been deprecated, please use value_inactive"
+        with pytest.warns(FutureWarning, match=msg):
+            mapping.valInactive = 3.14
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -987,7 +987,8 @@ class TestInjectActiveCells(DeprecatedIndActive):
         )
         msg = "valInactive has been deprecated, please use value_inactive"
         with pytest.warns(FutureWarning, match=msg):
-            mapping.valInactive = 3.14
+            mapping.valInactive = 4.5
+        np.testing.assert_allclose(mapping.value_inactive[~mapping.active_cells], 4.5)
 
 
 class TestParametric(DeprecatedIndActive):

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -947,15 +947,22 @@ class TestInjectActiveCells(DeprecatedIndActive):
             mapping.indActive = new_active_cells
         np.testing.assert_allclose(mapping.active_cells, new_active_cells)
 
-    def test_valinactive_warning_argument(self, mesh, active_cells):
+    @pytest.mark.parametrize("valInactive", (3.14, np.array([1])))
+    def test_valinactive_warning_argument(self, mesh, active_cells, valInactive):
         """
         Test if warning is raised after passing ``valInactive`` to the constructor.
         """
         msg = self.get_message_deprecated_warning("valInactive", "value_inactive")
         with pytest.warns(FutureWarning, match=msg):
-            maps.InjectActiveCells(mesh, active_cells=active_cells, valInactive=3.14)
+            maps.InjectActiveCells(
+                mesh, active_cells=active_cells, valInactive=valInactive
+            )
 
-    def test_valinactive_error_duplicated_argument(self, mesh, active_cells):
+    @pytest.mark.parametrize("valInactive", (3.14, np.array([3.14])))
+    @pytest.mark.parametrize("value_inactive", (3.14, np.array([3.14])))
+    def test_valinactive_error_duplicated_argument(
+        self, mesh, active_cells, valInactive, value_inactive
+    ):
         """
         Test error after passing ``valInactive`` and ``value_inactive`` to the
         constructor.
@@ -963,7 +970,10 @@ class TestInjectActiveCells(DeprecatedIndActive):
         msg = self.get_message_duplicated_error("valInactive", "value_inactive")
         with pytest.raises(TypeError, match=msg):
             maps.InjectActiveCells(
-                mesh, active_cells=active_cells, value_inactive=3.14, valInactive=3.14
+                mesh,
+                active_cells=active_cells,
+                value_inactive=value_inactive,
+                valInactive=valInactive,
             )
 
     def test_valinactive_warning_accessing_property(self, mesh, active_cells):

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import numpy as np
 import unittest
 import discretize
@@ -830,6 +831,53 @@ class TestParametricPolyMap(DeprecatedIndActive):
         msg = "actInd has been deprecated, please use active_cells"
         with pytest.warns(FutureWarning, match=msg):
             mapping.actInd = new_active_cells
+        np.testing.assert_allclose(mapping.active_cells, new_active_cells)
+
+
+class TestMesh2Mesh(DeprecatedIndActive):
+    """Test deprecated ``indActive`` in ``Mesh2Mesh``."""
+
+    @pytest.fixture
+    def meshes(self, mesh):
+        return [mesh, deepcopy(mesh)]
+
+    def test_warning_argument(self, meshes, active_cells):
+        """
+        Test if warning is raised after passing ``indActive`` to the constructor.
+        """
+        msg = "'indActive' has been deprecated and will be removed in "
+        with pytest.warns(FutureWarning, match=msg):
+            maps.Mesh2Mesh(meshes, indActive=active_cells)
+
+    def test_error_duplicated_argument(self, meshes, active_cells):
+        """
+        Test error after passing ``indActive`` and ``active_cells`` to the constructor.
+        """
+        msg = "Cannot pass both 'active_cells' and 'indActive'."
+        with pytest.raises(TypeError, match=msg):
+            maps.Mesh2Mesh(meshes, active_cells=active_cells, indActive=active_cells)
+
+    def test_warning_accessing_property(self, meshes, active_cells):
+        """
+        Test warning when trying to access the ``indActive`` property.
+        """
+        mapping = maps.Mesh2Mesh(meshes, active_cells=active_cells)
+        msg = "indActive has been deprecated, please use active_cells"
+        with pytest.warns(FutureWarning, match=msg):
+            old_act_ind = mapping.indActive
+        np.testing.assert_allclose(mapping.active_cells, old_act_ind)
+
+    def test_warning_setter(self, meshes, active_cells):
+        """
+        Test warning when trying to set the ``indActive`` property.
+        """
+        mapping = maps.Mesh2Mesh(meshes, active_cells=active_cells)
+        # Define new active cells to pass to the setter
+        new_active_cells = active_cells.copy()
+        new_active_cells[-4:] = False
+        msg = "indActive has been deprecated, please use active_cells"
+        with pytest.warns(FutureWarning, match=msg):
+            mapping.indActive = new_active_cells
         np.testing.assert_allclose(mapping.active_cells, new_active_cells)
 
 

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -788,6 +788,21 @@ class DeprecatedIndActive:
         active_cells[0] = False
         return active_cells
 
+    def get_message_duplicated_error(self, old_name, new_name, version="v0.24.0"):
+        msg = (
+            f"Cannot pass both '{new_name}' and '{old_name}'."
+            f"'{old_name}' has been deprecated and will be removed in "
+            f" SimPEG {version}, please use '{new_name}' instead."
+        )
+        return msg
+
+    def get_message_deprecated_warning(self, old_name, new_name, version="v0.24.0"):
+        msg = (
+            f"'{old_name}' has been deprecated and will be removed in "
+            f" SimPEG {version}, please use '{new_name}' instead."
+        )
+        return msg
+
 
 class TestParametricPolyMap(DeprecatedIndActive):
     """Test deprecated ``actInd`` in ParametricPolyMap."""
@@ -796,7 +811,7 @@ class TestParametricPolyMap(DeprecatedIndActive):
         """
         Test if warning is raised after passing ``actInd`` to the constructor.
         """
-        msg = "'actInd' has been deprecated and will be removed in "
+        msg = self.get_message_deprecated_warning("actInd", "active_cells")
         with pytest.warns(FutureWarning, match=msg):
             maps.ParametricPolyMap(mesh, 2, actInd=active_cells)
 
@@ -804,7 +819,7 @@ class TestParametricPolyMap(DeprecatedIndActive):
         """
         Test error after passing ``actInd`` and ``active_cells`` to the constructor.
         """
-        msg = "Cannot pass both 'active_cells' and 'actInd'."
+        msg = self.get_message_duplicated_error("actInd", "active_cells")
         with pytest.raises(TypeError, match=msg):
             maps.ParametricPolyMap(
                 mesh, 2, active_cells=active_cells, actInd=active_cells
@@ -845,7 +860,7 @@ class TestMesh2Mesh(DeprecatedIndActive):
         """
         Test if warning is raised after passing ``indActive`` to the constructor.
         """
-        msg = "'indActive' has been deprecated and will be removed in "
+        msg = self.get_message_deprecated_warning("indActive", "active_cells")
         with pytest.warns(FutureWarning, match=msg):
             maps.Mesh2Mesh(meshes, indActive=active_cells)
 
@@ -853,7 +868,7 @@ class TestMesh2Mesh(DeprecatedIndActive):
         """
         Test error after passing ``indActive`` and ``active_cells`` to the constructor.
         """
-        msg = "Cannot pass both 'active_cells' and 'indActive'."
+        msg = self.get_message_duplicated_error("indActive", "active_cells")
         with pytest.raises(TypeError, match=msg):
             maps.Mesh2Mesh(meshes, active_cells=active_cells, indActive=active_cells)
 
@@ -888,7 +903,7 @@ class TestInjectActiveCells(DeprecatedIndActive):
         """
         Test if warning is raised after passing ``indActive`` to the constructor.
         """
-        msg = "'indActive' has been deprecated and will be removed in "
+        msg = self.get_message_deprecated_warning("indActive", "active_cells")
         with pytest.warns(FutureWarning, match=msg):
             maps.InjectActiveCells(mesh, indActive=active_cells)
 
@@ -896,7 +911,7 @@ class TestInjectActiveCells(DeprecatedIndActive):
         """
         Test error after passing ``indActive`` and ``active_cells`` to the constructor.
         """
-        msg = "Cannot pass both 'active_cells' and 'indActive'."
+        msg = self.get_message_duplicated_error("indActive", "active_cells")
         with pytest.raises(TypeError, match=msg):
             maps.InjectActiveCells(
                 mesh, active_cells=active_cells, indActive=active_cells
@@ -929,7 +944,7 @@ class TestInjectActiveCells(DeprecatedIndActive):
         """
         Test if warning is raised after passing ``valInactive`` to the constructor.
         """
-        msg = "'valInactive' has been deprecated and will be removed in "
+        msg = self.get_message_deprecated_warning("valInactive", "value_inactive")
         with pytest.warns(FutureWarning, match=msg):
             maps.InjectActiveCells(mesh, active_cells=active_cells, valInactive=3.14)
 
@@ -938,7 +953,7 @@ class TestInjectActiveCells(DeprecatedIndActive):
         Test error after passing ``valInactive`` and ``value_inactive`` to the
         constructor.
         """
-        msg = "Cannot pass both 'value_inactive' and 'valInactive'."
+        msg = self.get_message_duplicated_error("valInactive", "value_inactive")
         with pytest.raises(TypeError, match=msg):
             maps.InjectActiveCells(
                 mesh, active_cells=active_cells, value_inactive=3.14, valInactive=3.14

--- a/tests/em/nsem/inversion/test_complex_resistivity.py
+++ b/tests/em/nsem/inversion/test_complex_resistivity.py
@@ -79,7 +79,7 @@ class ComplexResistivityTest(unittest.TestCase):
 
         # Set the mapping
         actMap = maps.InjectActiveCells(
-            mesh=self.mesh, indActive=self.active, valInactive=np.log(1e-8)
+            mesh=self.mesh, active_cells=self.active, value_inactive=np.log(1e-8)
         )
         mapping = maps.ExpMap(self.mesh) * actMap
         # print(survey_ns.source_list)
@@ -121,7 +121,7 @@ class ComplexResistivityTest(unittest.TestCase):
 
         # Set the mapping
         actMap = maps.InjectActiveCells(
-            mesh=self.mesh, indActive=self.active, valInactive=np.log(1e-8)
+            mesh=self.mesh, active_cells=self.active, value_inactive=np.log(1e-8)
         )
         mapping = maps.ExpMap(self.mesh) * actMap
         # print(survey_ns.source_list)
@@ -173,7 +173,7 @@ class ComplexResistivityTest(unittest.TestCase):
 
         # Set the mapping
         actMap = maps.InjectActiveCells(
-            mesh=self.mesh, indActive=self.active, valInactive=np.log(1e-8)
+            mesh=self.mesh, active_cells=self.active, value_inactive=np.log(1e-8)
         )
         mapping = maps.ExpMap(self.mesh) * actMap
         # print(survey_ns.source_list)
@@ -212,7 +212,7 @@ class ComplexResistivityTest(unittest.TestCase):
 
         # Set the mapping
         actMap = maps.InjectActiveCells(
-            mesh=self.mesh, indActive=self.active, valInactive=np.log(1e-8)
+            mesh=self.mesh, active_cells=self.active, value_inactive=np.log(1e-8)
         )
         mapping = maps.ExpMap(self.mesh) * actMap
         # print(survey_ns.source_list)

--- a/tutorials/01-models_mapping/plot_1_tensor_models.py
+++ b/tutorials/01-models_mapping/plot_1_tensor_models.py
@@ -263,7 +263,9 @@ active_map = maps.InjectActiveCells(mesh, ind_active, air_value)
 
 # Define the model on subsurface cells
 model = np.r_[background_value, block_value, xc, dx, yc, dy, zc, dz]
-parametric_map = maps.ParametricBlock(mesh, indActive=ind_active, epsilon=1e-10, p=5.0)
+parametric_map = maps.ParametricBlock(
+    mesh, active_cells=ind_active, epsilon=1e-10, p=5.0
+)
 
 # Define a single mapping from model to mesh
 model_map = active_map * parametric_map

--- a/tutorials/01-models_mapping/plot_2_cyl_models.py
+++ b/tutorials/01-models_mapping/plot_2_cyl_models.py
@@ -161,7 +161,9 @@ active_map = maps.InjectActiveCells(mesh, ind_active, air_value)
 model = np.r_[
     background_value, pipe_value, rc, dr, 0.0, 1.0, zc, dz
 ]  # add dummy values for phi
-parametric_map = maps.ParametricBlock(mesh, indActive=ind_active, epsilon=1e-10, p=8.0)
+parametric_map = maps.ParametricBlock(
+    mesh, active_cells=ind_active, epsilon=1e-10, p=8.0
+)
 
 # Define a single mapping from model to mesh
 model_map = active_map * parametric_map

--- a/tutorials/01-models_mapping/plot_3_tree_models.py
+++ b/tutorials/01-models_mapping/plot_3_tree_models.py
@@ -279,7 +279,9 @@ active_map = maps.InjectActiveCells(mesh, ind_active, air_value)
 
 # Define the model on subsurface cells
 model = np.r_[background_value, block_value, xc, dx, yc, dy, zc, dz]
-parametric_map = maps.ParametricBlock(mesh, indActive=ind_active, epsilon=1e-10, p=5.0)
+parametric_map = maps.ParametricBlock(
+    mesh, active_cells=ind_active, epsilon=1e-10, p=5.0
+)
 
 # Define a single mapping from model to mesh
 model_map = active_map * parametric_map


### PR DESCRIPTION
#### Summary

Deprecate the `indActive`, `actInd` arguments and properties from maps and replace them for `active_cells`. Deprecate the `valInactive` argument and property from `InjectActiveCells` and replace it for `value_inactive`. Add tests for the deprecations. Avoid a try and except pattern in the setter for `value_inactive`: we don't want to ignore any error that might happen in those lines. Update usage of `actInd`, `indActive` and `valInactive` in tutorials and examples.


#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Part of #1121

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->