### PR TITLE
Fix for removed quadrature function on new scipy versions

### DIFF
--- a/simpeg/electromagnetics/utils/waveform_utils.py
+++ b/simpeg/electromagnetics/utils/waveform_utils.py
@@ -119,6 +119,6 @@ def convolve_with_waveform(func, waveform, times, fargs=None, fkwargs=None):
             # just do not evaluate the integral at negative times...
             a = np.maximum(a, 0.0)
             b = np.maximum(b, 0.0)
-            val, _ = integrate.quadrature(integral, a, b, tol=0.0, maxiter=500, args=t)
+            val = integrate.quad(integral, a, b, epsabs=0.0, limit=500, args=t)[0]
             out[it] -= val
     return out


### PR DESCRIPTION
#### Summary
The function `scipy.integrate.quadrature` was removed in scipy v1.15.0 in favor of `scipy.integrate.quad`. This function is available in 1.8 so no need to update the minimum required scipy version.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.
