### PR TITLE
update PGI Example plotting script for deprecated collections

### DIFF
--- a/examples/10-pgi/plot_inv_1_PGI_Linear_1D_joint_WithRelationships.py
+++ b/examples/10-pgi/plot_inv_1_PGI_Linear_1D_joint_WithRelationships.py
@@ -11,6 +11,7 @@ properties are linked by polynomial relationships that change between rock units
 
 import discretize as Mesh
 import matplotlib.pyplot as plt
+import matplotlib.lines as mlines
 import numpy as np
 from simpeg import (
     data_misfit,
@@ -324,10 +325,16 @@ CS = axes[3].contour(
     alpha=0.25,
     cmap="viridis",
 )
-axes[3].scatter(wires.m1 * mcluster_map, wires.m2 * mcluster_map, marker="v")
+cs_proxy = mlines.Line2D([], [], label="True Petrophysical Distribution")
+
+ps = axes[3].scatter(
+    wires.m1 * mcluster_map,
+    wires.m2 * mcluster_map,
+    marker="v",
+    label="Recovered model crossplot",
+)
 axes[3].set_title("Petrophysical Distribution")
-CS.collections[0].set_label("")
-axes[3].legend(["True Petrophysical Distribution", "Recovered model crossplot"])
+axes[3].legend(handles=[cs_proxy, ps])
 axes[3].set_xlabel("Property 1")
 axes[3].set_ylabel("Property 2")
 
@@ -372,7 +379,6 @@ CS = axes[7].contour(
     500,
     cmap="viridis",
     linestyles="--",
-    label="Modeled Petro. Distribution",
 )
 axes[7].scatter(
     wires.m1 * mcluster_no_map,
@@ -380,8 +386,12 @@ axes[7].scatter(
     marker="v",
     label="Recovered model crossplot",
 )
+cs_modeled_proxy = mlines.Line2D(
+    [], [], linestyle="--", label="Modeled Petro. Distribution"
+)
+
 axes[7].set_title("Petrophysical Distribution")
-axes[7].legend()
+axes[7].legend(handles=[cs_proxy, cs_modeled_proxy, ps])
 axes[7].set_xlabel("Property 1")
 axes[7].set_ylabel("Property 2")
 
@@ -423,8 +433,7 @@ CS = axes[11].contour(
 )
 axes[11].scatter(wires.m1 * mtik, wires.m2 * mtik, marker="v")
 axes[11].set_title("Petro Distribution")
-CS.collections[0].set_label("")
-axes[11].legend(["True Petro Distribution", "Recovered model crossplot"])
+axes[11].legend(handles=[cs_proxy, ps])
 axes[11].set_xlabel("Property 1")
 axes[11].set_ylabel("Property 2")
 plt.subplots_adjust(wspace=0.3, hspace=0.3, top=0.85)


### PR DESCRIPTION
#### Summary
Updates the PGI plotting example for matplotlib 3.10 removals.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.