### PR TITLE
Simulation cleanup

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,26 +37,26 @@ stages:
     jobs:
       - template: .ci/azure/style.yml
 
-  - stage: Testing
-    dependsOn: StyleChecks
-    jobs:
-      - template: .ci/azure/test.yml
-
-  - stage: Codecov
-    dependsOn: Testing
-    jobs:
-      - template: .ci/azure/codecov.yml
-
-  - stage: Docs
-    dependsOn:
-      - StyleChecks
-      - Testing
-    jobs:
-      - template: .ci/azure/docs.yml
-
-  - stage: PyPI
-    dependsOn:
-      - StyleChecks
-      - Testing
-    jobs:
-      - template: .ci/azure/pypi.yml
+#  - stage: Testing
+#    dependsOn: StyleChecks
+#    jobs:
+#      - template: .ci/azure/test.yml
+#
+#  - stage: Codecov
+#    dependsOn: Testing
+#    jobs:
+#      - template: .ci/azure/codecov.yml
+#
+#  - stage: Docs
+#    dependsOn:
+#      - StyleChecks
+#      - Testing
+#    jobs:
+#      - template: .ci/azure/docs.yml
+#
+#  - stage: PyPI
+#    dependsOn:
+#      - StyleChecks
+#      - Testing
+#    jobs:
+#      - template: .ci/azure/pypi.yml

--- a/simpeg/base/__init__.py
+++ b/simpeg/base/__init__.py
@@ -2,5 +2,4 @@ from .pde_simulation import (
     BasePDESimulation,
     BaseElectricalPDESimulation,
     BaseMagneticPDESimulation,
-    with_property_mass_matrices,
 )

--- a/simpeg/base/pde_simulation.py
+++ b/simpeg/base/pde_simulation.py
@@ -1,9 +1,21 @@
+import discretize.base
 import numpy as np
 import scipy.sparse as sp
+from discretize.base import BaseMesh
 from discretize.utils import Zero, TensorType
+
+from ..props import PhysicalPropertyMetaclass, PhysicalProperty
 from ..simulation import BaseSimulation
 from .. import props
 from scipy.constants import mu_0
+
+from ..utils import validate_type
+
+AXIS_ALIGNED_MESH_TYPES = (
+    discretize.TensorMesh,
+    discretize.TreeMesh,
+    discretize.CylindricalMesh,
+)
 
 
 def __inner_mat_mul_op(M, u, v=None, adjoint=False):
@@ -77,483 +89,527 @@ def __inner_mat_mul_op(M, u, v=None, adjoint=False):
         )
 
 
-def with_property_mass_matrices(property_name):
-    """
-    This decorator will automatically populate all of the property mass matrices.
+def _get_mass_matrix_functions(property_name: str, invertible: bool = False):
 
-    Given the property "prop", this will add properties and functions to the class
-    representing all of the possible mass matrix operations on the mesh.
+    mm_funcs = {}
 
-    For a given property, "prop", they will be named:
+    @property
+    def Mcc_prop(self):
+        """
+        Cell center property inner product matrix.
+        """
+        stash_name = f"_Mcc_{property_name}"
+        if (M_prop := self._cache[stash_name]) is None:
+            prop = getattr(self, property_name)
+            M_prop = sp.diags(self.mesh.cell_volumes * prop, format="csr")
+            self._cache[stash_name] = M_prop
+        return M_prop
 
-    * MccProp
-    * MccPropDeriv
-    * MccPropI
-    * MccPropIDeriv
+    mm_funcs[f"_Mcc_{property_name}"] = Mcc_prop
 
-    and so on for each "Mcc", "Mn", "Mf", and "Me".
-    """
+    @property
+    def Mn_prop(self):
+        """
+        Node property inner product matrix.
+        """
+        stash_name = f"_Mn_{property_name}"
+        if (M_prop := self._cache[stash_name]) is None:
+            prop = getattr(self, property_name)
+            vol = self.mesh.cell_volumes
+            M_prop = sp.diags(self.mesh.aveN2CC.T * (vol * prop), format="csr")
+            self._cache[stash_name] = M_prop
+        return M_prop
 
-    def decorator(cls):
-        arg = property_name.lower()
-        arg = arg[0].upper() + arg[1:]
+    mm_funcs[f"_Mn_{property_name}"] = Mn_prop
 
-        @property
-        def Mcc_prop(self):
-            """
-            Cell center property inner product matrix.
-            """
-            stash_name = f"_Mcc_{arg}"
-            if getattr(self, stash_name, None) is None:
-                prop = getattr(self, arg.lower())
-                M_prop = sp.diags(self.mesh.cell_volumes * prop, format="csr")
-                setattr(self, stash_name, M_prop)
-            return getattr(self, stash_name)
+    @property
+    def Mf_prop(self):
+        """
+        Face property inner product matrix.
+        """
+        stash_name = f"_Mf_{property_name}"
+        if (M_prop := self._cache[stash_name]) is None:
+            prop = getattr(self, property_name)
+            M_prop = self.mesh.get_face_inner_product(model=prop)
+            self._cache[stash_name] = M_prop
+        return M_prop
 
-        setattr(cls, f"Mcc{arg}", Mcc_prop)
+    mm_funcs[f"_Mf_{property_name}"] = Mf_prop
 
-        @property
-        def Mn_prop(self):
-            """
-            Node property inner product matrix.
-            """
-            stash_name = f"_Mn_{arg}"
-            if getattr(self, stash_name, None) is None:
-                prop = getattr(self, arg.lower())
-                vol = self.mesh.cell_volumes
-                M_prop = sp.diags(self.mesh.aveN2CC.T * (vol * prop), format="csr")
-                setattr(self, stash_name, M_prop)
-            return getattr(self, stash_name)
+    @property
+    def Me_prop(self):
+        """
+        Edge property inner product matrix.
+        """
+        stash_name = f"_Me_{property_name}"
+        if (M_prop := self._cache[stash_name]) is None:
+            prop = getattr(self, property_name)
+            M_prop = self.mesh.get_edge_inner_product(model=prop)
+            self._cache[stash_name] = M_prop
+        return M_prop
 
-        setattr(cls, f"Mn{arg}", Mn_prop)
+    mm_funcs[f"_Me_{property_name}"] = Me_prop
 
-        @property
-        def Mf_prop(self):
-            """
-            Face property inner product matrix.
-            """
-            stash_name = f"_Mf_{arg}"
-            if getattr(self, stash_name, None) is None:
-                prop = getattr(self, arg.lower())
-                M_prop = self.mesh.get_face_inner_product(model=prop)
-                setattr(self, stash_name, M_prop)
-            return getattr(self, stash_name)
+    @property
+    def inv_Mcc_prop(self):
+        """
+        Cell center property inner product inverse matrix.
+        """
+        stash_name = f"_inv_Mcc_{property_name}"
+        if (M_prop := self._cache[stash_name]) is None:
+            prop = getattr(self, property_name)
+            M_prop = sp.diags(1.0 / (self.mesh.cell_volumes * prop), format="csr")
+            self._cache[stash_name] = M_prop
+        return M_prop
 
-        setattr(cls, f"Mf{arg}", Mf_prop)
+    mm_funcs[f"_inv_Mcc_{property_name}"] = inv_Mcc_prop
 
