### PR TITLE
Fix mappings in regularizations

### DIFF
--- a/tests/base/regularizations/test_mappings.py
+++ b/tests/base/regularizations/test_mappings.py
@@ -1,0 +1,97 @@
+"""
+Test mapping functions in regularizations.
+"""
+
+import numpy as np
+import pytest
+from discretize import TensorMesh
+from scipy.sparse import diags
+
+from simpeg.maps import IdentityMap, LinearMap, LogMap
+from simpeg.regularization import Smallness
+
+
+@pytest.fixture
+def tensor_mesh():
+    hx = [(2.0, 10)]
+    h = [hx, hx, hx]
+    return TensorMesh(h)
+
+
+@pytest.fixture
+def active_cells(tensor_mesh):
+    return np.ones(tensor_mesh.n_cells, dtype=bool)
+
+
+@pytest.fixture
+def model(tensor_mesh):
+    n = tensor_mesh.n_cells
+    return np.linspace(1.0, 51.0, n)
+
+
+@pytest.fixture
+def reference_model(tensor_mesh):
+    return np.full(tensor_mesh.n_cells, fill_value=2.0)
+
+
+class TestMappingInSmallness:
+    """
+    Test mapping in Smallness regularization.
+    """
+
+    def test_default_mapping(self, tensor_mesh, active_cells, model, reference_model):
+        """
+        Test if default mapping is set to IdentityMap.
+        """
+        reg = Smallness(
+            mesh=tensor_mesh, active_cells=active_cells, reference_model=reference_model
+        )
+        assert isinstance(reg.mapping, IdentityMap)
+        volume_weights = tensor_mesh.cell_volumes
+        expected = np.sum(volume_weights * (model - reference_model) ** 2)
+        np.testing.assert_allclose(reg(model), expected)
+        expected_gradient = 2 * volume_weights * (model - reference_model)
+        np.testing.assert_allclose(reg.deriv(model), expected_gradient)
+
+    def test_linear_mapping(self, tensor_mesh, active_cells, model, reference_model):
+        """
+        Test regularization using a linear mapping.
+        """
+        n_active_cells = active_cells.sum()
+        a = np.full(n_active_cells, 3.5)
+        a_matrix = diags(a)
+        linear_mapping = LinearMap(a_matrix, b=None)
+        reg = Smallness(
+            mesh=tensor_mesh,
+            active_cells=active_cells,
+            mapping=linear_mapping,
+            reference_model=reference_model,
+        )
+        assert reg.mapping is linear_mapping
+        volume_weights = tensor_mesh.cell_volumes
+        expected = np.sum(volume_weights * (a * model - a * reference_model) ** 2)
+        np.testing.assert_allclose(reg(model), expected)
+        expected_gradient = 2 * a * volume_weights * (a * model - a * reference_model)
+        np.testing.assert_allclose(reg.deriv(model), expected_gradient)
+
+    def test_nonlinear_mapping(self, tensor_mesh, active_cells, model, reference_model):
+        """
+        Test regularization using a non-linear mapping.
+        """
+        log_mapping = LogMap()
+        reg = Smallness(
+            mesh=tensor_mesh,
+            active_cells=active_cells,
+            mapping=log_mapping,
+            reference_model=reference_model,
+        )
+        assert reg.mapping is log_mapping
+        volume_weights = tensor_mesh.cell_volumes
+        expected = np.sum(
+            volume_weights * (np.log(model) - np.log(reference_model)) ** 2
+        )
+        np.testing.assert_allclose(reg(model), expected)
+        expected_gradient = (
+            2 * (1 / model) * volume_weights * (np.log(model) - np.log(reference_model))
+        )
+        np.testing.assert_allclose(reg.deriv(model), expected_gradient)


### PR DESCRIPTION
#### Summary

Fix how the mapping is being used in `Smallness` regularization: regularize on `mapping(m) - mapping(m_ref)` instead of `mapping(m - m_ref)`. Update the documentation of `Smallness` to include details on how the mapping is being used. Add tests to check this intended behaviour.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
