### PR TITLE
Only warn about default solver when set in simulations

### DIFF
--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -1612,7 +1612,7 @@ def MagneticsDiffSecondaryInv(mesh, model, data, **kwargs):
 
     # Create an optimization program
     opt = optimization.InexactGaussNewton(maxIter=miter)
-    opt.bfgsH0 = get_default_solver()(sp.identity(model.nP), flag="D")
+    opt.bfgsH0 = get_default_solver(warn=True)(sp.identity(model.nP), flag="D")
     # Create a regularization program
     reg = regularization.WeightedLeastSquares(model)
     # Create an objective function

--- a/simpeg/simulation.py
+++ b/simpeg/simulation.py
@@ -194,7 +194,7 @@ class BaseSimulation(props.HasModel):
         if self._solver is None:
             # do not cache this, in case the user wants to
             # change it after the first time it is requested.
-            return get_default_solver()
+            return get_default_solver(warn=True)
         return self._solver
 
     @solver.setter

--- a/simpeg/utils/solver_utils.py
+++ b/simpeg/utils/solver_utils.py
@@ -49,22 +49,30 @@ class DefaultSolverWarning(UserWarning):
     pass
 
 
-def get_default_solver() -> Type[Base]:
+def get_default_solver(warn=False) -> Type[Base]:
     """Return the default solver used by simpeg.
+
+    Parameters
+    ----------
+    warn : bool, optional
+        If True, a warning will be raised to let users know that the default
+        solver is being chosen depending on their system.
 
     Returns
     -------
     solver
         The default solver class used by simpeg's simulations.
     """
-    warnings.warn(
-        f"Using the default solver: {_DEFAULT_SOLVER.__name__}. \n\n"
-        f"If you would like to suppress this notification, add \n"
-        f"warnings.filterwarnings('ignore', simpeg.utils.solver_utils.DefaultSolverWarning)\n"
-        f" to your script.",
-        DefaultSolverWarning,
-        stacklevel=2,
-    )
+    if warn:
+        warnings.warn(
+            f"Using the default solver: {_DEFAULT_SOLVER.__name__}. \n\n"
+            f"If you would like to suppress this notification, add \n"
+            f"warnings.filterwarnings("
+            "'ignore', simpeg.utils.solver_utils.DefaultSolverWarning)\n"
+            f" to your script.",
+            DefaultSolverWarning,
+            stacklevel=2,
+        )
     return _DEFAULT_SOLVER
 
 

--- a/tests/utils/test_default_solver.py
+++ b/tests/utils/test_default_solver.py
@@ -1,3 +1,4 @@
+import warnings
 import pytest
 from pymatsolver import SolverCG
 
@@ -11,18 +12,14 @@ from simpeg.utils.solver_utils import (
 @pytest.fixture(autouse=True)
 def reset_default_solver():
     # This should get automatically used
-    with pytest.warns(DefaultSolverWarning):
-        initial_default = get_default_solver()
+    initial_default = get_default_solver()
     yield
     set_default_solver(initial_default)
 
 
 def test_default_setting():
     set_default_solver(SolverCG)
-
-    with pytest.warns(DefaultSolverWarning, match="Using the default solver: SolverCG"):
-        new_default = get_default_solver()
-
+    new_default = get_default_solver()
     assert new_default == SolverCG
 
 
@@ -31,7 +28,7 @@ def test_default_error():
         pass
 
     with pytest.warns(DefaultSolverWarning):
-        initial_default = get_default_solver()
+        initial_default = get_default_solver(warn=True)
 
     with pytest.raises(
         TypeError,
@@ -40,7 +37,20 @@ def test_default_error():
         set_default_solver(Temp)
 
     with pytest.warns(DefaultSolverWarning):
-        after_default = get_default_solver()
+        after_default = get_default_solver(warn=True)
 
     # make sure we didn't accidentally set the default.
     assert initial_default == after_default
+
+
+def test_warning():
+    """Test if warning is raised when warn=True."""
+    with pytest.warns(DefaultSolverWarning, match="Using the default solver"):
+        get_default_solver(warn=True)
+
+
+def test_no_warning():
+    """Test if no warning is issued with default parameters."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # raise error if warning was raised
+        get_default_solver()


### PR DESCRIPTION
#### Summary

Add a `warn=False` argument to the `get_default_solver()` function. Only when `warn=True`, the warning about the setting of the default solver is raised. This makes the function not to raise a warning when called with the default arguments. When default solvers are being used within simulations, call the function with `warn=True` to let users know about the solver being automatically selected. Update tests accordingly.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue

Fix #1563

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
