### PR TITLE
Fixes for most recent geoana 0.7

### DIFF
--- a/.ci/environment_test.yml
+++ b/.ci/environment_test.yml
@@ -7,7 +7,7 @@ dependencies:
   - pymatsolver>=0.3
   - matplotlib-base
   - discretize>=0.10
-  - geoana>=0.5.0
+  - geoana>=0.7
   - empymod>=2.0.0
 
 # optional dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - pymatsolver>=0.3
   - matplotlib-base
   - discretize>=0.10
-  - geoana>=0.5.0
+  - geoana>=0.7
   - empymod>=2.0.0
 
 # solver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "pymatsolver>=0.3",
     "matplotlib",
     "discretize>=0.10",
-    "geoana>=0.5.0",
+    "geoana>=0.7",
     "empymod>=2.0.0",
 ]
 classifiers = [

--- a/simpeg/electromagnetics/frequency_domain/sources.py
+++ b/simpeg/electromagnetics/frequency_domain/sources.py
@@ -473,7 +473,9 @@ class MagDipole(BaseFDEMSrc):
         return self.__dipole
 
     def _srcFct(self, obsLoc, coordinates="cartesian"):
-        return self._dipole.vector_potential(obsLoc, coordinates=coordinates)
+        out = self._dipole.vector_potential(obsLoc, coordinates=coordinates)
+        out[np.isnan(out)] = 0
+        return out
 
     def bPrimary(self, simulation):
         """Compute primary magnetic flux density.
@@ -683,7 +685,9 @@ class MagDipole_Bfield(MagDipole):
                 location=self.location,
                 moment=self.moment,
             )
-        return self._dipole.magnetic_flux_density(obsLoc, coordinates=coordinates)
+        out = self._dipole.magnetic_flux_density(obsLoc, coordinates=coordinates)
+        out[np.isnan(out)] = 0
+        return out
 
     def bPrimary(self, simulation):
         """
@@ -869,7 +873,9 @@ class CircularLoop(MagDipole):
                 radius=self.radius,
                 current=self.current,
             )
-        return self.n_turns * self._loop.vector_potential(obsLoc, coordinates)
+        out = self._loop.vector_potential(obsLoc, coordinates)
+        out[np.isnan(out)] = 0
+        return self.n_turns * out
 
     N = deprecate_property(
         n_turns, "N", "n_turns", removal_version="0.19.0", error=True

--- a/simpeg/electromagnetics/time_domain/sources.py
+++ b/simpeg/electromagnetics/time_domain/sources.py
@@ -1239,7 +1239,9 @@ class MagDipole(BaseTDEMSrc):
                 location=self.location,
                 moment=self.moment,
             )
-        return self._dipole.vector_potential(obsLoc, coordinates=coordinates)
+        out = self._dipole.vector_potential(obsLoc, coordinates=coordinates)
+        out[np.isnan(out)] = 0
+        return out
 
     def _aSrc(self, simulation):
         coordinates = "cartesian"

--- a/simpeg/electromagnetics/time_domain/sources.py
+++ b/simpeg/electromagnetics/time_domain/sources.py
@@ -1597,7 +1597,9 @@ class CircularLoop(MagDipole):
                 radius=self.radius,
                 current=self.current,
             )
-        return self.n_turns * self._loop.vector_potential(obsLoc, coordinates)
+        out = self._loop.vector_potential(obsLoc, coordinates)
+        out[np.isnan(out)] = 0
+        return self.n_turns * out
 
     N = deprecate_property(
         n_turns, "N", "n_turns", removal_version="0.19.0", error=True


### PR DESCRIPTION
#### Summary
Updates for geoana 0.7.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.
>

#### What does this implement/fix?
0.7 geoana will no assume zero at singularities, instead filling with `np.nan`. Now we must explicitly remove any potential singular points after evaluations.

#### Additional information
As of right now these look to be the only failure points due to the most recent `geoana`.
