### PR TITLE
Use zizmor to lint GitHub Actions workflows

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,35 @@
+# Lint GitHub Actions for common security issues using zizmor.
+# Docs: https://woodruffw.github.io/zizmor
+
+name: lint-actions
+
+# Only run on PRs and the main branch.
+# Pushes to branches will only trigger a run when a PR is opened.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install zizmor
+        run: python install zizmor
+
+      - name: List installed packages
+        run: python -m pip freeze
+
+      - name: Lint GitHub Actions
+        run: make check-actions

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 STYLE_CHECK_FILES = simpeg examples tutorials tests
+GITHUB_ACTIONS=.github/workflows
 
-.PHONY: help docs check black flake
+.PHONY: help docs clean check black flake flake-all zizmor
 
 help:
 	@echo "Commands:"
 	@echo ""
-	@echo "  check       run code style and quality checks (black and flake8)"
-	@echo "  black       checks code style with black"
-	@echo "  flake       checks code style with flake8"
-	@echo "  flake-all   checks code style with flake8 (full set of rules)"
+	@echo "  check         run code style and quality checks (black and flake8)"
+	@echo "  black         checks code style with black"
+	@echo "  flake         checks code style with flake8"
+	@echo "  flake-all     checks code style with flake8 (full set of rules)"
+	@echo "  check-actions lint GitHub Actions workflows (with zizmor)"
 	@echo ""
 
 docs:
@@ -31,3 +33,6 @@ flake:
 flake-all:
 	flake8 --version
 	flake8 ${FLAKE8_OPTS} --ignore "" ${STYLE_CHECK_FILES}
+
+check-actions:
+	zizmor ${GITHUB_ACTIONS}

--- a/environment.yml
+++ b/environment.yml
@@ -60,3 +60,6 @@ dependencies:
 # recommended
   - jupyter
   - pyvista
+
+  pip:
+    - zizmor # lint GitHub Actions workflows


### PR DESCRIPTION
Make use of `zizmor` to lint the GitHub Actions workflows under the `.github/workflows` directory for common security vulnerabilities. Add a new `check-actions` target in the `Makefile` that runs `zizmor` on those files. Add a new GitHub Action that runs `zizmor`. Add `zizmor` to the `environment.yml`.

#### Summary
<!-- Add a summary of this Pull Request -->

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information

Inspired by: https://github.com/fatiando/community/issues/159
