### PR TITLE
Use random seed when using `make_synthetic_data` in tests

### DIFF
--- a/tests/base/test_data_misfit.py
+++ b/tests/base/test_data_misfit.py
@@ -6,8 +6,6 @@ import discretize
 from simpeg import maps
 from simpeg import data_misfit, simulation, survey
 
-np.random.seed(17)
-
 
 class DataMisfitTest(unittest.TestCase):
     def setUp(self):
@@ -23,7 +21,7 @@ class DataMisfitTest(unittest.TestCase):
             mesh=mesh, survey=survey.BaseSurvey([source]), model_map=maps.ExpMap(mesh)
         )
 
-        synthetic_data = sim.make_synthetic_data(model)
+        synthetic_data = sim.make_synthetic_data(model, random_seed=17)
 
         self.relative = 0.01
         self.noise_floor = 1e-8

--- a/tests/base/test_directives.py
+++ b/tests/base/test_directives.py
@@ -88,7 +88,7 @@ class ValidationInInversion(unittest.TestCase):
 
         m = np.random.rand(mesh.nC)
 
-        data = sim.make_synthetic_data(m, add_noise=True)
+        data = sim.make_synthetic_data(m, add_noise=True, random_seed=19)
         dmis = data_misfit.L2DataMisfit(data=data, simulation=sim)
         dmis.W = 1.0 / data.relative_error
 
@@ -391,7 +391,9 @@ def test_save_output_dict(RegClass):
     sim = simulation.ExponentialSinusoidSimulation(
         mesh=mesh, model_map=maps.IdentityMap()
     )
-    data = sim.make_synthetic_data(np.ones(mesh.n_cells), add_noise=True)
+    data = sim.make_synthetic_data(
+        np.ones(mesh.n_cells), add_noise=True, random_seed=20
+    )
     dmis = data_misfit.L2DataMisfit(data, sim)
 
     opt = optimization.InexactGaussNewton(maxIter=1)

--- a/tests/base/test_joint.py
+++ b/tests/base/test_joint.py
@@ -53,8 +53,9 @@ class DataMisfitTest(unittest.TestCase):
             mesh=mesh, survey=survey1, rhoMap=maps.ExpMap(mesh)
         )
 
-        dobs0 = simulation0.make_synthetic_data(model)
-        dobs1 = simulation1.make_synthetic_data(model)
+        rng = np.random.default_rng(seed=42)
+        dobs0 = simulation0.make_synthetic_data(model, random_seed=rng)
+        dobs1 = simulation1.make_synthetic_data(model, random_seed=rng)
 
         self.mesh = mesh
         self.model = model

--- a/tests/dask/test_DC_jvecjtvecadj_dask.py
+++ b/tests/dask/test_DC_jvecjtvecadj_dask.py
@@ -15,8 +15,6 @@ from simpeg.utils import mkvc
 from simpeg.electromagnetics import resistivity as dc
 import shutil
 
-np.random.seed(40)
-
 TOL = 1e-5
 FLR = 1e-20  # "zero", so if residual below this --> pass regardless of order
 
@@ -45,7 +43,7 @@ class DCProblemTestsCC_storeJ(unittest.TestCase):
         )
 
         mSynth = np.ones(mesh.nC)
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
 
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(simulation=simulation, data=dobs)
@@ -123,7 +121,7 @@ class DCProblemTestsN_storeJ(unittest.TestCase):
         )
 
         mSynth = np.ones(mesh.nC)
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
 
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(simulation=simulation, data=dobs)

--- a/tests/dask/test_IP_jvecjtvecadj_dask.py
+++ b/tests/dask/test_IP_jvecjtvecadj_dask.py
@@ -162,7 +162,7 @@ class IPProblemTestsCC(unittest.TestCase):
             mesh=mesh, survey=survey, sigma=sigma, etaMap=maps.IdentityMap(mesh)
         )
         mSynth = np.ones(mesh.nC) * 0.1
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=simulation)
         reg = regularization.WeightedLeastSquares(mesh)