-        @property
-        def Me_prop(self):
-            """
-            Edge property inner product matrix.
-            """
-            stash_name = f"_Me_{arg}"
-            if getattr(self, stash_name, None) is None:
-                prop = getattr(self, arg.lower())
-                M_prop = self.mesh.get_edge_inner_product(model=prop)
-                setattr(self, stash_name, M_prop)
-            return getattr(self, stash_name)
+    @property
+    def inv_Mn_prop(self):
+        """
+        Node property inner product inverse matrix.
+        """
+        stash_name = f"_inv_Mn_{property_name}"
+        if (M_prop := self._cache[stash_name]) is None:
+            prop = getattr(self, property_name)
+            vol = self.mesh.cell_volumes
+            M_prop = sp.diags(1.0 / (self.mesh.aveN2CC.T * (vol * prop)), format="csr")
+            self._cache[stash_name] = M_prop
+        return M_prop
 
-        setattr(cls, f"Me{arg}", Me_prop)
+    mm_funcs[f"_inv_Mn_{property_name}"] = inv_Mn_prop
 
-        @property
-        def MccI_prop(self):
-            """
-            Cell center property inner product inverse matrix.
-            """
-            stash_name = f"_MccI_{arg}"
-            if getattr(self, stash_name, None) is None:
-                prop = getattr(self, arg.lower())
-                M_prop = sp.diags(1.0 / (self.mesh.cell_volumes * prop), format="csr")
-                setattr(self, stash_name, M_prop)
-            return getattr(self, stash_name)
+    @property
+    def inv_Mf_prop(self):
+        """
+        Face property inner product inverse matrix.
+        """
+        stash_name = f"_inv_Mf_{property_name}"
+        if (M_prop := self._cache[stash_name]) is None:
+            prop = getattr(self, property_name)
+            M_prop = self.mesh.get_face_inner_product(model=prop, invert_matrix=True)
+            self._cache[stash_name] = M_prop
+        return M_prop
 
-        setattr(cls, f"Mcc{arg}I", MccI_prop)
+    mm_funcs[f"_inv_Mf_{property_name}"] = inv_Mf_prop
 
-        @property
-        def MnI_prop(self):
-            """
-            Node property inner product inverse matrix.
-            """
-            stash_name = f"_MnI_{arg}"
-            if getattr(self, stash_name, None) is None:
-                prop = getattr(self, arg.lower())
-                vol = self.mesh.cell_volumes
-                M_prop = sp.diags(
-                    1.0 / (self.mesh.aveN2CC.T * (vol * prop)), format="csr"
-                )
-                setattr(self, stash_name, M_prop)
-            return getattr(self, stash_name)
+    @property
+    def inv_Me_prop(self):
+        """
+        Edge property inner product inverse matrix.
+        """
+        stash_name = f"_inv_Me_{property_name}"
+        if (M_prop := self._cache[stash_name]) is None:
+            prop = getattr(self, property_name)
+            M_prop = self.mesh.get_edge_inner_product(model=prop, invert_matrix=True)
+            self._cache[stash_name] = M_prop
+        return M_prop
 
-        setattr(cls, f"Mn{arg}I", MnI_prop)
+    mm_funcs[f"_inv_Me_{property_name}"] = inv_Me_prop
 
-        @property
-        def MfI_prop(self):
-            """
-            Face property inner product inverse matrix.
-            """
-            stash_name = f"_MfI_{arg}"
-            if getattr(self, stash_name, None) is None:
-                prop = getattr(self, arg.lower())
-                M_prop = self.mesh.get_face_inner_product(
-                    model=prop, invert_matrix=True
-                )
-                setattr(self, stash_name, M_prop)
-            return getattr(self, stash_name)
+    if invertible:
 
