### PR TITLE
Fix math in docstring of eigenvalue_by_power_iteration

### DIFF
--- a/simpeg/utils/mat_utils.py
+++ b/simpeg/utils/mat_utils.py
@@ -175,12 +175,14 @@ def eigenvalue_by_power_iteration(
     approximated by the Rayleigh quotient:
 
     .. math::
+
         \lambda_k = \frac{\mathbf{x_k^T A x_k}}{\mathbf{x_k^T x_k}}
 
-    where :math:`\mathfb{A}` is our matrix and :math:`\mathfb{x_k}` is computed
+    where :math:`\mathbf{A}` is our matrix and :math:`\mathbf{x_k}` is computed
     recursively according to:
 
     .. math::
+
         \mathbf{x_{k+1}} = \frac{\mathbf{A x_k}}{\| \mathbf{Ax_k} \|}
 
     The elements of the initial vector :math:`\mathbf{x_0}` are randomly


### PR DESCRIPTION
#### Summary

Fix RST syntax to show math in the `eigenvalue_by_power_iteration` function.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