@@ -232,7 +232,7 @@ class IPProblemTestsN(unittest.TestCase):
             mesh=mesh, survey=survey, sigma=sigma, etaMap=maps.IdentityMap(mesh)
         )
         mSynth = np.ones(mesh.nC) * 0.1
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=simulation)
         reg = regularization.WeightedLeastSquares(mesh)
@@ -305,7 +305,7 @@ class IPProblemTestsCC_storeJ(unittest.TestCase):
             storeJ=True,
         )
         mSynth = np.ones(mesh.nC) * 0.1
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=simulation)
         reg = regularization.WeightedLeastSquares(mesh)
@@ -385,7 +385,7 @@ class IPProblemTestsN_storeJ(unittest.TestCase):
             storeJ=True,
         )
         mSynth = np.ones(mesh.nC) * 0.1
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=simulation)
         reg = regularization.WeightedLeastSquares(mesh)

--- a/tests/dask/test_grav_inversion_linear.py
+++ b/tests/dask/test_grav_inversion_linear.py
@@ -86,7 +86,11 @@ class GravInvLinProblemTest(unittest.TestCase):
         # computing sensitivities to ram is best using dask processes
         with dask.config.set(scheduler="processes"):
             data = sim.make_synthetic_data(
-                self.model, relative_error=0.0, noise_floor=0.0005, add_noise=True
+                self.model,
+                relative_error=0.0,
+                noise_floor=0.0005,
+                add_noise=True,
+                random_seed=42,
             )
         # Create a regularization
         reg = regularization.Sparse(self.mesh, active_cells=actv, mapping=idenMap)

--- a/tests/dask/test_mag_MVI_Octree.py
+++ b/tests/dask/test_mag_MVI_Octree.py
@@ -108,7 +108,11 @@ class MVIProblemTest(unittest.TestCase):
 
         # Compute some data and add some random noise
         data = sim.make_synthetic_data(
-            utils.mkvc(self.model), relative_error=0.0, noise_floor=5.0, add_noise=True
+            utils.mkvc(self.model),
+            relative_error=0.0,
+            noise_floor=5.0,
+            add_noise=True,
+            random_seed=40,
         )
 
         # This Mapping connects the regularizations for the three-component

--- a/tests/dask/test_mag_inversion_linear_Octree.py
+++ b/tests/dask/test_mag_inversion_linear_Octree.py
@@ -113,7 +113,11 @@ class MagInvLinProblemTest(unittest.TestCase):
         )
         self.sim = sim
         data = sim.make_synthetic_data(
-            self.model, relative_error=0.0, noise_floor=1.0, add_noise=True
+            self.model,
+            relative_error=0.0,
+            noise_floor=1.0,
+            add_noise=True,
+            random_seed=40,
         )
 
         # Create a regularization

--- a/tests/em/static/test_DC_2D_jvecjtvecadj.py
+++ b/tests/em/static/test_DC_2D_jvecjtvecadj.py
@@ -52,7 +52,7 @@ class DCProblem_2DTests(unittest.TestCase):
             bc_type=self.bc_type,
         )
         mSynth = np.ones(mesh.nC) * 1.0
-        data = simulation.make_synthetic_data(mSynth, add_noise=True)
+        data = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
 
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(simulation=simulation, data=data)

--- a/tests/em/static/test_DC_Utils.py
+++ b/tests/em/static/test_DC_Utils.py
@@ -91,7 +91,9 @@ class DCUtilsTests_halfspace(unittest.TestCase):
             problem.solver = Solver
 
             # Create synthetic data
-            dobs = problem.make_synthetic_data(self.model, relative_error=0.0)
+            dobs = problem.make_synthetic_data(
+                self.model, relative_error=0.0, random_seed=40
+            )
             dobs.noise_floor = 1e-5
 
             # Testing IO

--- a/tests/em/static/test_DC_jvecjtvecadj.py
+++ b/tests/em/static/test_DC_jvecjtvecadj.py
@@ -16,7 +16,6 @@ from simpeg.electromagnetics import resistivity as dc
 from pymatsolver import Pardiso
 import shutil
 
-np.random.seed(40)
 
 TOL = 1e-5
 FLR = 1e-20  # "zero", so if residual below this --> pass regardless of order