-        setattr(cls, f"Mf{arg}I", MfI_prop)
-
-        @property
-        def MeI_prop(self):
-            """
-            Edge property inner product inverse matrix.
-            """
-            stash_name = f"_MeI_{arg}"
-            if getattr(self, stash_name, None) is None:
-                prop = getattr(self, arg.lower())
-                M_prop = self.mesh.get_edge_inner_product(
-                    model=prop, invert_matrix=True
-                )
-                setattr(self, stash_name, M_prop)
-            return getattr(self, stash_name)
-
-        setattr(cls, f"Me{arg}I", MeI_prop)
-
-        def MccDeriv_prop(self, u, v=None, adjoint=False):
-            """
+        def Mcc_prop_deriv(self, u, v=None, adjoint=False):
+            f"""
             Derivative of `MccProperty` with respect to the model.
             """
-            if getattr(self, f"{arg.lower()}Map") is None:
+            if getattr(self, f"{property_name}_map") is None:
                 return Zero()
             if isinstance(u, Zero) or isinstance(v, Zero):
                 return Zero()
-            stash_name = f"_Mcc_{arg}_deriv"
 
-            if getattr(self, stash_name, None) is None:
-                M_prop_deriv = sp.diags(self.mesh.cell_volumes) * getattr(
-                    self, f"{arg.lower()}Deriv"
-                )
-                setattr(self, stash_name, M_prop_deriv)
-            return __inner_mat_mul_op(
-                getattr(self, stash_name), u, v=v, adjoint=adjoint
-            )
+            stash_name = f"_Mcc_{property_name}_deriv"
+            if (M_prop_deriv := self._cache[stash_name]) is None:
+                prop_deriv = getattr(self, f"{property_name}_deriv")
+                M_prop_deriv = sp.diags(self.mesh.cell_volumes) @ prop_deriv
+                self._cache[stash_name] = M_prop_deriv
+            return __inner_mat_mul_op(M_prop_deriv, u, v=v, adjoint=adjoint)
 
-        setattr(cls, f"Mcc{arg}Deriv", MccDeriv_prop)
+        mm_funcs[f"_Mcc_{property_name}_deriv"] = Mcc_prop_deriv
 
-        def MnDeriv_prop(self, u, v=None, adjoint=False):
+        def Mn_prop_deriv(self, u, v=None, adjoint=False):
             """
             Derivative of `MnProperty` with respect to the model.
             """
-            if getattr(self, f"{arg.lower()}Map") is None:
+            if getattr(self, f"{property_name}_map") is None:
                 return Zero()
             if isinstance(u, Zero) or isinstance(v, Zero):
                 return Zero()
-            stash_name = f"_Mn_{arg}_deriv"
-            if getattr(self, stash_name, None) is None:
+            stash_name = f"_Mn_{property_name}_deriv"
+            if (M_prop_deriv := self._cache[stash_name]) is None:
+                prop_deriv = getattr(self, f"{property_name}_deriv")
                 M_prop_deriv = (
-                    self.mesh.aveN2CC.T
-                    * sp.diags(self.mesh.cell_volumes)
-                    * getattr(self, f"{arg.lower()}Deriv")
+                    self.mesh.aveN2CC.T @ sp.diags(self.mesh.cell_volumes) @ prop_deriv
                 )
-                setattr(self, stash_name, M_prop_deriv)
-            return __inner_mat_mul_op(
-                getattr(self, stash_name), u, v=v, adjoint=adjoint
-            )
+                self._cache[stash_name] = M_prop_deriv
+            return __inner_mat_mul_op(M_prop_deriv, u, v=v, adjoint=adjoint)
 
-        setattr(cls, f"Mn{arg}Deriv", MnDeriv_prop)
+        mm_funcs[f"_Mn_{property_name}_deriv"] = Mn_prop_deriv
 
-        def MfDeriv_prop(self, u, v=None, adjoint=False):
+        def Mf_prop_deriv(self, u, v=None, adjoint=False):
             """
             Derivative of `MfProperty` with respect to the model.
             """
-            if getattr(self, f"{arg.lower()}Map") is None:
+            if getattr(self, f"{property_name}_map") is None:
                 return Zero()
             if isinstance(u, Zero) or isinstance(v, Zero):
                 return Zero()
-            stash_name = f"_Mf_{arg}_deriv"
-            if getattr(self, stash_name, None) is None:
-                prop = getattr(self, arg.lower())
+            stash_name = f"_Mf_{property_name}_deriv"
+            if (M_prop_deriv := self._cache[stash_name]) is None:
+                prop = getattr(self, property_name)
                 t_type = TensorType(self.mesh, prop)
 
                 M_deriv_func = self.mesh.get_face_inner_product_deriv(model=prop)
-                prop_deriv = getattr(self, f"{arg.lower()}Deriv")
+                prop_deriv = getattr(self, f"{property_name}_deriv")
                 # t_type == 3 for full tensor model, t_type < 3 for scalar, isotropic, or axis-aligned anisotropy.
-                if t_type < 3 and self.mesh._meshType.lower() in (
-                    "cyl",
-                    "tensor",
-                    "tree",
-                ):
+                if t_type < 3 and isinstance(self.mesh, AXIS_ALIGNED_MESH_TYPES):
                     M_prop_deriv = M_deriv_func(np.ones(self.mesh.n_faces)) @ prop_deriv
-                    setattr(self, stash_name, M_prop_deriv)
                 else:
-                    setattr(self, stash_name, (M_deriv_func, prop_deriv))
+                    M_prop_deriv = (M_deriv_func, prop_deriv)
+                self._cache[stash_name] = M_prop_deriv
 
-            return __inner_mat_mul_op(
-                getattr(self, stash_name), u, v=v, adjoint=adjoint
-            )
+            return __inner_mat_mul_op(M_prop_deriv, u, v=v, adjoint=adjoint)
 
-        setattr(cls, f"Mf{arg}Deriv", MfDeriv_prop)
+        mm_funcs[f"_Mf_{property_name}_deriv"] = Mf_prop_deriv
 
-        def MeDeriv_prop(self, u, v=None, adjoint=False):
+        def Me_prop_deriv(self, u, v=None, adjoint=False):
             """
             Derivative of `MeProperty` with respect to the model.
             """
-            if getattr(self, f"{arg.lower()}Map") is None:
+            if getattr(self, f"{property_name}_map") is None:
                 return Zero()
             if isinstance(u, Zero) or isinstance(v, Zero):
                 return Zero()
-            stash_name = f"_Me_{arg}_deriv"
-            if getattr(self, stash_name, None) is None:
-                prop = getattr(self, arg.lower())
+            stash_name = f"_Me_{property_name}_deriv"
+            if (M_prop_deriv := self._cache[stash_name]) is None:
+                prop = getattr(self, property_name)
                 t_type = TensorType(self.mesh, prop)
 
                 M_deriv_func = self.mesh.get_edge_inner_product_deriv(model=prop)
-                prop_deriv = getattr(self, f"{arg.lower()}Deriv")
+                prop_deriv = getattr(self, f"{property_name}_deriv")
                 # t_type == 3 for full tensor model, t_type < 3 for scalar, isotropic, or axis-aligned anisotropy.
-                if t_type < 3 and self.mesh._meshType.lower() in (
-                    "cyl",
-                    "tensor",
-                    "tree",
-                ):
+                if t_type < 3 and isinstance(self.mesh, AXIS_ALIGNED_MESH_TYPES):
                     M_prop_deriv = M_deriv_func(np.ones(self.mesh.n_edges)) @ prop_deriv
-                    setattr(self, stash_name, M_prop_deriv)
                 else:
-                    setattr(self, stash_name, (M_deriv_func, prop_deriv))
-            return __inner_mat_mul_op(
-                getattr(self, stash_name), u, v=v, adjoint=adjoint
-            )
+                    M_prop_deriv = (M_deriv_func, prop_deriv)
+                self._cache[stash_name] = M_prop_deriv
+            return __inner_mat_mul_op(M_prop_deriv, u, v=v, adjoint=adjoint)
 
-        setattr(cls, f"Me{arg}Deriv", MeDeriv_prop)
+        mm_funcs[f"_Me_{property_name}_deriv"] = Me_prop_deriv
 
-        def MccIDeriv_prop(self, u, v=None, adjoint=False):
+        def inv_Mcc_prop_deriv(self, u, v=None, adjoint=False):
             """
             Derivative of `MccPropertyI` with respect to the model.
             """
-            if getattr(self, f"{arg.lower()}Map") is None:
+            if getattr(self, f"{property_name}Map") is None:
                 return Zero()
             if isinstance(u, Zero) or isinstance(v, Zero):
                 return Zero()
 
-            MI_prop = getattr(self, f"Mcc{arg}I")
+            MI_prop = getattr(self, f"_inv_Mcc_{property_name}")
             u = MI_prop @ (MI_prop @ -u)
-            M_prop_deriv = getattr(self, f"Mcc{arg}Deriv")
+            M_prop_deriv = getattr(self, f"_Mcc_{property_name}_deriv")
             return M_prop_deriv(u, v, adjoint=adjoint)
 
-        setattr(cls, f"Mcc{arg}IDeriv", MccIDeriv_prop)
+        mm_funcs[f"_inv_Mcc_{property_name}_deriv"] = inv_Mcc_prop_deriv
 
-        def MnIDeriv_prop(self, u, v=None, adjoint=False):
+        def inv_Mn_prop_deriv(self, u, v=None, adjoint=False):
             """
             Derivative of `MnPropertyI` with respect to the model.
             """
-            if getattr(self, f"{arg.lower()}Map") is None:
+            if getattr(self, f"{property_name}_map") is None:
                 return Zero()
             if isinstance(u, Zero) or isinstance(v, Zero):
                 return Zero()
 
-            MI_prop = getattr(self, f"Mn{arg}I")
+            MI_prop = getattr(self, f"_inv_Mn_{property_name}")
             u = MI_prop @ (MI_prop @ -u)
-            M_prop_deriv = getattr(self, f"Mn{arg}Deriv")
+            M_prop_deriv = getattr(self, f"_Mn_{property_name}_deriv")
             return M_prop_deriv(u, v, adjoint=adjoint)
 
-        setattr(cls, f"Mn{arg}IDeriv", MnIDeriv_prop)
+        mm_funcs[f"_inv_Mn_{property_name}_deriv"] = inv_Mn_prop_deriv
 
-        def MfIDeriv_prop(self, u, v=None, adjoint=False):
+        def inv_Mf_prop_deriv(self, u, v=None, adjoint=False):
             """I
             Derivative of `MfPropertyI` with respect to the model.
             """
-            if getattr(self, f"{arg.lower()}Map") is None:
+            if getattr(self, f"{property_name}_map") is None:
                 return Zero()
             if isinstance(u, Zero) or isinstance(v, Zero):
                 return Zero()
 
-            MI_prop = getattr(self, f"Mf{arg}I")
+            MI_prop = getattr(self, f"_inv_Mf_{property_name}")
             u = MI_prop @ (MI_prop @ -u)
-            M_prop_deriv = getattr(self, f"Mf{arg}Deriv")
+            M_prop_deriv = getattr(self, f"_Mf_{property_name}_deriv")
             return M_prop_deriv(u, v, adjoint=adjoint)
 
-        setattr(cls, f"Mf{arg}IDeriv", MfIDeriv_prop)
+        mm_funcs[f"_inv_Mf_{property_name}_deriv"] = inv_Mf_prop_deriv
 
-        def MeIDeriv_prop(self, u, v=None, adjoint=False):
+        def inv_Me_prop_deriv(self, u, v=None, adjoint=False):
             """
             Derivative of `MePropertyI` with respect to the model.
             """
-            if getattr(self, f"{arg.lower()}Map") is None:
+            if getattr(self, f"{property_name}_map") is None:
                 return Zero()
             if isinstance(u, Zero) or isinstance(v, Zero):
                 return Zero()
 
-            MI_prop = getattr(self, f"Me{arg}I")
+            MI_prop = getattr(self, f"_inv_Me_{property_name}")
             u = MI_prop @ (MI_prop @ -u)
-            M_prop_deriv = getattr(self, f"Me{arg}Deriv")
+            M_prop_deriv = getattr(self, f"_Me_{property_name}_deriv")
             return M_prop_deriv(u, v, adjoint=adjoint)
 
-        setattr(cls, f"Me{arg}IDeriv", MeIDeriv_prop)
+        mm_funcs[f"_inv_Me_{property_name}_deriv"] = inv_Me_prop_deriv
+
+    cached_items = {
+        f"_Mcc_{property_name}",
+        f"_Mn_{property_name}",
+        f"_Mf_{property_name}",
+        f"_Me_{property_name}",
+        f"_inv_Mc_{property_name}",
+        f"_inv_Mn_{property_name}",
+        f"_inv_Mf_{property_name}",
+        f"_inv_Me_{property_name}",
+    }
+    if invertible:
+        cached_items |= {
+            f"_Mcc_{property_name}_deriv",
+            f"_Mn_{property_name}_deriv",
+            f"_Mf_{property_name}_deriv",
+            f"_Me_{property_name}_deriv",
+        }
+
+    return mm_funcs, cached_items
+
+
+class MassMatrixMeta(PhysicalPropertyMetaclass):
+
+    def __new__(cls, name, bases, attrs: dict):
+
+        cls = super().__new__(cls, name, bases, attrs)
+        phys_props = {}
+        for base in reversed(cls.__mro__[1:]):
+            metaclass = type(base)
+            if issubclass(metaclass, PhysicalPropertyMetaclass):
+                for prop_name, prop in base._physical_properties.items():
+                    # loop through properties that have not already been
+                    # given a mass matrix function.
+                    if getattr(cls, f"_Mcc_{prop_name}", None) is None:
+                        phys_props[prop_name] = prop
+        # always update with anything specifically defined on this class.
+        phys_props.update(cls._physical_properties)
+
+        mm_funcs = {}
+        invertible_props = set()
+        for prop_name, prop in phys_props.items():
+            invertible = prop.mapping is not None
+            mm_func, prop_cache = _get_mass_matrix_functions(
+                prop.name, invertible=invertible
+            )
+            mm_funcs.update(mm_func)
+            prop.cached_items = prop_cache
+            if invertible:
+                invertible_props.add(prop)
+
+        for name, func in mm_funcs.items():
+            setattr(cls, name, func)
+
+        model_change_delete_prop = attrs.get("_delete_on_model_change", None)
 
         @property
-        def _clear_on_prop_update(self):
-            items = [
-                f"_Mcc_{arg}",
-                f"_Mn_{arg}",
-                f"_Mf_{arg}",
-                f"_Me_{arg}",
-                f"_MccI_{arg}",
-                f"_MnI_{arg}",
-                f"_MfI_{arg}",
-                f"_MeI_{arg}",
-                f"_Mcc_{arg}_deriv",
-                f"_Mn_{arg}_deriv",
-                f"_Mf_{arg}_deriv",
-                f"_Me_{arg}_deriv",
-            ]
+        def delete_on_model_change(self):
+            if model_change_delete_prop is not None:
+                items = model_change_delete_prop.fget(self)
+            else:
+                items = super(bases[0], self)._delete_on_model_change
+            for prop in invertible_props:
+                if getattr(self, prop.mapping.name, None) is not None:
+                    items.extend(prop.cached_items)
             return items
 
-        setattr(cls, f"_clear_on_{arg.lower()}_update", _clear_on_prop_update)
+        cls._delete_on_model_change = delete_on_model_change
         return cls
 
-    return decorator
 
+class BasePDESimulation(BaseSimulation, metaclass=MassMatrixMeta):
+    """
+    Parameters
+    ----------
+    mesh : discretize.base.BaseMesh, optional
+        Mesh on which the forward problem is discretized.
+    solver : None or pymatsolver.base.Base, optional
+        Numerical solver used to solve the forward problem. If ``None``,
+        an appropriate solver specific to the simulation class is set by default.
+    solver_opts : dict, optional
+        Solver-specific parameters. If ``None``, default parameters are used for
+        the solver set by ``solver``. Otherwise, the ``dict`` must contain appropriate
+        pairs of keyword arguments and parameter values for the solver. Please visit
+        `pymatsolver <https://pymatsolver.readthedocs.io/en/latest/>`__ to learn more
+        about solvers and their parameters.
+    """
 
-class BasePDESimulation(BaseSimulation):
+    def __init__(self, mesh, solver=None, solver_opts=None, **kwargs):
+        super().__init__(**kwargs)
+        self.mesh = mesh
+        self.solver = solver
+        if solver_opts is None:
+            solver_opts = {}
+        self.solver_opts = solver_opts
+
     @property
-    def Vol(self):
-        return self.Mcc
+    def mesh(self):
+        """Mesh for the simulation.
+
+        For more on meshes, visit :py:class:`discretize.base.BaseMesh`.
+
+        Returns
+        -------
+        discretize.base.BaseMesh
+            Mesh on which the forward problem is discretized.
+        """
+        return self._mesh
+
+    @mesh.setter
+    def mesh(self, value):
+        self._mesh = validate_type("mesh", value, BaseMesh, cast=False)
 
     @property
-    def Mcc(self):
+    def _Mcc(self):
         """
         Cell center inner product matrix.
         """
-        if getattr(self, "_Mcc", None) is None:
-            self._Mcc = sp.diags(self.mesh.cell_volumes, format="csr")
-        return self._Mcc
+        if (Mcc := self._cache["_Mcc"]) is None:
+            Mcc = sp.diags(self.mesh.cell_volumes, format="csr")
+            self._cache["_Mcc"] = Mcc
+        return Mcc
 
     @property
-    def Mn(self):
+    def _Mn(self):
         """
         Node inner product matrix.
         """
-        if getattr(self, "_Mn", None) is None:
-            vol = self.mesh.cell_volumes
-            self._Mn = sp.diags(self.mesh.aveN2CC.T * vol, format="csr")
-        return self._Mn
+        if (Mn := self._cache["_Mn"]) is None:
+            Mn = sp.diags(self.mesh.aveN2CC.T * self.mesh.cell_volumes, format="csr")
+            self._cache["_Mn"] = Mn
+        return Mn
 
     @property
-    def Mf(self):
+    def _Mf(self):
         """
         Face inner product matrix.
         """
-        if getattr(self, "_Mf", None) is None:
-            self._Mf = self.mesh.get_face_inner_product()
-        return self._Mf
+        if (Mf := self._cache["_Mf"]) is None:
+            Mf = self.mesh.get_face_inner_product()
+            self._cache["_Mf"] = Mf
+        return Mf
 
     @property
-    def Me(self):
+    def _Me(self):
         """
         Edge inner product matrix.
         """
-        if getattr(self, "_Me", None) is None:
-            self._Me = self.mesh.get_edge_inner_product()
-        return self._Me
+        if (Me := self._cache["_Me"]) is None:
+            Me = self.mesh.get_face_inner_product()
+            self._cache["_Me"] = Me
+        return Me
 
     @property
-    def MccI(self):
-        if getattr(self, "_MccI", None) is None:
-            self._MccI = sp.diags(1.0 / self.mesh.cell_volumes, format="csr")
-        return self._MccI
+    def _MccI(self):
+        if (MccI := self._cache["_MccI"]) is None:
+            MccI = sp.diags(1.0 / self.mesh.cell_volumes, format="csr")
+            self._cache["_MccI"] = MccI
+        return MccI
 
     @property
-    def MnI(self):
+    def _MnI(self):
         """
         Node inner product inverse matrix.
         """
-        if getattr(self, "_MnI", None) is None:
-            vol = self.mesh.cell_volumes
-            self._MnI = sp.diags(1.0 / (self.mesh.aveN2CC.T * vol), format="csr")
-        return self._MnI
+        if (MnI := self._cache["_MnI"]) is None:
+            MnI = sp.diags(
+                1.0 / (self.mesh.aveN2CC.T * self.mesh.cell_volumes), format="csr"
+            )
+            self._cache["_MnI"] = MnI
+        return MnI
 
     @property
-    def MfI(self):
+    def _MfI(self):
         """
         Face inner product inverse matrix.
         """
-        if getattr(self, "_MfI", None) is None:
-            self._MfI = self.mesh.get_face_inner_product(invert_matrix=True)
-        return self._MfI
+        if (MfI := self._cache["_MfI"]) is None:
+            if isinstance(self.mesh, AXIS_ALIGNED_MESH_TYPES):
+                MfI = self.mesh.get_face_inner_product(invert_matrix=True)
+            else:
+                MfI = self.solver(self._Mf, symmetric=True, positive_definite=True)
+            self._cache["_MfI"] = MfI
+        return MfI
 
     @property
-    def MeI(self):
+    def _MeI(self):
         """
         Edge inner product inverse matrix.
         """
-        if getattr(self, "_MeI", None) is None:
-            self._MeI = self.mesh.get_edge_inner_product(invert_matrix=True)
+        if (MeI := self._cache["_MeI"]) is None:
+            if isinstance(self.mesh, AXIS_ALIGNED_MESH_TYPES):
+                MeI = self.mesh.get_edge_inner_product(invert_matrix=True)
+            else:
+                MeI = self.solver(self._Me, symmetric=True, positive_definite=True)
+            self._cache["_MeI"] = MeI
         return self._MeI
 
 
-@with_property_mass_matrices("sigma")
-@with_property_mass_matrices("rho")
-class BaseElectricalPDESimulation(BasePDESimulation):
-    sigma, sigmaMap, sigmaDeriv = props.Invertible("Electrical conductivity (S/m)")
-    rho, rhoMap, rhoDeriv = props.Invertible("Electrical resistivity (Ohm m)")
-    props.Reciprocal(sigma, rho)
+class BaseElectricalSimulation(BaseSimulation):
+    conductivity, conductivity_map, _con_deriv = props.Invertible(
+        "Electrical conductivity (S/m)"
+    )
+    resistivity, resistivity_map, _res_deriv = props.Invertible(
+        "Electrical resistivity (Ohm m)"
+    )
+    props.Reciprocal(conductivity, resistivity)
 
     def __init__(
-        self, mesh, sigma=None, sigmaMap=None, rho=None, rhoMap=None, **kwargs
+        self,
+        conductivity=None,
+        conductivity_map=None,
+        resistivity=None,
+        resistivity_map=None,
+        **kwargs,
     ):
-        super().__init__(mesh=mesh, **kwargs)
-        self.sigma = sigma
-        self.rho = rho
-        self.sigmaMap = sigmaMap
-        self.rhoMap = rhoMap
-
-    @property
-    def deleteTheseOnModelUpdate(self):
-        """
-        matrices to be deleted if the model for conductivity/resistivity is updated
-        """
-        toDelete = super().deleteTheseOnModelUpdate
-        if self.sigmaMap is not None or self.rhoMap is not None:
-            toDelete = (
-                toDelete + self._clear_on_sigma_update + self._clear_on_rho_update
-            )
-        return toDelete
-
-    def __setattr__(self, name, value):
-        super().__setattr__(name, value)
-        if name in ["sigma", "rho"]:
-            for mat in self._clear_on_sigma_update + self._clear_on_rho_update:
-                if hasattr(self, mat):
-                    delattr(self, mat)
+        super().__init__(**kwargs)
+        self.conductivity = conductivity
+        self.resistivity = resistivity
+        self.conductivity_map = conductivity_map
+        self.resistivity_map = resistivity_map
 
 
-@with_property_mass_matrices("mu")
-@with_property_mass_matrices("mui")
-class BaseMagneticPDESimulation(BasePDESimulation):
-    mu, muMap, muDeriv = props.Invertible(
-        "Magnetic Permeability (H/m)",
+class BaseMagneticSimulation(BaseSimulation):
+    conductivity, conductivity_map, _con_deriv = props.Invertible(
+        "Electrical conductivity (S/m)"
     )
-    mui, muiMap, muiDeriv = props.Invertible("Inverse Magnetic Permeability (m/H)")
-    props.Reciprocal(mu, mui)
+    resistivity, resistivity_map, _res_deriv = props.Invertible(
+        "Electrical resistivity (Ohm m)"
+    )
+    props.Reciprocal(conductivity, resistivity)
 
-    def __init__(self, mesh, mu=mu_0, muMap=None, mui=None, muiMap=None, **kwargs):
-        super().__init__(mesh=mesh, **kwargs)
-        self.mu = mu
-        self.mui = mui
-        self.muMap = muMap
-        self.muiMap = muiMap
+    def __init__(
+        self,
+        conductivity=None,
+        conductivity_map=None,
+        resistivity=None,
+        resistivity_map=None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.conductivity = conductivity
+        self.resistivity = resistivity
+        self.conductivity_map = conductivity_map
+        self.resistivity_map = resistivity_map
 
-    def __setattr__(self, name, value):
-        super().__setattr__(name, value)
-        if name in ["mu", "mui"]:
-            for mat in self._clear_on_mu_update + self._clear_on_mui_update:
-                if hasattr(self, mat):
-                    delattr(self, mat)
 
-    @property
-    def deleteTheseOnModelUpdate(self):
-        """
-        items to be deleted if the model for Magnetic Permeability is updated
-        """
-        toDelete = super().deleteTheseOnModelUpdate
-        if self.muMap is not None or self.muiMap is not None:
-            toDelete = toDelete + self._clear_on_mu_update + self._clear_on_mui_update
-        return toDelete
+class BaseElectricalPDESimulation(BasePDESimulation, BaseElectricalSimulation):
+    pass
+
+
+class BaseMagneticPDESimulation(BasePDESimulation, BaseElectricalSimulation):
+    pass

--- a/simpeg/electromagnetics/base.py
+++ b/simpeg/electromagnetics/base.py
@@ -1,3 +1,6 @@
+import warnings
+
+from ..base.pde_simulation import BaseElectricalSimulation, BaseMagneticSimulation
 from ..survey import BaseSrc
 from ..utils import Zero, validate_type
 from ..base import BaseElectricalPDESimulation, BaseMagneticPDESimulation
@@ -12,36 +15,22 @@ __all__ = ["BaseEMSimulation", "BaseEMSrc"]
 ###############################################################################
 
 
-class BaseEMSimulation(BaseElectricalPDESimulation, BaseMagneticPDESimulation):
+class BaseEMSimulation(BaseElectricalSimulation, BaseMagneticSimulation):
     """Base electromagnetic simulation class"""
 
-    def __init__(self, mesh, storeInnerProduct=True, **kwargs):
+    def __init__(self, mesh, **kwargs):
         super().__init__(mesh=mesh, **kwargs)
-        self.storeInnerProduct = storeInnerProduct
+        if kwargs.pop('storeInnerProductMatrices', None) is not None:
+            warnings.warn('storeInnerProductMatrices was unused and is now deprecated.')
 
-    @property
-    def storeInnerProduct(self):
-        """Whether to store inner product matrices
 
