### PR TITLE
Minor fix in deprecation notice in docstrings

### DIFF
--- a/simpeg/potential_fields/base.py
+++ b/simpeg/potential_fields/base.py
@@ -66,7 +66,7 @@ class BasePFSimulation(LinearSimulation):
 
         .. deprecated:: 0.23.0
 
-           Keyword argument ``ind_active`` is deprecated in favor of
+           Argument ``ind_active`` is deprecated in favor of
            ``active_cells`` and will be removed in SimPEG v0.24.0.
 
     Notes

--- a/simpeg/potential_fields/gravity/simulation.py
+++ b/simpeg/potential_fields/gravity/simulation.py
@@ -110,7 +110,7 @@ class Simulation3DIntegral(BasePFSimulation):
 
         .. deprecated:: 0.23.0
 
-           Keyword argument ``ind_active`` is deprecated in favor of
+           Argument ``ind_active`` is deprecated in favor of
            ``active_cells`` and will be removed in SimPEG v0.24.0.
     """
 

--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -87,7 +87,7 @@ class Simulation3DIntegral(BasePFSimulation):
 
         .. deprecated:: 0.23.0
 
-           Keyword argument ``ind_active`` is deprecated in favor of
+           Argument ``ind_active`` is deprecated in favor of
            ``active_cells`` and will be removed in SimPEG v0.24.0.
     """
 


### PR DESCRIPTION
#### Summary

Apply a minor fix to the deprecation notice of `ind_active` in the potential field simulations.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