@@ -46,7 +45,7 @@ class DCProblemTestsCC(unittest.TestCase):
         )
 
         mSynth = np.ones(mesh.nC)
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
 
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(simulation=simulation, data=dobs)
@@ -191,7 +190,7 @@ class DCProblemTestsN(unittest.TestCase):
         )
 
         mSynth = np.ones(mesh.nC)
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
 
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(simulation=simulation, data=dobs)
@@ -339,7 +338,7 @@ class DCProblemTestsCC_storeJ(unittest.TestCase):
         )
 
         mSynth = np.ones(mesh.nC)
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
 
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(simulation=simulation, data=dobs)
@@ -420,7 +419,7 @@ class DCProblemTestsN_storeJ(unittest.TestCase):
         )
 
         mSynth = np.ones(mesh.nC)
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
 
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(simulation=simulation, data=dobs)
@@ -505,7 +504,7 @@ class DCProblemTestsN_storeJ_Robin(unittest.TestCase):
         )
 
         mSynth = np.ones(mesh.nC)
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
 
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(simulation=simulation, data=dobs)

--- a/tests/em/static/test_IP_2D_jvecjtvecadj.py
+++ b/tests/em/static/test_IP_2D_jvecjtvecadj.py
@@ -47,7 +47,7 @@ class IPProblemTestsCC(unittest.TestCase):
         )
 
         mSynth = np.ones(mesh.nC) * 0.1
-        dobs = problem.make_synthetic_data(mSynth, add_noise=True)
+        dobs = problem.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=problem)
         reg = regularization.WeightedLeastSquares(mesh)
@@ -127,7 +127,7 @@ class IPProblemTestsN(unittest.TestCase):
         )
 
         mSynth = np.ones(mesh.nC) * 0.1
-        dobs = problem.make_synthetic_data(mSynth, add_noise=True)
+        dobs = problem.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=problem)
         reg = regularization.WeightedLeastSquares(mesh)

--- a/tests/em/static/test_IP_jvecjtvecadj.py
+++ b/tests/em/static/test_IP_jvecjtvecadj.py
@@ -39,7 +39,7 @@ class IPProblemTestsCC(unittest.TestCase):
             mesh=mesh, survey=survey, sigma=sigma, etaMap=maps.IdentityMap(mesh)
         )
         mSynth = np.ones(mesh.nC) * 0.1
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=simulation)
         reg = regularization.WeightedLeastSquares(mesh)
@@ -112,7 +112,7 @@ class IPProblemTestsN(unittest.TestCase):
             mesh=mesh, survey=survey, sigma=sigma, etaMap=maps.IdentityMap(mesh)
         )
         mSynth = np.ones(mesh.nC) * 0.1
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=simulation)
         reg = regularization.WeightedLeastSquares(mesh)
@@ -188,7 +188,7 @@ class IPProblemTestsCC_storeJ(unittest.TestCase):
             storeJ=True,
         )
         mSynth = np.ones(mesh.nC) * 0.1
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=simulation)
         reg = regularization.WeightedLeastSquares(mesh)
@@ -271,7 +271,7 @@ class IPProblemTestsN_storeJ(unittest.TestCase):
             storeJ=True,
         )
         mSynth = np.ones(mesh.nC) * 0.1
-        dobs = simulation.make_synthetic_data(mSynth, add_noise=True)
+        dobs = simulation.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=simulation)
         reg = regularization.WeightedLeastSquares(mesh)

--- a/tests/em/static/test_SIP_2D_jvecjtvecadj.py
+++ b/tests/em/static/test_SIP_2D_jvecjtvecadj.py
@@ -66,7 +66,7 @@ class SIPProblemTestsCC(unittest.TestCase):
         )
         mSynth = np.r_[eta, 1.0 / tau]
         problem.model = mSynth
-        dobs = problem.make_synthetic_data(mSynth, add_noise=True)
+        dobs = problem.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=problem)
         reg = regularization.WeightedLeastSquares(mesh)
@@ -161,7 +161,7 @@ class SIPProblemTestsN(unittest.TestCase):
         )
         mSynth = np.r_[eta, 1.0 / tau]
         problem.model = mSynth