-        Returns
-        -------
-        bool
-        """
-        return self._storeInnerProduct
+class BaseEMPDESimulation(BaseElectricalPDESimulation, BaseMagneticPDESimulation):
+    """Base electromagnetic simulation class"""
 
-    @storeInnerProduct.setter
-    def storeInnerProduct(self, value):
-        self._storeInnerProduct = validate_type("storeInnerProduct", value, bool)
-
-    ####################################################
-    # Make A Symmetric
-    ####################################################
-    @property
-    def _makeASymmetric(self):
-        if getattr(self, "__makeASymmetric", None) is None:
-            self.__makeASymmetric = True
-        return self.__makeASymmetric
-
+    def __init__(self, mesh, survey, **kwargs):
+        super().__init__(mesh=mesh, survey=survey, **kwargs)
+        if kwargs.pop('storeInnerProductMatrices', None) is not None:
+            warnings.warn('storeInnerProductMatrices was unused and is now deprecated.')
 
 ###############################################################################
 #                                                                             #

--- a/simpeg/electromagnetics/base_1d.py
+++ b/simpeg/electromagnetics/base_1d.py
@@ -5,6 +5,7 @@ import numpy as np
 from scipy import sparse as sp
 from scipy.special import roots_legendre
 
+from .base import BaseEMSimulation
 from ..simulation import BaseSimulation
 
 # from .time_domain.sources import MagDipole as t_MagDipole, CircularLoop as t_CircularLoop
@@ -35,7 +36,7 @@ for filter_name in libdlf.hankel.__all__:
 ###############################################################################
 
 
-class BaseEM1DSimulation(BaseSimulation):
+class BaseEM1DSimulation(BaseEMSimulation):
     """
     Base simulation class for simulating the EM response over a 1D layered Earth
     for a single sounding. The simulation computes the fields by solving the
