### PR TITLE
Numpy2.0 and discretize 0.11.0 updates

### DIFF
--- a/.ci/environment_test.yml
+++ b/.ci/environment_test.yml
@@ -2,11 +2,11 @@ name: simpeg-test
 channels:
   - conda-forge
 dependencies:
-  - numpy>=1.21
+  - numpy>=1.22
   - scipy>=1.8
   - pymatsolver>=0.3
   - matplotlib-base
-  - discretize>=0.10
+  - discretize>=0.11
   - geoana>=0.7
   - empymod>=2.0.0
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,11 +4,11 @@ channels:
 dependencies:
 # dependencies
   - python=3.11
-  - numpy>=1.21
+  - numpy>=1.22
   - scipy>=1.8
   - pymatsolver>=0.3
   - matplotlib-base
-  - discretize>=0.10
+  - discretize>=0.11
   - geoana>=0.7
   - empymod>=2.0.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,11 @@ keywords = [
     'geophysics', 'inverse problem'
 ]
 dependencies = [
-    "numpy>=1.21",
+    "numpy>=1.22",
     "scipy>=1.8",
     "pymatsolver>=0.3",
     "matplotlib",
-    "discretize>=0.10",
+    "discretize>=0.11",
     "geoana>=0.7",
     "empymod>=2.0.0",
 ]

--- a/simpeg/maps/_base.py
+++ b/simpeg/maps/_base.py
@@ -1294,7 +1294,7 @@ class TileMap(IdentityMap):
         Set the projection matrix with partial volumes
         """
         if getattr(self, "_P", None) is None:
-            in_local = self.local_mesh._get_containing_cell_indexes(
+            in_local = self.local_mesh.get_containing_cells(
                 self.global_mesh.cell_centers
             )
 

--- a/simpeg/utils/mat_utils.py
+++ b/simpeg/utils/mat_utils.py
@@ -123,11 +123,7 @@ def unique_rows(M):
         Indices to project from output array to input array
 
     """
-    b = np.ascontiguousarray(M).view(np.dtype((np.void, M.dtype.itemsize * M.shape[1])))
-    _, unqInd = np.unique(b, return_index=True)
-    _, invInd = np.unique(b, return_inverse=True)
-    unqM = M[unqInd]
-    return unqM, unqInd, invInd
+    return np.unique(M, return_index=True, return_inverse=True, axis=0)
 
 
 def eigenvalue_by_power_iteration(


### PR DESCRIPTION
#### Summary
Necessary updates for `numpy2.0` and `discretize` 0.11.0

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### What does this implement/fix?
Related to Numpy 2.0:
* Simplifies `unique_rows` function to more directly use numpy's `unique` function.
Related to discretize 0.11:
* Uses public `get_containing_cells` function of `TreeMesh` instead of private method.
* {WIP} Adds random seeds to `check_derivative` functions now that it is supported.

#### Additional information
We were generally in a good position for numpy 2.0! The only breaking point from discretize 0.11 was due to using a private method of a TreeMesh, which is again a pretty good place to be. The `check_derivative` tests are expected to be needed to updated.