-        dobs = problem.make_synthetic_data(mSynth, add_noise=True)
+        dobs = problem.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=problem)
         reg = regularization.WeightedLeastSquares(mesh)
@@ -265,7 +265,7 @@ class SIPProblemTestsN_air(unittest.TestCase):
             survey=survey,
         )
         mSynth = np.r_[eta[~airind], 1.0 / tau[~airind], c[~airind]]
-        dobs = problem.make_synthetic_data(mSynth, add_noise=True)
+        dobs = problem.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=problem)
         reg_eta = regularization.WeightedLeastSquares(

--- a/tests/em/static/test_SIP_jvecjtvecadj.py
+++ b/tests/em/static/test_SIP_jvecjtvecadj.py
@@ -72,7 +72,7 @@ class SIPProblemTestsCC(unittest.TestCase):
         problem.solver = Solver
         mSynth = np.r_[eta, 1.0 / tau]
         problem.model = mSynth
-        dobs = problem.make_synthetic_data(mSynth, add_noise=True)
+        dobs = problem.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=problem)
         reg = regularization.WeightedLeastSquares(mesh)
@@ -172,7 +172,7 @@ class SIPProblemTestsN(unittest.TestCase):
         problem.solver = Solver
         mSynth = np.r_[eta, 1.0 / tau]
         print(survey.nD)
-        dobs = problem.make_synthetic_data(mSynth, add_noise=True)
+        dobs = problem.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         print(survey.nD)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=problem)
@@ -283,7 +283,7 @@ class SIPProblemTestsN_air(unittest.TestCase):
 
         problem.solver = Solver
         mSynth = np.r_[eta[~airind], 1.0 / tau[~airind], c[~airind]]
-        dobs = problem.make_synthetic_data(mSynth, add_noise=True)
+        dobs = problem.make_synthetic_data(mSynth, add_noise=True, random_seed=40)
         # Now set up the problem to do some minimization
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=problem)
         reg_eta = regularization.Sparse(mesh, mapping=wires.eta, active_cells=~airind)

--- a/tests/em/static/test_SPjvecjtvecadj.py
+++ b/tests/em/static/test_SPjvecjtvecadj.py
@@ -43,8 +43,8 @@ def test_forward():
         mesh=mesh, survey=dc_survey, sigma=conductivity
     )
 
-    dc_dpred = sim_dc.make_synthetic_data(None, add_noise=False)
-    sp_dpred = sim.make_synthetic_data(q, add_noise=False)
+    dc_dpred = sim_dc.make_synthetic_data(None, add_noise=False, random_seed=40)
+    sp_dpred = sim.make_synthetic_data(q, add_noise=False, random_seed=40)
 
     np.testing.assert_allclose(dc_dpred.dobs, sp_dpred.dobs)
 

--- a/tests/em/vrm/test_vrminv.py
+++ b/tests/em/vrm/test_vrminv.py
@@ -58,7 +58,7 @@ class VRM_inversion_tests(unittest.TestCase):
         Survey.t_active = np.zeros(Survey.nD, dtype=bool)
         Survey.set_active_interval(-1e6, 1e6)
         Problem = vrm.Simulation3DLinear(meshObj, survey=Survey, refinement_factor=2)
-        dobs = Problem.make_synthetic_data(mod)
+        dobs = Problem.make_synthetic_data(mod, random_seed=40)
         Survey.noise_floor = 1e-11
 
         dmis = data_misfit.L2DataMisfit(data=dobs, simulation=Problem)

--- a/tests/utils/test_mat_utils.py
+++ b/tests/utils/test_mat_utils.py
@@ -51,6 +51,7 @@ class TestEigenvalues(unittest.TestCase):
             relative_error=relative_error,
             noise_floor=noise_floor,
             add_noise=True,
+            random_seed=40,
         )
         dmis = data_misfit.L2DataMisfit(simulation=sim, data=data_obj)
         self.dmis = dmis


### PR DESCRIPTION
#### Summary

Pass a `random_seed` when calling `make_synthetic_data` method of simulations in tests so we ensure that they are always run with the same synthetic data. Remove unused calls to `np.random.seed`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