@@ -46,21 +47,20 @@ class BaseEM1DSimulation(BaseSimulation):
     _formulation = "1D"
     _coefficients_set = False
 
-    # Properties for electrical conductivity/resistivity
-    sigma, sigmaMap, sigmaDeriv = props.Invertible(
-        "Electrical conductivity at infinite frequency (S/m)"
-    )
-    rho, rhoMap, rhoDeriv = props.Invertible("Electrical resistivity (Ohm m)")
-    props.Reciprocal(sigma, rho)
 
+    # Additional Invertible properties
+    h, hMap, hDeriv = props.Invertible("Receiver Height (m), h > 0")
+
+    thicknesses, thicknessesMap, thicknessesDeriv = props.Invertible(
+        "layer thicknesses (m)"
+    )
+
+
+    # Additional properties in forward modeling
     eta = props.PhysicalProperty("Intrinsic chargeability (V/V), 0 <= eta < 1")
     tau = props.PhysicalProperty("Time constant for Cole-Cole model (s)")
     c = props.PhysicalProperty("Frequency Dependency for Cole-Cole model, 0 < c < 1")
 
-    # Properties for magnetic susceptibility
-    mu, muMap, muDeriv = props.Invertible(
-        "Magnetic permeability at infinite frequency (SI)"
-    )
     dchi = props.PhysicalProperty(
         "DC magnetic susceptibility for viscous remanent magnetization contribution (SI)"
     )
