### PR TITLE
Bugfix for TDEM magnetic dipole sources 

### DIFF
--- a/simpeg/electromagnetics/time_domain/sources.py
+++ b/simpeg/electromagnetics/time_domain/sources.py
@@ -1428,11 +1428,7 @@ class MagDipole(BaseTDEMSrc):
                 self.waveform.has_initial_fields is True
                 and time < simulation.time_steps[1]
             ):
-                if simulation._fieldType == "b":
-                    return Zero()
-                elif simulation._fieldType == "e":
-                    # Compute s_e from vector potential
-                    return C.T * (MfMui * b)
+                return C.T * (MfMui * b)
             else:
                 return C.T * (MfMui * b) * self.waveform.eval(time)
 
@@ -1443,11 +1439,7 @@ class MagDipole(BaseTDEMSrc):
                 self.waveform.has_initial_fields is True
                 and time < simulation.time_steps[1]
             ):
-                if simulation._fieldType == "h":
-                    return Zero()
-                elif simulation._fieldType == "j":
-                    # Compute s_e from vector potential
-                    return C * h
+                return C * h
             else:
                 return C * h * self.waveform.eval(time)
 

--- a/tests/em/tdem/test_TDEM_crosscheck.py
+++ b/tests/em/tdem/test_TDEM_crosscheck.py
@@ -35,7 +35,7 @@ def setUp_TDEM(
     )
     mapping = maps.ExpMap(mesh) * maps.SurjectVertical1D(mesh) * activeMap
 
-    rxtimes = np.logspace(-4, -3, 20)
+    rxtimes = np.hstack([np.r_[0], np.logspace(-4, -3, 20)])
 
     if waveform.upper() == "RAW":
         t0 = 0.006


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing/pull-requests.html

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
Bugfix so that the initial fields produced for `db/dt`, `dh/dt`, from the B field or H field simulations are zero. There was previously a bug where we set the electric source term to `Zero()` when infact it should have been evaluated. This would only effect `db/dt` (or `dh/dt`) that were measured before the first time-step, but it also impacted visualizations of the fields. 

To catch this issue, I have extended our cross-check tests for tdem simulation to also include an evaluation of the data at t=0. Running this test on the current main version of SimPEG will fail. 

As an example, using the `tdem.simulation.Simulation3DMagneticFluxDensity` for a loop source and plotting db/dt gives: 

**Before the bugfix**
Crazy db/dt! 
![image](https://github.com/user-attachments/assets/e948331a-9b60-4930-8b96-9f8dfe9ae7de)


**After**
Zero -- as it should be
![image](https://github.com/user-attachments/assets/a85f24cc-a8bd-4f10-8423-e43d49dd4321)


#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
