### PR TITLE
Add docstring to `n_processes` in potential field simulations

### DIFF
--- a/simpeg/potential_fields/base.py
+++ b/simpeg/potential_fields/base.py
@@ -222,6 +222,11 @@ class BasePFSimulation(LinearSimulation):
 
     @property
     def n_processes(self):
+        """
+        Number of processes to use for forward modeling.
+
+        If ``engine`` is ``"choclo"``, then this property will be ignored.
+        """
         return self._n_processes
 
     @n_processes.setter


### PR DESCRIPTION
#### Summary

Add missing docstring to the `n_processes` property in potential field simulation classes.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


The missing docstrings were raised by @thibaut-kobold in Mattermost.