@@ -70,24 +70,10 @@ class BaseEM1DSimulation(BaseSimulation):
     tau2 = props.PhysicalProperty(
         "Upper bound for log-uniform distribution of time-relaxation constants for viscous remanent magnetization (s)"
     )
-
-    # Additional properties
-    h, hMap, hDeriv = props.Invertible("Receiver Height (m), h > 0")
-
-    thicknesses, thicknessesMap, thicknessesDeriv = props.Invertible(
-        "layer thicknesses (m)"
-    )
-
     def __init__(
         self,
-        sigma=None,
-        sigmaMap=None,
-        rho=None,
-        rhoMap=None,
         thicknesses=None,
         thicknessesMap=None,
-        mu=mu_0,
-        muMap=None,
         h=None,
         hMap=None,
         eta=0.0,
@@ -103,12 +89,6 @@ class BaseEM1DSimulation(BaseSimulation):
         **kwargs,
     ):
         super().__init__(mesh=None, **kwargs)
-        self.sigma = sigma
-        self.rho = rho
-        self.sigmaMap = sigmaMap
-        self.rhoMap = rhoMap
-        self.mu = mu
-        self.muMap = muMap
         self.h = h
         self.hMap = hMap
         if thicknesses is None:
@@ -576,11 +556,11 @@ class BaseEM1DSimulation(BaseSimulation):
         self._W = self._W.tocsr()
 
     @property
-    def deleteTheseOnModelUpdate(self):
-        toDelete = super().deleteTheseOnModelUpdate
+    def _delete_on_model_change(self):
+        to_delete = super()._delete_on_model_change
         if self.fix_Jmatrix is False:
-            toDelete += ["_J", "_gtgdiag"]
-        return toDelete
+            to_delete += ["_J", "_gtgdiag"]
+        return to_delete
 
     def depth_of_investigation_christiansen_2012(self, std, thres_hold=0.8):
         pred = self.survey._pred.copy()

--- a/simpeg/electromagnetics/frequency_domain/simulation.py
+++ b/simpeg/electromagnetics/frequency_domain/simulation.py
@@ -486,7 +486,7 @@ class BaseFDEMSimulation(BaseEMSimulation):
         return s_m, s_e
 
     @property
-    def deleteTheseOnModelUpdate(self):
+    def _delete_on_model_change(self):
         """List of model-dependent attributes to clean upon model update.
 
         Some of the FDEM simulation's attributes are model-dependent. This property specifies
@@ -497,7 +497,7 @@ class BaseFDEMSimulation(BaseEMSimulation):
         list of str
             List of the model-dependent attributes to clean upon model update.
         """
