### PR TITLE
Test assigned values when passing deprecated args

### DIFF
--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -820,7 +820,8 @@ class TestParametricPolyMap(DeprecatedIndActive):
         """
         msg = self.get_message_deprecated_warning("actInd", "active_cells")
         with pytest.warns(FutureWarning, match=msg):
-            maps.ParametricPolyMap(mesh, 2, actInd=active_cells)
+            map_instance = maps.ParametricPolyMap(mesh, 2, actInd=active_cells)
+        np.testing.assert_allclose(map_instance.active_cells, active_cells)
 
     def test_error_duplicated_argument(self, mesh, active_cells):
         """
@@ -869,7 +870,8 @@ class TestMesh2Mesh(DeprecatedIndActive):
         """
         msg = self.get_message_deprecated_warning("indActive", "active_cells")
         with pytest.warns(FutureWarning, match=msg):
-            maps.Mesh2Mesh(meshes, indActive=active_cells)
+            mapping_instance = maps.Mesh2Mesh(meshes, indActive=active_cells)
+        np.testing.assert_allclose(mapping_instance.active_cells, active_cells)
 
     def test_error_duplicated_argument(self, meshes, active_cells):
         """
@@ -912,7 +914,8 @@ class TestInjectActiveCells(DeprecatedIndActive):
         """
         msg = self.get_message_deprecated_warning("indActive", "active_cells")
         with pytest.warns(FutureWarning, match=msg):
-            maps.InjectActiveCells(mesh, indActive=active_cells)
+            mapping_instance = maps.InjectActiveCells(mesh, indActive=active_cells)
+        np.testing.assert_allclose(mapping_instance.active_cells, active_cells)
 
     def test_indactive_error_duplicated_argument(self, mesh, active_cells):
         """
@@ -947,16 +950,20 @@ class TestInjectActiveCells(DeprecatedIndActive):
             mapping.indActive = new_active_cells
         np.testing.assert_allclose(mapping.active_cells, new_active_cells)
 
-    @pytest.mark.parametrize("valInactive", (3.14, np.array([1])))
-    def test_valinactive_warning_argument(self, mesh, active_cells, valInactive):
+    @pytest.mark.parametrize("value_inactive", (3.14, np.array([1])))
+    def test_valinactive_warning_argument(self, mesh, active_cells, value_inactive):
         """
         Test if warning is raised after passing ``valInactive`` to the constructor.
         """
         msg = self.get_message_deprecated_warning("valInactive", "value_inactive")
         with pytest.warns(FutureWarning, match=msg):
-            maps.InjectActiveCells(
-                mesh, active_cells=active_cells, valInactive=valInactive
+            mapping_instance = maps.InjectActiveCells(
+                mesh, active_cells=active_cells, valInactive=value_inactive
             )
+        # Ensure that the value passed to valInactive was correctly used
+        expected = np.zeros_like(active_cells, dtype=np.float64)
+        expected[~active_cells] = value_inactive
+        np.testing.assert_allclose(mapping_instance.value_inactive, expected)
 
     @pytest.mark.parametrize("valInactive", (3.14, np.array([3.14])))
     @pytest.mark.parametrize("value_inactive", (3.14, np.array([3.14])))
@@ -1013,7 +1020,8 @@ class TestParametric(DeprecatedIndActive):
         """
         msg = self.get_message_deprecated_warning("indActive", "active_cells")
         with pytest.warns(FutureWarning, match=msg):
-            map_class(mesh, indActive=active_cells)
+            mapping_instance = map_class(mesh, indActive=active_cells)
+        np.testing.assert_allclose(mapping_instance.active_cells, active_cells)
 
     @pytest.mark.parametrize("map_class", CLASSES)
     def test_indactive_error_duplicated_argument(self, mesh, active_cells, map_class):

--- a/tests/em/vrm/test_vrmfwd.py
+++ b/tests/em/vrm/test_vrmfwd.py
@@ -569,7 +569,8 @@ class TestDeprecatedIndActive:
         """
         msg = self.get_message_deprecated_warning(self.OLD_NAME, self.NEW_NAME)
         with pytest.warns(FutureWarning, match=msg):
-            simulation(mesh, indActive=active_cells)
+            sim = simulation(mesh, indActive=active_cells)
+        np.testing.assert_allclose(sim.active_cells, active_cells)
 
     @pytest.mark.parametrize("simulation", CLASSES)
     def test_error_duplicated_argument(self, mesh, active_cells, simulation):

--- a/tests/pf/test_base_pf_simulation.py
+++ b/tests/pf/test_base_pf_simulation.py
@@ -320,7 +320,8 @@ class TestDeprecationIndActive:
             f" SimPEG {version_regex}, please use 'active_cells' instead."
         )
         with pytest.warns(FutureWarning, match=msg):
-            mock_simulation_class(tensor_mesh, ind_active=ind_active)
+            sim = mock_simulation_class(tensor_mesh, ind_active=ind_active)
+        np.testing.assert_allclose(sim.active_cells, ind_active)
 
     def test_error_both_args(self, tensor_mesh, mock_simulation_class):
         """Test if passing both ind_active and active_cells raises error."""


### PR DESCRIPTION
#### Summary

Extend tests for some of the latest deprecated arguments to ensure that after passing the deprecated argument to the class constructor not only we receive the right warning, but the class still behaves in the same way it will if passing the new argument.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
