### PR TITLE
Minor improvements to UpdateIRLS stopping criteria

### DIFF
--- a/simpeg/directives/_regularization.py
+++ b/simpeg/directives/_regularization.py
@@ -410,15 +410,13 @@ class UpdateIRLS(InversionDirective):
             else np.inf
         )
 
-        # Get target chi factor minus current chi factor
-        chi_factor_diff = 1.0 - self.invProb.phi_d / self.misfit_from_chi_factor(
-            self.chifact_target
-        )
-
+        # Get misfit_ratio as: 1 - (phi_d / phi_d_star)
+        phi_d_star = self.misfit_from_chi_factor(self.chifact_target)
+        misfit_ratio = 1.0 - self.invProb.phi_d / phi_d_star
         if (
             f_change < self.f_min_change
             and self.metrics.irls_iteration_count > 1
-            and (0 <= chi_factor_diff < self.misfit_tolerance)
+            and (0 <= misfit_ratio < self.misfit_tolerance)
         ):
             if self.verbose:
                 print("Minimum decrease in regularization. End of IRLS")

--- a/simpeg/directives/_regularization.py
+++ b/simpeg/directives/_regularization.py
@@ -403,17 +403,22 @@ class UpdateIRLS(InversionDirective):
                 )
             return True
 
-        # Check if the function has changed enough
-        f_change = np.abs(self.metrics.f_old - phim_new) / (self.metrics.f_old + 1e-12)
+        # Get how much the regularization has changed from previous value
+        f_change = (
+            np.abs(self.metrics.f_old - phim_new) / self.metrics.f_old
+            if self.metrics.f_old != 0.0
+            else np.inf
+        )
+
+        # Get target chi factor minus current chi factor
+        chi_factor_diff = 1.0 - self.invProb.phi_d / self.misfit_from_chi_factor(
+            self.chifact_target
+        )
 
         if (
             f_change < self.f_min_change
             and self.metrics.irls_iteration_count > 1
-            and np.abs(
-                1.0
-                - self.invProb.phi_d / self.misfit_from_chi_factor(self.chifact_target)
-            )
-            < self.misfit_tolerance
+            and (0 < chi_factor_diff < self.misfit_tolerance)
         ):
             if self.verbose:
                 print("Minimum decrease in regularization. End of IRLS")

--- a/simpeg/directives/_regularization.py
+++ b/simpeg/directives/_regularization.py
@@ -410,9 +410,10 @@ class UpdateIRLS(InversionDirective):
             else np.inf
         )
 
-        # Get misfit_ratio as: 1 - (phi_d / phi_d_star)
+        # Get misfit_ratio as: (phi_d - phi_d_star) / phi_d_star
         phi_d_star = self.misfit_from_chi_factor(self.chifact_target)
-        misfit_ratio = 1.0 - self.invProb.phi_d / phi_d_star
+        phi_d = self.invProb.phi_d
+        misfit_ratio = (phi_d - phi_d_star) / phi_d_star
         if (
             f_change < self.f_min_change
             and self.metrics.irls_iteration_count > 1

--- a/simpeg/directives/_regularization.py
+++ b/simpeg/directives/_regularization.py
@@ -418,7 +418,7 @@ class UpdateIRLS(InversionDirective):
         if (
             f_change < self.f_min_change
             and self.metrics.irls_iteration_count > 1
-            and (0 < chi_factor_diff < self.misfit_tolerance)
+            and (0 <= chi_factor_diff < self.misfit_tolerance)
         ):
             if self.verbose:
                 print("Minimum decrease in regularization. End of IRLS")


### PR DESCRIPTION
#### Summary

Apply some minor improvements to the stopping criteria method of `directives.UpdateIRLS`. Ditch the hard-coded `1e-12` value that gets added to the `f_old` to avoid division by zero: assign `f_change` to `np.inf` instead. Remove the absolute value computation while comparing `1 - chi_factor` with the `misfit_tolerance`. This way we avoid ending the inversion with a chi factor above the 1.0.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->


**TODO**

- [ ] Enable users to use `np.abs` when checking for the chifactor within tolerance. Basically, allow users to stop the IRLS even if the chifact is slightly higher than the target. 