-        toDelete = super().deleteTheseOnModelUpdate
+        toDelete = super()._delete_on_model_change
         return toDelete + ["_Jmatrix", "_gtgdiag"]
 
 

--- a/simpeg/electromagnetics/natural_source/simulation.py
+++ b/simpeg/electromagnetics/natural_source/simulation.py
@@ -474,8 +474,8 @@ class Simulation2DElectricField(BaseFDEMSimulation):
         return self._boundary_fields
 
     @property
-    def deleteTheseOnModelUpdate(self):
-        items = super().deleteTheseOnModelUpdate
+    def _delete_on_model_change(self):
+        items = super()._delete_on_model_change
         items.append("_boundary_fields")
         return items
 
@@ -696,8 +696,8 @@ class Simulation2DMagneticField(BaseFDEMSimulation):
         return self._boundary_fields
 
     @property
-    def deleteTheseOnModelUpdate(self):
-        items = super().deleteTheseOnModelUpdate
+    def _delete_on_model_change(self):
+        items = super()._delete_on_model_change
         items.append("_boundary_fields")
         return items
 

--- a/simpeg/electromagnetics/natural_source/simulation_1d.py
+++ b/simpeg/electromagnetics/natural_source/simulation_1d.py
@@ -352,8 +352,8 @@ class Simulation1DRecursive(BaseSimulation):
         return JTvec
 
     @property
-    def deleteTheseOnModelUpdate(self):
-        toDelete = super().deleteTheseOnModelUpdate
+    def _delete_on_model_change(self):
+        toDelete = super()._delete_on_model_change
         if self.fix_Jmatrix:
             return toDelete
         else:

--- a/simpeg/electromagnetics/static/induced_polarization/simulation.py
+++ b/simpeg/electromagnetics/static/induced_polarization/simulation.py
@@ -132,7 +132,7 @@ class BaseIPSimulation(BasePDESimulation):
         return super().Jtvec(m, v * self._scale, f)
 
     @property
-    def deleteTheseOnModelUpdate(self):
+    def _delete_on_model_change(self):
         toDelete = []
         return toDelete
 

--- a/simpeg/electromagnetics/static/resistivity/simulation.py
+++ b/simpeg/electromagnetics/static/resistivity/simulation.py
@@ -284,8 +284,8 @@ class BaseDCSimulation(BaseElectricalPDESimulation):
         return self._q
 
     @property
-    def deleteTheseOnModelUpdate(self):
-        toDelete = super().deleteTheseOnModelUpdate
+    def _delete_on_model_change(self):
+        toDelete = super()._delete_on_model_change
         return toDelete + ["_Jmatrix", "_gtgdiag"]
 
     def _mini_survey_data(self, d_mini):

--- a/simpeg/electromagnetics/static/resistivity/simulation_1d.py
+++ b/simpeg/electromagnetics/static/resistivity/simulation_1d.py
@@ -340,8 +340,8 @@ class Simulation1DLayers(BaseSimulation):
         return self.getJ(m, f=f).T @ v
 
     @property
-    def deleteTheseOnModelUpdate(self):
-        to_delete = super().deleteTheseOnModelUpdate
+    def _delete_on_model_change(self):
+        to_delete = super()._delete_on_model_change
         if not self.fix_Jmatrix:
             to_delete = to_delete + ["_Jmatrix"]
         return to_delete

--- a/simpeg/electromagnetics/static/resistivity/simulation_2d.py
+++ b/simpeg/electromagnetics/static/resistivity/simulation_2d.py
@@ -435,8 +435,8 @@ class BaseDCSimulation2D(BaseElectricalPDESimulation):
         return q
 
     @property
-    def deleteTheseOnModelUpdate(self):
-        toDelete = super().deleteTheseOnModelUpdate
+    def _delete_on_model_change(self):
+        toDelete = super()._delete_on_model_change
         if self.fix_Jmatrix:
             return toDelete
         return toDelete + ["_Jmatrix"]

--- a/simpeg/electromagnetics/static/self_potential/simulation.py
+++ b/simpeg/electromagnetics/static/self_potential/simulation.py
@@ -78,10 +78,10 @@ class Simulation3DCellCentered(dc.Simulation3DCellCentered):
         return self._Mcc @ (self.qDeriv @ v)
 
     @property
-    def deleteTheseOnModelUpdate(self):
+    def _delete_on_model_change(self):
         # When enabling resistivity derivatives, uncomment these lines
         # if self.rhoMap is not None:
-        #     return super().deleteTheseOnModelUpdate
+        #     return super()._delete_on_model_change
         if self.storeJ and self.qMap is not None and not self.qMap.is_linear:
             return ["_Jmatrix", "_gtgdiag"]
         return []

--- a/simpeg/electromagnetics/static/self_potential/simulation.py
+++ b/simpeg/electromagnetics/static/self_potential/simulation.py
@@ -70,12 +70,12 @@ class Simulation3DCellCentered(dc.Simulation3DCellCentered):
         self.qMap = qMap
 
     def getRHS(self):
-        return self.Vol @ self.q
+        return self._Mcc @ self.q
 
     def getRHSDeriv(self, source, v, adjoint=False):
         if adjoint:
-            return self.qDeriv.T @ (self.Vol @ v)
-        return self.Vol @ (self.qDeriv @ v)
+            return self.qDeriv.T @ (self._Mcc @ v)
+        return self._Mcc @ (self.qDeriv @ v)
 
     @property
     def deleteTheseOnModelUpdate(self):

--- a/simpeg/electromagnetics/static/spectral_induced_polarization/simulation.py
+++ b/simpeg/electromagnetics/static/spectral_induced_polarization/simulation.py
@@ -603,7 +603,7 @@ class BaseSIPSimulation(BaseIPSimulation):
             return Jtv
 
     @property
