### PR TITLE
Tutorial notebook FDEM: Only calculate response for a single frequency

### DIFF
--- a/tutorials/07-fdem/plot_fwd_3_fem_3d.py
+++ b/tutorials/07-fdem/plot_fwd_3_fem_3d.py
@@ -69,7 +69,7 @@ topo_xyz = np.c_[mkvc(xx), mkvc(yy), mkvc(zz)]
 #
 
 # Frequencies being predicted
-frequencies = [100, 500, 2500]
+frequencies = [100]
 
 # Defining transmitter locations
 N = 9
@@ -257,7 +257,7 @@ plot2Ddata(
     clim=(-v_max, v_max),
     contourOpts={"cmap": "bwr"},
 )
-ax1.set_title("Re[$B_z$] at 100 Hz")
+ax1.set_title(f"Re[$B_z$] at {frequencies[frequencies_index]} Hz")
 
 ax2 = fig.add_axes([0.41, 0.05, 0.02, 0.9])
 norm = mpl.colors.Normalize(vmin=-v_max, vmax=v_max)
@@ -277,7 +277,7 @@ plot2Ddata(
     clim=(-v_max, v_max),
     contourOpts={"cmap": "bwr"},
 )
-ax1.set_title("Im[$B_z$] at 100 Hz")
+ax1.set_title(f"Im[$B_z$] at {frequencies[frequencies_index]} Hz")
 
 ax2 = fig.add_axes([0.91, 0.05, 0.02, 0.9])
 norm = mpl.colors.Normalize(vmin=-v_max, vmax=v_max)


### PR DESCRIPTION
<!-- 
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing/pull-requests.html

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary

Updates the tutorial notebook for frequency-domain electromagnetics tutorial notebook "3D Forward Simulation on a Tree Mesh," to correctly only calculate response for a single frequency.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue

None.

#### What does this implement/fix?

This PR makes a small change to the frequency-domain electromagnetics tutorial notebook, for the "3D Forward Simulation on a Tree Mesh" example, i.e.:

https://docs.simpeg.xyz/latest/content/tutorials/07-fdem/plot_fwd_3_fem_3d.html

The notebook says:

> To save time, we will only compute the response for a single frequency.

https://github.com/simpeg/simpeg/blob/50b79e287227e965cd3ca22ff297615e74d50a28/tutorials/07-fdem/plot_fwd_3_fem_3d.py#L66-L68

However, I noticed that responses were actually being calculated for 3 frequencies:

https://github.com/simpeg/simpeg/blob/50b79e287227e965cd3ca22ff297615e74d50a28/tutorials/07-fdem/plot_fwd_3_fem_3d.py#L72

My change alters the frequency line to specify the intended single frequency. This removes unnecessary computation (on my laptop, it speeds up the execution of the notebook x3).

https://github.com/williamjsdavis/simpeg/blob/dd6c79a1ddc578e8342bca72d91d06e177d8be2a/tutorials/07-fdem/plot_fwd_3_fem_3d.py#L72

I also change the definition of axes titles of the final plot, from:

https://github.com/simpeg/simpeg/blob/50b79e287227e965cd3ca22ff297615e74d50a28/tutorials/07-fdem/plot_fwd_3_fem_3d.py#L260

https://github.com/simpeg/simpeg/blob/50b79e287227e965cd3ca22ff297615e74d50a28/tutorials/07-fdem/plot_fwd_3_fem_3d.py#L280

... so now the titles display the referenced frequency, in case the user changes the defined frequency back on line 72.

https://github.com/williamjsdavis/simpeg/blob/dd6c79a1ddc578e8342bca72d91d06e177d8be2a/tutorials/07-fdem/plot_fwd_3_fem_3d.py#L260

https://github.com/williamjsdavis/simpeg/blob/dd6c79a1ddc578e8342bca72d91d06e177d8be2a/tutorials/07-fdem/plot_fwd_3_fem_3d.py#L280

#### Additional information

None
