### PR TITLE
Publish coverage data as artifacts

### DIFF
--- a/.ci/azure/codecov.yml
+++ b/.ci/azure/codecov.yml
@@ -9,26 +9,37 @@ jobs:
       - checkout: self
         displayName: "Checkout repository"
 
+      - bash: pip install coverage
+        displayName: "Install coverage"
+
+      - bash: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+        displayName: "Install codecov cli"
+
       - task: DownloadPipelineArtifact@2
         inputs:
-          patterns: "coverage-*/coverage-*.xml"
+          patterns: "coverage-*/coverage-*"
         displayName: "Download coverage artifacts"
 
       - bash: ls -la $(Pipeline.Workspace)/coverage-*/coverage-*.xml
         displayName: "List downloaded coverage artifacts"
 
       - bash: |
-          cp $(Pipeline.Workspace)/coverage-*/coverage-*.xml .
-          ls -la
+          mkdir coverages
+          cp $(Pipeline.Workspace)/coverage-*/coverage-* coverages
+          ls -la coverages
         displayName: "Copy coverage files"
 
-      - script: |
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          chmod +x codecov
-        displayName: "Install codecov cli"
+      - bash: |
+          coverage combine coverages/*
+          ls -la .coverage
+        displayName: "Combine coverages"
 
-      - script: |
-          for report in coverage-*.xml; do
-            ./codecov --verbose upload-process -f "$report"
-          done
+      - bash: |
+          coverage xml
+        displayName: "Convert coverage to xml"
+
+      - bash: |
+          ./codecov --verbose upload-process -f coverage.xml
         displayName: "Upload coverage to codecov.io"

--- a/.ci/azure/run_tests_with_coverage.sh
+++ b/.ci/azure/run_tests_with_coverage.sh
@@ -3,4 +3,3 @@ set -ex #echo on and exit if any line fails
 
 source activate simpeg-test
 pytest $TEST_TARGET --cov --cov-config=pyproject.toml -v -W ignore::DeprecationWarning
-coverage xml

--- a/.ci/azure/test.yml
+++ b/.ci/azure/test.yml
@@ -55,12 +55,12 @@ jobs:
           - bash: |
               job="${{ os }}_${{ py_vers }}_${{ test }}"
               jobhash=$(echo $job | sha256sum | cut -f 1 -d " " | cut -c 1-7)
-              cp coverage.xml "coverage-$jobhash.xml"
+              cp .coverage "coverage-$jobhash"
               echo "##vso[task.setvariable variable=jobhash]$jobhash"
             displayName: 'Rename coverage report'
 
           - task: PublishPipelineArtifact@1
             inputs:
-              targetPath: $(Build.SourcesDirectory)/coverage-$(jobhash).xml
+              targetPath: $(Build.SourcesDirectory)/coverage-$(jobhash)
               artifactName: coverage-$(jobhash)
             displayName: 'Publish coverage artifact'


### PR DESCRIPTION
#### Summary

Publish de binary coverage data as artifacts when running tests on Azure instead of publishing the XML files. Combine the coverage files and convert them to XML before uploading them to Codecov. Upload to Codecov in a single push.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