-    def deleteTheseOnModelUpdate(self):
+    def _delete_on_model_change(self):
         toDelete = [
             "_etaDeriv_store",
             "_tauiDeriv_store",

--- a/simpeg/inverse_problem.py
+++ b/simpeg/inverse_problem.py
@@ -144,7 +144,7 @@ class BaseInvProblem:
         self._opt = validate_type("opt", value, Minimize, cast=False)
 
     @property
-    def deleteTheseOnModelUpdate(self):
+    def _delete_on_model_change(self):
         """A list of properties stored on this object to delete when the model is updated
 
         Returns
@@ -170,7 +170,7 @@ class BaseInvProblem:
             value = validate_ndarray_with_shape(
                 "model", value, shape=[("*",), ("*", "*")], dtype=None
             )
-        for prop in self.deleteTheseOnModelUpdate:
+        for prop in self._delete_on_model_change:
             if hasattr(self, prop):
                 delattr(self, prop)
         self._model = value

--- a/simpeg/meta/simulation.py
+++ b/simpeg/meta/simulation.py
@@ -325,8 +325,8 @@ class MetaSimulation(BaseSimulation):
         return self._jtjdiag
 
     @property
-    def deleteTheseOnModelUpdate(self):
-        return super().deleteTheseOnModelUpdate + ["_jtjdiag"]
+    def _delete_on_model_change(self):
+        return super()._delete_on_model_change + ["_jtjdiag"]
 
 
 class SumMetaSimulation(MetaSimulation):

--- a/simpeg/potential_fields/base.py
+++ b/simpeg/potential_fields/base.py
@@ -8,7 +8,7 @@ from scipy.sparse import csr_matrix as csr
 
 from simpeg.utils import mkvc
 
-from ..simulation import LinearSimulation
+from ..simulation import BaseLinearSimulation
 from ..utils import validate_active_indices, validate_integer, validate_string
 from ..utils.code_utils import deprecate_property
 
@@ -24,7 +24,7 @@ except ImportError:
 ###############################################################################
 
 
-class BasePFSimulation(LinearSimulation):
+class BasePFSimulation(BaseLinearSimulation):
     r"""Base class for potential field simulations that use integral formulations.
 
     For integral formulations, the forward simulation for a set of voxel cells

--- a/simpeg/potential_fields/gravity/simulation.py
+++ b/simpeg/potential_fields/gravity/simulation.py
@@ -211,7 +211,7 @@ class Simulation3DIntegral(BasePFSimulation):
                 self._sensitivity_gravity = _sensitivity_gravity_serial
                 self._forward_gravity = _forward_gravity_serial
 
-    def fields(self, m):
+    def dpred(self, m, f=None):
         """
         Forward model the gravity field of the mesh on the receivers in the survey
 

--- a/simpeg/potential_fields/gravity/simulation.py
+++ b/simpeg/potential_fields/gravity/simulation.py
@@ -652,7 +652,7 @@ class Simulation3DDifferential(BasePDESimulation):
 
     def getRHS(self):
         """Return right-hand side for the linear system"""
-        Mc = self.Mcc
+        Mc = self._Mcc
         rho = self.rho
         return -Mc * rho
 

--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -682,8 +682,8 @@ class Simulation3DIntegral(BasePFSimulation):
         )
 
     @property
-    def deleteTheseOnModelUpdate(self):
-        deletes = super().deleteTheseOnModelUpdate
+    def _delete_on_model_change(self):
+        deletes = super()._delete_on_model_change
         if self.is_amplitude_data:
             deletes = deletes + ["_gtg_diagonal", "_ampDeriv"]
         return deletes

--- a/simpeg/simulation.py
+++ b/simpeg/simulation.py
@@ -4,10 +4,10 @@ Define simulation classes.
 
 import os
 import inspect
+
 import numpy as np
 import warnings
 
-from discretize.base import BaseMesh
 from discretize import TensorMesh
 from discretize.utils import unpack_widths, sdiag, mkvc
 
@@ -51,19 +51,8 @@ class BaseSimulation(props.HasModel):
 
     Parameters
     ----------
-    mesh : discretize.base.BaseMesh, optional
-        Mesh on which the forward problem is discretized.
     survey : simpeg.survey.BaseSurvey, optional
         The survey for the simulation.
-    solver : None or pymatsolver.base.Base, optional
-        Numerical solver used to solve the forward problem. If ``None``,
-        an appropriate solver specific to the simulation class is set by default.
-    solver_opts : dict, optional
-        Solver-specific parameters. If ``None``, default parameters are used for
-        the solver set by ``solver``. Otherwise, the ``dict`` must contain appropriate
-        pairs of keyword arguments and parameter values for the solver. Please visit
-        `pymatsolver <https://pymatsolver.readthedocs.io/en/latest/>`__ to learn more
-        about solvers and their parameters.
     sensitivity_path : str, optional
         Path to directory where sensitivity file is stored.
     counter : None or simpeg.utils.Counter
@@ -76,21 +65,13 @@ class BaseSimulation(props.HasModel):
 
     def __init__(
         self,
-        mesh=None,
         survey=None,
-        solver=None,
-        solver_opts=None,
         sensitivity_path=None,
         counter=None,
         verbose=False,
         **kwargs,
     ):
-        self.mesh = mesh
         self.survey = survey
-        self.solver = solver
-        if solver_opts is None:
-            solver_opts = {}
-        self.solver_opts = solver_opts
         if sensitivity_path is None:
             sensitivity_path = os.path.join(".", "sensitivity")
         self.sensitivity_path = sensitivity_path
@@ -100,25 +81,6 @@ class BaseSimulation(props.HasModel):
         self._uuid = uuid.uuid4()
 
         super().__init__(**kwargs)
-
-    @property
-    def mesh(self):
-        """Mesh for the simulation.
-
-        For more on meshes, visit :py:class:`discretize.base.BaseMesh`.
-
-        Returns
-        -------
-        discretize.base.BaseMesh
-            Mesh on which the forward problem is discretized.
-        """
-        return self._mesh
-
-    @mesh.setter
-    def mesh(self, value):
-        if value is not None:
-            value = validate_type("mesh", value, BaseMesh, cast=False)
-        self._mesh = value
 
     @property
     def survey(self):

--- a/simpeg/survey.py
+++ b/simpeg/survey.py
@@ -574,3 +574,11 @@ class BaseTimeSurvey(BaseSurvey):
                     rx_times.append(receiver.times)
             self._unique_times = np.unique(np.hstack(rx_times))
         return self._unique_times
+
+
+class SimpleSurvey(BaseSurvey):
+
+    def __init__(self, n_data, **kwargs):
+        self._vnD = np.array([n_data])
+        source_list = kwargs.pop("source_list", [])
+        super().__init__(source_list=source_list, **kwargs)

--- a/tests/base/test_mass_matrices.py
+++ b/tests/base/test_mass_matrices.py
@@ -28,11 +28,11 @@ class SimpleSim(BasePDESimulation):
         self.muMap = muMap
 
     @property
-    def deleteTheseOnModelUpdate(self):
+    def _delete_on_model_change(self):
         """
         matrices to be deleted if the model for conductivity/resistivity is updated
         """
-        toDelete = super().deleteTheseOnModelUpdate
+        toDelete = super()._delete_on_model_change
         if self.sigmaMap is not None or self.rhoMap is not None:
             toDelete = toDelete + self._clear_on_sigma_update
         return toDelete

--- a/tests/em/static/test_SPjvecjtvecadj.py
+++ b/tests/em/static/test_SPjvecjtvecadj.py
@@ -114,12 +114,12 @@ def test_clears():
     # set qMap as a non-linear map to make sure it adds the correct
     # items to be cleared on model update
     sim.qMap = maps.IdentityMap()
-    assert sim.deleteTheseOnModelUpdate == []
+    assert sim._delete_on_model_change == []
     assert sim.clean_on_model_update == []
 
     sim.storeJ = True
     sim.qMap = maps.ExpMap()
-    assert sim.deleteTheseOnModelUpdate == ["_Jmatrix", "_gtgdiag"]
+    assert sim._delete_on_model_change == ["_Jmatrix", "_gtgdiag"]
     assert sim.clean_on_model_update == []
 
 


### PR DESCRIPTION
#### Summary
Started working on cleaning up public attributes of simulations. Making most things private, as well as changing `BaseSimulation` into a abstract base class as well. This is very much a work in progress (and I have disabled most tests for now).

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
Addresses #1429

#### What does this implement/fix?
The public namespace of most `Simulation` classes is extremely cluttered. This is a work in progress to de-clutter them, making many of the internal public methods private.

#### Additional information
This is very much a work in progress, and I am open to changing more (or less) items to private methods.

Right now I was focusing on at least privatizing the mass matrices for each simulation. I think a good path forward for this is to do pull requests onto this branch for intermediate items.
