### PR TITLE
Set `permissions` in Actions to avoid zizmor's `excessive-permissions`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,14 +36,14 @@ name : Reviewdog PR Annotations
 #
 on: [pull_request_target] # zizmor: ignore[dangerous-triggers]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   flake8:
     runs-on: ubuntu-latest
     name: Flake8 check
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout target repository source
         uses: actions/checkout@v4
@@ -77,6 +77,10 @@ jobs:
   black:
     name: Black check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout target repository source
         uses: actions/checkout@v4

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,6 +36,10 @@ name : Reviewdog PR Annotations
 #
 on: [pull_request_target] # zizmor: ignore[dangerous-triggers]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   flake8:
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/simpeg/foobar.py
+++ b/simpeg/foobar.py
@@ -1,9 +1,0 @@
-def f(x):
-    # black should complain about the spaces between the pow operator
-    return x ** 2
-
-
-def g(x, y):
-    # flake8 should complain about unused variable
-    z = x == y
-    return x + y

--- a/simpeg/foobar.py
+++ b/simpeg/foobar.py
@@ -1,0 +1,9 @@
+def f(x):
+    # black should complain about the spaces between the pow operator
+    return x ** 2
+
+
+def g(x, y):
+    # flake8 should complain about unused variable
+    z = x == y
+    return x + y


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Set `permissions` in Action workflows to solve zizmor's complains about excessive permissions for the `GITHUB_TOKEN`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information

Some references:

* [zizmor docs for the `excessive-permissions` audit rule](https://woodruffw.github.io/zizmor/audits/#excessive-permissions)
* [Defining access for the GITHUB_TOKEN permissions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#defining-access-for-the-github_token-permissions)
* [Controlling permissions for `GITHUB_TOKEN`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token)