### PR TITLE
Remove empymod dependency

### DIFF
--- a/.ci/environment_test.yml
+++ b/.ci/environment_test.yml
@@ -8,7 +8,7 @@ dependencies:
   - matplotlib-base
   - discretize>=0.11
   - geoana>=0.7
-  - empymod>=2.0.0
+  - libdlf
 
 # optional dependencies
   - dask

--- a/.ci/environment_test.yml
+++ b/.ci/environment_test.yml
@@ -28,13 +28,13 @@ dependencies:
   - nbsphinx
   - numpydoc
   - pillow
+  - empymod>=2.0.0
   - sympy
   - memory_profiler
   - python-kaleido
   - h5py
 
 # testing
-  - empymod>=2.0.0
   - pytest
   - pytest-cov
 

--- a/.ci/environment_test.yml
+++ b/.ci/environment_test.yml
@@ -34,6 +34,7 @@ dependencies:
   - h5py
 
 # testing
+  - empymod>=2.0.0
   - pytest
   - pytest-cov
 

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - matplotlib-base
   - discretize>=0.11
   - geoana>=0.7
-  - empymod>=2.0.0
+  - libdlf
 
 # solver
 # uncomment the next line if you are on an intel platform

--- a/environment.yml
+++ b/environment.yml
@@ -44,6 +44,7 @@ dependencies:
 # testing
   - pytest
   - pytest-cov
+  - empymod>=2.0.0
 
 # style checking
   - pre-commit

--- a/environment.yml
+++ b/environment.yml
@@ -33,6 +33,7 @@ dependencies:
   - sphinx-gallery>=0.1.13
   - sphinxcontrib-apidoc
   - pydata-sphinx-theme
+  - empymod>=2.0.0
   - nbsphinx
   - numpydoc
   - pillow
@@ -44,7 +45,6 @@ dependencies:
 # testing
   - pytest
   - pytest-cov
