### PR TITLE
Implement magnetic eq sources with Choclo

### DIFF
--- a/simpeg/potential_fields/_numba_utils.py
+++ b/simpeg/potential_fields/_numba_utils.py
@@ -5,6 +5,8 @@ These functions are meant to be used both in the Numba-based gravity and
 magnetic simulations.
 """
 
+import numpy as np
+
 try:
     from numba import jit
 except ImportError:
@@ -41,3 +43,109 @@ def kernels_in_nodes_to_cell(kernels, nodes_indices):
         + kernels[nodes_indices[7]]
     )
     return result
+
+
+@jit(nopython=True)
+def evaluate_kernels_on_cell(
+    easting,
+    northing,
+    upward,
+    prism_west,
+    prism_east,
+    prism_south,
+    prism_north,
+    prism_bottom,
+    prism_top,
+    kernel_x,
+    kernel_y,
+    kernel_z,
+):
+    r"""
+    Evaluate three kernel functions on every shifted vertex of a prism.
+
+    .. note::
+
+        This function was inspired in the ``_evaluate_kernel`` function in
+        Choclo (released under BSD 3-clause Licence):
+        https://www.fatiando.org/choclo
+
+    Parameters
+    ----------
+    easting, northing, upward : float
+        Easting, northing and upward coordinates of the observation point. Must
+        be in meters.
+    prism_west, prism_east : floats
+        The West and East boundaries of the prism. Must be in meters.
+    prism_south, prism_north : floats
+        The South and North boundaries of the prism. Must be in meters.
+    prism_bottom, prism_top : floats
+        The bottom and top boundaries of the prism. Must be in meters.
+    kernel_x, kernel_y, kernel_z : callable
+        Kernel functions that will be evaluated on each one of the shifted
+        vertices of the prism.
+
+    Returns
+    -------
+    result_x, result_y, result_z : floats
+        Evaluation of the kernel functions on each one of the vertices of the
+        prism.
+
+    Notes
+    -----
+    This function evaluates each numerical kernel :math:`k(x, y, z)` on each one
+    of the vertices of the prism:
+
+    .. math::
+
+        v(\mathbf{p}) =
+            \Bigg\lvert \Bigg\lvert \Bigg\lvert
+            k(x, y, z)
+            \Bigg\rvert_{X_1}^{X_2}
+            \Bigg\rvert_{Y_1}^{Y_2}
+            \Bigg\rvert_{Z_1}^{Z_2}
+
+    where :math:`X_1`, :math:`X_2`, :math:`Y_1`, :math:`Y_2`, :math:`Z_1` and
+    :math:`Z_2` are boundaries of the rectangular prism in the *shifted
+    coordinates* defined by the Cartesian coordinate system with its origin
+    located on the observation point :math:`\mathbf{p}`.
+    """
+    # Initialize result floats to zero
+    result_x, result_y, result_z = 0, 0, 0
+    # Iterate over the vertices of the prism
+    for i in range(2):
+        # Compute shifted easting coordinate
+        if i == 0:
+            shift_east = prism_east - easting
+        else:
+            shift_east = prism_west - easting
+        shift_east_sq = shift_east**2
+        for j in range(2):
+            # Compute shifted northing coordinate
+            if j == 0:
+                shift_north = prism_north - northing
+            else:
+                shift_north = prism_south - northing
+            shift_north_sq = shift_north**2
+            for k in range(2):
+                # Compute shifted upward coordinate
+                if k == 0:
+                    shift_upward = prism_top - upward
+                else:
+                    shift_upward = prism_bottom - upward
+                shift_upward_sq = shift_upward**2
+                # Compute the radius
+                radius = np.sqrt(shift_east_sq + shift_north_sq + shift_upward_sq)
+                # If i, j or k is 1, the corresponding shifted
+                # coordinate will refer to the lower boundary,
+                # meaning the corresponding term should have a minus
+                # sign.
+                result_x += (-1) ** (i + j + k) * kernel_x(
+                    shift_east, shift_north, shift_upward, radius
+                )
+                result_y += (-1) ** (i + j + k) * kernel_y(
+                    shift_east, shift_north, shift_upward, radius
+                )
+                result_z += (-1) ** (i + j + k) * kernel_z(
+                    shift_east, shift_north, shift_upward, radius
+                )
+    return result_x, result_y, result_z

--- a/simpeg/potential_fields/magnetics/_numba_functions.py
+++ b/simpeg/potential_fields/magnetics/_numba_functions.py
@@ -1248,6 +1248,182 @@ def _forward_tmi_2d_mesh(
             )
 
 
+def _forward_tmi_derivative_2d_mesh(
+    receivers,
+    cells_bounds,
+    top,
+    bottom,
+    model,
+    fields,
+    regional_field,
+    kernel_xx,
+    kernel_yy,
+    kernel_zz,
+    kernel_xy,
+    kernel_xz,
+    kernel_yz,
+    scalar_model,
+):
+    r"""
+    Forward model a TMI derivative for 2D meshes.
+
+    This function is designed to be used with equivalent sources, where the
+    mesh is a 2D mesh (prism layer). The top and bottom boundaries of each cell
+    are passed through the ``top`` and ``bottom`` arrays.
+
+    This function should be used with a `numba.jit` decorator, for example:
+
+    .. code::
+
+        from numba import jit
+
+        jit_forward = jit(nopython=True, parallel=True)(_forward_tmi_2d_mesh)
+
+    Parameters
+    ----------
+    receivers : (n_receivers, 3) numpy.ndarray
+        Array with the locations of the receivers
+    cells_bounds : (n_active_cells, 4) numpy.ndarray
+        Array with the bounds of each active cell in the 2D mesh. For each row, the
+        bounds should be passed in the following order: ``x_min``, ``x_max``,
+        ``y_min``, ``y_max``.
+    top : (n_active_cells) np.ndarray
+        Array with the top boundaries of each active cell in the 2D mesh.
+    bottom : (n_active_cells) np.ndarray
+        Array with the bottom boundaries of each active cell in the 2D mesh.
+    model : (n_active_cells) or (3 * n_active_cells)
+        Array with the susceptibility (scalar model) or the effective
+        susceptibility (vector model) of each active cell in the mesh.
+        If the model is scalar, the ``model`` array should have
+        ``n_active_cells`` elements and ``scalar_model`` should be True.
+        If the model is vector, the ``model`` array should have
+        ``3 * n_active_cells`` elements and ``scalar_model`` should be False.
+    fields : (n_receivers) array
+        Array full of zeros where the TMI on each receiver will be stored. This
+        could be a preallocated array or a slice of it.
+    regional_field : (3,) array
+        Array containing the x, y and z components of the regional magnetic
+        field (uniform background field).
+    kernel_xx, kernel_yy, kernel_zz, kernel_xy, kernel_xz, kernel_yz : callables
+        Kernel functions used for computing the desired TMI derivative.
+    scalar_model : bool
+        If True, the sensitivity matrix is build to work with scalar models
+        (susceptibilities).
+        If False, the sensitivity matrix is build to work with vector models
+        (effective susceptibilities).
+
+    Notes
+    -----
+
+    About the kernel functions
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    To compute the :math:`\alpha` derivative of the TMI :math:`\Delta T` (with
+    :math:`\alpha \in \{x, y, z\}` we need to evaluate third order kernels
+    functions for the prism. The kernels we need to evaluate can be obtained by
+    fixing one of the subindices to the direction of the derivative
+    (:math:`\alpha`) and cycle through combinations of the other two.
+
+    For ``tmi_x`` we need to pass:
+
+    .. code::
+
+        kernel_xx=kernel_eee, kernel_yy=kernel_enn, kernel_zz=kernel_euu,
+        kernel_xy=kernel_een, kernel_xz=kernel_eeu, kernel_yz=kernel_enu
+
+    For ``tmi_y`` we need to pass:
+
+    .. code::
+
+        kernel_xx=kernel_een, kernel_yy=kernel_nnn, kernel_zz=kernel_nuu,
+        kernel_xy=kernel_enn, kernel_xz=kernel_enu, kernel_yz=kernel_nnu
+
+    For ``tmi_z`` we need to pass:
+
+    .. code::
+
+        kernel_xx=kernel_eeu, kernel_yy=kernel_nnu, kernel_zz=kernel_uuu,
+        kernel_xy=kernel_enu, kernel_xz=kernel_euu, kernel_yz=kernel_nuu
+
+
+    About the model array
+    ^^^^^^^^^^^^^^^^^^^^^
+
+    The ``model`` must always be a 1d array:
+
+    * If ``scalar_model`` is ``True``, then ``model`` should be a 1d array with
+      the same number of elements as active cells in the mesh. It should store
+      the magnetic susceptibilities of each active cell in SI units.
+    * If ``scalar_model`` is ``False``, then ``model`` should be a 1d array
+      with a number of elements equal to three times the active cells in the
+      mesh. It should store the components of the magnetization vector of each
+      active cell in :math:`Am^{-1}`. The order in which the components should
+      be passed are:
+          * every _easting_ component of each active cell,
+          * then every _northing_ component of each active cell,
+          * and finally every _upward_ component of each active cell.
+
+    """
+    n_receivers = receivers.shape[0]
+    n_cells = cells_bounds.shape[0]
+    fx, fy, fz = regional_field
+    regional_field_amplitude = np.sqrt(fx**2 + fy**2 + fz**2)
+    fx /= regional_field_amplitude
+    fy /= regional_field_amplitude
+    fz /= regional_field_amplitude
+    # Forward model the magnetic component of each cell on each receiver location
+    for i in prange(n_receivers):
+        for j in range(n_cells):
+            uxx, uyy, uzz = evaluate_kernels_on_cell(
+                receivers[i, 0],
+                receivers[i, 1],
+                receivers[i, 2],
+                cells_bounds[j, 0],
+                cells_bounds[j, 1],
+                cells_bounds[j, 2],
+                cells_bounds[j, 3],
+                bottom[j],
+                top[j],
+                kernel_xx,
+                kernel_yy,
+                kernel_zz,
+            )
+            uxy, uxz, uyz = evaluate_kernels_on_cell(
+                receivers[i, 0],
+                receivers[i, 1],
+                receivers[i, 2],
+                cells_bounds[j, 0],
+                cells_bounds[j, 1],
+                cells_bounds[j, 2],
+                cells_bounds[j, 3],
+                bottom[j],
+                top[j],
+                kernel_xy,
+                kernel_xz,
+                kernel_yz,
+            )
+            if scalar_model:
+                bx = uxx * fx + uxy * fy + uxz * fz
+                by = uxy * fx + uyy * fy + uyz * fz
+                bz = uxz * fx + uyz * fy + uzz * fz
+                fields[i] += (
+                    model[j]
+                    * regional_field_amplitude
+                    * (fx * bx + fy * by + fz * bz)
+                    / (4 * np.pi)
+                )
+            else:
+                model_x = model[j]
+                model_y = model[j + n_cells]
+                model_z = model[j + 2 * n_cells]
+                bx = uxx * model_x + uxy * model_y + uxz * model_z
+                by = uxy * model_x + uyy * model_y + uyz * model_z
+                bz = uxz * model_x + uyz * model_y + uzz * model_z
+                fields[i] += (
+                    regional_field_amplitude * (bx * fx + by * fy + bz * fz) / 4 / np.pi
+                )
+
+
 def _sensitivity_mag_2d_mesh(
     receivers,
     cells_bounds,
@@ -1636,6 +1812,12 @@ _forward_tmi_2d_mesh_serial = jit(nopython=True, parallel=False)(_forward_tmi_2d
 _forward_tmi_2d_mesh_parallel = jit(nopython=True, parallel=True)(_forward_tmi_2d_mesh)
 _forward_mag_2d_mesh_serial = jit(nopython=True, parallel=False)(_forward_mag_2d_mesh)
 _forward_mag_2d_mesh_parallel = jit(nopython=True, parallel=True)(_forward_mag_2d_mesh)
+_forward_tmi_derivative_2d_mesh_serial = jit(nopython=True, parallel=False)(
+    _forward_tmi_derivative_2d_mesh
+)
+_forward_tmi_derivative_2d_mesh_parallel = jit(nopython=True, parallel=True)(
+    _forward_tmi_derivative_2d_mesh
+)
 _sensitivity_mag_2d_mesh_serial = jit(nopython=True, parallel=False)(
     _sensitivity_mag_2d_mesh
 )

--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -46,6 +46,8 @@ from ._numba_functions import (
     _forward_tmi_derivative_serial,
     _sensitivity_tmi_derivative_parallel,
     _sensitivity_tmi_derivative_serial,
+    _sensitivity_tmi_derivative_2d_mesh_serial,
+    _sensitivity_tmi_derivative_2d_mesh_parallel,
 )
 
 if choclo is not None:
@@ -921,12 +923,18 @@ class SimulationEquivalentSourceLayer(
                 self._forward_tmi = _forward_tmi_2d_mesh_parallel
                 self._forward_mag = _forward_mag_2d_mesh_parallel
                 self._forward_tmi_derivative = _forward_tmi_derivative_2d_mesh_parallel
+                self._sensitivity_tmi_derivative = (
+                    _sensitivity_tmi_derivative_2d_mesh_parallel
+                )
             else:
                 self._sensitivity_tmi = _sensitivity_tmi_2d_mesh_serial
                 self._sensitivity_mag = _sensitivity_mag_2d_mesh_serial
                 self._forward_tmi = _forward_tmi_2d_mesh_serial
                 self._forward_mag = _forward_mag_2d_mesh_serial
                 self._forward_tmi_derivative = _forward_tmi_derivative_2d_mesh_serial
+                self._sensitivity_tmi_derivative = (
+                    _sensitivity_tmi_derivative_2d_mesh_serial
+                )
 
     def _forward(self, model):
         """
@@ -1072,6 +1080,25 @@ class SimulationEquivalentSourceLayer(
                         self.cell_z_bottom,
                         sensitivity_matrix[matrix_slice, :],
                         regional_field,
+                        scalar_model,
+                    )
+                elif component in ("tmi_x", "tmi_y", "tmi_z"):
+                    kernel_xx, kernel_yy, kernel_zz, kernel_xy, kernel_xz, kernel_yz = (
+                        CHOCLO_KERNELS[component]
+                    )
+                    self._sensitivity_tmi_derivative(
+                        receivers,
+                        cells_bounds_active,
+                        self.cell_z_top,
+                        self.cell_z_bottom,
+                        sensitivity_matrix[matrix_slice, :],
+                        regional_field,
+                        kernel_xx,
+                        kernel_yy,
+                        kernel_zz,
+                        kernel_xy,
+                        kernel_xz,
+                        kernel_yz,
                         scalar_model,
                     )
                 else:

--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -36,6 +36,8 @@ from ._numba_functions import (
     _forward_tmi_2d_mesh_parallel,
     _forward_mag_2d_mesh_serial,
     _forward_mag_2d_mesh_parallel,
+    _forward_tmi_derivative_2d_mesh_serial,
+    _forward_tmi_derivative_2d_mesh_parallel,
     _sensitivity_mag_2d_mesh_serial,
     _sensitivity_mag_2d_mesh_parallel,
     _sensitivity_tmi_2d_mesh_serial,
@@ -918,11 +920,13 @@ class SimulationEquivalentSourceLayer(
                 self._sensitivity_mag = _sensitivity_mag_2d_mesh_parallel
                 self._forward_tmi = _forward_tmi_2d_mesh_parallel
                 self._forward_mag = _forward_mag_2d_mesh_parallel
+                self._forward_tmi_derivative = _forward_tmi_derivative_2d_mesh_parallel
             else:
                 self._sensitivity_tmi = _sensitivity_tmi_2d_mesh_serial
                 self._sensitivity_mag = _sensitivity_mag_2d_mesh_serial
                 self._forward_tmi = _forward_tmi_2d_mesh_serial
                 self._forward_mag = _forward_mag_2d_mesh_serial
+                self._forward_tmi_derivative = _forward_tmi_derivative_2d_mesh_serial
 
     def _forward(self, model):
         """
@@ -977,6 +981,26 @@ class SimulationEquivalentSourceLayer(
                         model,
                         fields[vector_slice],
                         regional_field,
+                        scalar_model,
+                    )
+                elif component in ("tmi_x", "tmi_y", "tmi_z"):
+                    kernel_xx, kernel_yy, kernel_zz, kernel_xy, kernel_xz, kernel_yz = (
+                        CHOCLO_KERNELS[component]
+                    )
+                    self._forward_tmi_derivative(
+                        receivers,
+                        cells_bounds_active,
+                        self.cell_z_top,
+                        self.cell_z_bottom,
+                        model,
+                        fields[vector_slice],
+                        regional_field,
+                        kernel_xx,
+                        kernel_yy,
+                        kernel_zz,
+                        kernel_xy,
+                        kernel_xz,
+                        kernel_yz,
                         scalar_model,
                     )
                 else:

--- a/tests/pf/test_equivalent_sources.py
+++ b/tests/pf/test_equivalent_sources.py
@@ -20,6 +20,9 @@ MAGNETIC_COMPONENTS = [
     "bxy",
     "bxz",
     "byz",
+    "tmi_x",
+    "tmi_y",
+    "tmi_z",
 ]
 
 


### PR DESCRIPTION
#### Summary

Implement magnetic equivalent sources using Choclo as the engine. Allow magnetic equivalent sources to take ``engine="choclo"``. Implement new Numba-based forward and sensitivity matrix functions that use Choclo's forward modelling functions for a prism. These new functions can take a 2D mesh and the arrays for the top and bottom boundaries for each cell and compute the forward or build the sensitivity matrix by iterating over each prism in the layer. Add extended tests for the new implementation that also extend the tests for the geoana-based implementation.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/content/getting_started/practices.html#testing) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/content/getting_started/practices.html#documentation).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Closes #1373

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->

TODO:
- [x] Include tests that fit the sources with synthetic data and check if we recover the original data
- [x] Add tests to the forward functionalities of the new class but with vector models.
- [x] Add support for tmi derivatives after #1553 is merged