### PR TITLE
Improve dot products in `PGIsmallness.__call__` and update docstring

### DIFF
--- a/simpeg/regularization/pgi.py
+++ b/simpeg/regularization/pgi.py
@@ -574,7 +574,8 @@ class PGIsmallness(Smallness):
             ) and not self.non_linear_relationships:
                 r = np.zeros_like(r0)
                 for i in range(self.gmm.n_components):
-                    r[membership == i] = r0[membership == i] * self.gmm.precisions_[i].T
+                    selection = membership == i
+                    r[selection] = r0[selection] * self.gmm.precisions_[i].T
                 r = mkvc(r)
 
             else:

--- a/simpeg/regularization/pgi.py
+++ b/simpeg/regularization/pgi.py
@@ -600,8 +600,9 @@ class PGIsmallness(Smallness):
                     r0 = (self.W * (mkvc(dm))).reshape(dm.shape, order="F")
                     r = np.zeros_like(r0)
                     for i in range(self.gmm.n_components):
-                        r[membership == i] = (
-                            self.gmm.precisions_[i] @ r0[membership == i].T
+                        selection = membership == i
+                        r[selection] = (
+                            self.gmm.precisions_[i] @ r0[selection].T
                         ).T
                     r = mkvc(r)
             return 2 * mkvc(mD.T * (self.W.T * r))

--- a/simpeg/regularization/pgi.py
+++ b/simpeg/regularization/pgi.py
@@ -601,9 +601,7 @@ class PGIsmallness(Smallness):
                     r = np.zeros_like(r0)
                     for i in range(self.gmm.n_components):
                         selection = membership == i
-                        r[selection] = (
-                            self.gmm.precisions_[i] @ r0[selection].T
-                        ).T
+                        r[selection] = (self.gmm.precisions_[i] @ r0[selection].T).T
                     r = mkvc(r)
             return 2 * mkvc(mD.T * (self.W.T * r))
 


### PR DESCRIPTION

#### Summary
Change the `__call__` method in PGI smallness to avoid for loops through numpy arrays. Fix the docstring to reflect that physical properties can still be correlated if `approx_eval=True` and `approx_gradient=True`.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