-  - empymod>=2.0.0
 
 # style checking
   - pre-commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ docs = [
 ]
 tests = [
     "simpeg[all,docs]",
+    "empymod>=2.0.0",
     "pytest",
     "pytest-cov",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ docs = [
     "sphinxcontrib-apidoc",
     "pydata-sphinx-theme",
     "nbsphinx",
+    "empymod>=2.0.0",
     "numpydoc",
     "pillow",
     "sympy",
@@ -82,7 +83,6 @@ docs = [
 ]
 tests = [
     "simpeg[all,docs]",
-    "empymod>=2.0.0",
     "pytest",
     "pytest-cov",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "matplotlib",
     "discretize>=0.11",
     "geoana>=0.7",
-    "empymod>=2.0.0",
+    "libdlf",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/simpeg/electromagnetics/base_1d.py
+++ b/simpeg/electromagnetics/base_1d.py
@@ -22,6 +22,12 @@ import libdlf
 
 __all__ = ["BaseEM1DSimulation"]
 
+HANKEL_FILTERS = {}
+for filter_name in libdlf.hankel.__all__:
+    hankel_filter = getattr(libdlf.hankel, filter_name)
+    if "j0" in hankel_filter.values and "j1" in hankel_filter.values:
+        HANKEL_FILTERS[filter_name] = hankel_filter
+
 ###############################################################################
 #                                                                             #
 #                             Base EM1D Simulation                            #
@@ -159,9 +165,9 @@ class BaseEM1DSimulation(BaseSimulation):
     @hankel_filter.setter
     def hankel_filter(self, value):
         self._hankel_filter = validate_string(
-            "hankel_filter", value, libdlf.hankel.__all__
+            "hankel_filter", value, list(HANKEL_FILTERS.keys())
         )
-        base, j0, j1 = getattr(libdlf.hankel, value)()
+        base, j0, j1 = HANKEL_FILTERS[self._hankel_filter]()
         hank = namedtuple("HankelFilter", "base j0 j1")
         self._fhtfilt = hank(base, j0, j1)
         self._coefficients_set = False

--- a/simpeg/electromagnetics/base_1d.py
+++ b/simpeg/electromagnetics/base_1d.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 from scipy.constants import mu_0
 import numpy as np
 from scipy import sparse as sp
@@ -159,7 +161,9 @@ class BaseEM1DSimulation(BaseSimulation):
         self._hankel_filter = validate_string(
             "hankel_filter", value, libdlf.hankel.__all__
         )
-        self._fhtfilt = getattr(libdlf.hankel, value)()
+        base, j0, j1 = getattr(libdlf.hankel, value)()
+        hank = namedtuple("HankelFilter", "base j0 j1")
+        self._fhtfilt = hank(base, j0, j1)
         self._coefficients_set = False
 
     _hankel_pts_per_dec = 0  # Default: Standard DLF

--- a/simpeg/electromagnetics/static/resistivity/simulation_1d.py
+++ b/simpeg/electromagnetics/static/resistivity/simulation_1d.py
@@ -12,6 +12,12 @@ from .survey import Survey
 from ....utils import validate_type, validate_string
 from scipy.interpolate import InterpolatedUnivariateSpline as iuSpline
 
+HANKEL_FILTERS = {}
+for filter_name in libdlf.hankel.__all__:
+    hankel_filter = getattr(libdlf.hankel, filter_name)
+    if "j0" in hankel_filter.values:
+        HANKEL_FILTERS[filter_name] = hankel_filter
+
 
 def _phi_tilde(rho, thicknesses, lambdas):
     """Calculate potential in the hankel domain.
@@ -188,11 +194,11 @@ class Simulation1DLayers(BaseSimulation):
     @hankel_filter.setter
     def hankel_filter(self, value):
         self._hankel_filter = validate_string(
-            "hankel_filter", value, libdlf.hankel.__all__
+            "hankel_filter", value, list(HANKEL_FILTERS.keys())
         )
-        base, j0, j1 = getattr(libdlf.hankel, value)()
-        hank = namedtuple("HankelFilter", "base j0 j1")
-        self._fhtfilt = hank(base, j0, j1)
+        filt = HANKEL_FILTERS[self._hankel_filter]()
+        hank = namedtuple("HankelFilter", "base j0")
+        self._fhtfilt = hank(filt[0], filt[1])
         self._coefficients_set = False
 
     @property

--- a/simpeg/electromagnetics/static/resistivity/simulation_1d.py
+++ b/simpeg/electromagnetics/static/resistivity/simulation_1d.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 import libdlf
 import numpy as np
 
@@ -188,7 +190,9 @@ class Simulation1DLayers(BaseSimulation):
         self._hankel_filter = validate_string(
             "hankel_filter", value, libdlf.hankel.__all__
         )
-        self._fhtfilt = getattr(libdlf.hankel, value)()
+        base, j0, j1 = getattr(libdlf.hankel, value)()
+        hank = namedtuple("HankelFilter", "base j0 j1")
+        self._fhtfilt = hank(base, j0, j1)
         self._coefficients_set = False
 
     @property

--- a/simpeg/electromagnetics/static/resistivity/simulation_1d.py
+++ b/simpeg/electromagnetics/static/resistivity/simulation_1d.py
@@ -1,28 +1,14 @@
+import libdlf
 import numpy as np
 
+from ...utils.em1d_utils import get_splined_dlf_points
 from ....simulation import BaseSimulation
 from .... import props
 
 from .survey import Survey
 
-from empymod.transform import get_dlf_points
-from empymod import filters
 from ....utils import validate_type, validate_string
 from scipy.interpolate import InterpolatedUnivariateSpline as iuSpline
-
-
-HANKEL_FILTERS = [
-    "kong_61_2007",
-    "kong_241_2007",
-    "key_101_2009",
-    "key_201_2009",
-    "key_401_2009",
-    "anderson_801_1982",
-    "key_51_2012",
-    "key_101_2012",
-    "key_201_2012",
-    "wer_201_2018",
-]
 
 
 def _phi_tilde(rho, thicknesses, lambdas):
@@ -200,11 +186,10 @@ class Simulation1DLayers(BaseSimulation):
     @hankel_filter.setter
     def hankel_filter(self, value):
         self._hankel_filter = validate_string(
-            "hankel_filter",
-            value,
-            HANKEL_FILTERS,
+            "hankel_filter", value, libdlf.hankel.__all__
         )
-        self._fhtfilt = getattr(filters, self._hankel_filter)()
+        self._fhtfilt = getattr(libdlf.hankel, value)()
+        self._coefficients_set = False
 
     @property
     def fix_Jmatrix(self):
@@ -241,9 +226,8 @@ class Simulation1DLayers(BaseSimulation):
                     r_max = max(off.max(), r_max)
         self.survey.set_geometric_factor()
 
-        lambdas, r_spline_points = get_dlf_points(
-            self._fhtfilt, np.r_[r_min, r_max], -1
-        )
+        lambdas, r_spline_points = get_splined_dlf_points(self._fhtfilt, r_min, r_max)
+
         lambdas = lambdas.reshape(-1)
         n_lambda = len(lambdas)
         n_r = len(r_spline_points)

--- a/simpeg/electromagnetics/utils/em1d_utils.py
+++ b/simpeg/electromagnetics/utils/em1d_utils.py
@@ -226,8 +226,8 @@ def get_splined_dlf_points(filt, v_min, v_max):
 
     Parameters
     ----------
-    filt : dict of numpy.ndarray
-        The filter parameters loaded from libdlf.
+    filt : namedtuple of numpy.ndarray
+        The filter parameters loaded from libdlf, in a named tuple containing a `.base` property.
     v_min, v_max : float
         The minimum and maximum points needed
 
@@ -242,7 +242,9 @@ def get_splined_dlf_points(filt, v_min, v_max):
     outmax = filt.base[-1] / v_min
     outmin = filt.base[0] / v_max
 
-    pts_per_dec = np.squeeze(1 / np.log(filt.factor))
+    factor = np.around([filt.base[1] / filt.base[0]], 15)
+
+    pts_per_dec = np.squeeze(1 / np.log(factor))
 
     nout = int(np.ceil(np.log(outmax / outmin) * pts_per_dec) + 1)
     if nout - filt.base.size < 3:

--- a/simpeg/electromagnetics/utils/em1d_utils.py
+++ b/simpeg/electromagnetics/utils/em1d_utils.py
@@ -219,3 +219,37 @@ def LogUniform(f, chi_inf=0.05, del_chi=0.05, tau1=1e-5, tau2=1e-2):
     return chi_inf + del_chi * (
         1 - np.log((1 + 1j * w * tau2) / (1 + 1j * w * tau1)) / np.log(tau2 / tau1)
     )
+
+
+def get_splined_dlf_points(filt, v_min, v_max):
+    """
+
+    Parameters
+    ----------
+    filt : dict of numpy.ndarray
+        The filter parameters loaded from libdlf.
+    v_min, v_max : float
+        The minimum and maximum points needed
+
+    Returns
+    -------
+    lamb, spline_points : numpy.ndarray
+        The points to evaluate at in the filter space, and the
+        corresponding spline points in the transformed space.
+    """
+
+    # the below is adapted from empymod.transform.get_dlf_points
+    outmax = filt.base[-1] / v_min
+    outmin = filt.base[0] / v_max
+
+    pts_per_dec = np.squeeze(1 / np.log(filt.factor))
+
+    nout = int(np.ceil(np.log(outmax / outmin) * pts_per_dec) + 1)
+    if nout - filt.base.size < 3:
+        nout = filt.base.size + 3
+    out = np.exp(
+        np.arange(np.log(outmin), np.log(outmin) + nout / pts_per_dec, 1 / pts_per_dec)
+    )
+
+    spline_points = v_max * np.exp(-np.arange(nout - filt.base.size + 1) / pts_per_dec)
+    return out, spline_points

--- a/simpeg/utils/code_utils.py
+++ b/simpeg/utils/code_utils.py
@@ -478,8 +478,8 @@ class Report(ScoobyReport):
             "numpy",
             "scipy",
             "matplotlib",
-            "empymod",
             "geoana",
+            "libdlf",
         ]
 
         # Optional packages.

--- a/tests/em/em1d/test_EM1D_TD_general_fwd.py
+++ b/tests/em/em1d/test_EM1D_TD_general_fwd.py
@@ -276,5 +276,14 @@ class EM1D_TD_LineCurrent_FwdProblemTests(unittest.TestCase):
         np.testing.assert_allclose(self.bzdt, empymod_solution, rtol=1e-2)
 
 
+def test_backwards_compatible_filter_key():
+
+    srv = tdem.Survey([])
+    sim = tdem.Simulation1DLayered(survey=srv)
+    sim.time_filter = "key_81_CosSin_2009"
+
+    assert sim.time_filter == "key_81_2009"
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/em/em1d/test_utils.py
+++ b/tests/em/em1d/test_utils.py
@@ -1,0 +1,37 @@
+from collections import namedtuple
+
+import pytest
+import libdlf
+import numpy as np
+import numpy.testing as npt
+from empymod.transform import get_dlf_points
+
+from simpeg.electromagnetics.utils.em1d_utils import get_splined_dlf_points
+
+FILTERS = [f"hankel.{filt}" for filt in libdlf.hankel.__all__] + [
+    f"fourier.{filt}" for filt in libdlf.fourier.__all__
+]
+
+
+@pytest.mark.parametrize("filt", FILTERS)
+@pytest.mark.parametrize("n_points", [1, 5, 10])
+def test_splined_dlf(filt, n_points):
+    f_type, f_name = filt.split(".")
+    f_module = getattr(libdlf, f_type)
+    filt = getattr(f_module, f_name)
+    base, *vals = filt()
+    if len(vals) == 2:
+        v0, v1 = vals
+    else:
+        v0 = v1 = vals[0]
+    factor = np.around([base[1] / base[0]], 15)
+    filt_type = namedtuple("Filter", "base v0 v1 factor")
+    filt = filt_type(base, v0, v1, factor)
+
+    r_s = np.logspace(-1, 1, n_points)
+
+    out1, out2 = get_splined_dlf_points(filt, r_s.min(), r_s.max())
+    test1, test2 = get_dlf_points(filt, r_s, -1)
+
+    npt.assert_allclose(out1, test1[0])
+    npt.assert_allclose(out2, test2)

--- a/tests/utils/test_report.py
+++ b/tests/utils/test_report.py
@@ -16,8 +16,8 @@ class TestReport(unittest.TestCase):
                 "numpy",
                 "scipy",
                 "matplotlib",
-                "libdlf",
                 "geoana",
+                "libdlf",
             ],
             # Optional packages.
             optional=[

--- a/tests/utils/test_report.py
+++ b/tests/utils/test_report.py
@@ -16,7 +16,7 @@ class TestReport(unittest.TestCase):
                 "numpy",
                 "scipy",
                 "matplotlib",
-                "empymod",
+                "libdlf",
                 "geoana",
             ],
             # Optional packages.


### PR DESCRIPTION
#### Summary
`empymod` is a pretty heavy dependency for the functionality we are using from it. This removes the dependency and instead uses `libdlf` to get the filters, and a streamlined `get_splined_dlf_points` for our internal use.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Additional information
I say `empymod` is a heavy dependency because it in turn relies on `numba`.
