### PR TITLE
Raise errors if dpred in `BaseDataMisfit` has nans

### DIFF
--- a/simpeg/data_misfit.py
+++ b/simpeg/data_misfit.py
@@ -226,10 +226,10 @@ class BaseDataMisfit(L2ObjectiveFunction):
             The data residual vector.
         """
         dpred = self.simulation.dpred(m, f=f)
-        if np.isnan(dpred).any():
+        if np.isnan(dpred).any() or np.isinf(dpred).any():
             msg = (
                 f"The `{type(self.simulation).__name__}.dpred()` method "
-                "returned an array that contains nan's."
+                "returned an array that contains `nan`s and/or `inf`s."
             )
             raise ValueError(msg)
         return dpred - self.data.dobs

--- a/simpeg/data_misfit.py
+++ b/simpeg/data_misfit.py
@@ -225,15 +225,6 @@ class BaseDataMisfit(L2ObjectiveFunction):
         (n_data, ) numpy.ndarray
             The data residual vector.
         """
-        if self.data is None:
-            msg = (
-                f"Invalid `{type(self).__name__}.data` as None. "
-                "The `data` attribute should be set to a `simpeg.Data` "
-                "before a residual can be calculated"
-            )
-            raise ValueError(msg)
-
-        # Compute and validate dpred
         dpred = self.simulation.dpred(m, f=f)
         if np.isnan(dpred).any():
             msg = (
@@ -241,7 +232,6 @@ class BaseDataMisfit(L2ObjectiveFunction):
                 "returned an array that contain nan's."
             )
             raise ValueError(msg)
-
         return dpred - self.data.dobs
 
 

--- a/simpeg/data_misfit.py
+++ b/simpeg/data_misfit.py
@@ -226,8 +226,23 @@ class BaseDataMisfit(L2ObjectiveFunction):
             The data residual vector.
         """
         if self.data is None:
-            raise Exception("data must be set before a residual can be calculated.")
-        return self.simulation.residual(m, self.data.dobs, f=f)
+            msg = (
+                f"Invalid `{type(self).__name__}.data` as None. "
+                "The `data` attribute should be set to a `simpeg.Data` "
+                "before a residual can be calculated"
+            )
+            raise ValueError(msg)
+
+        # Compute and validate dpred
+        dpred = self.simulation.dpred(m, f=f)
+        if np.isnan(dpred).any():
+            msg = (
+                f"The `{type(self.simulation).__name__}.dpred()` method "
+                "returned an array that contain nan's."
+            )
+            raise ValueError(msg)
+
+        return dpred - self.data.dobs
 
 
 class L2DataMisfit(BaseDataMisfit):

--- a/simpeg/data_misfit.py
+++ b/simpeg/data_misfit.py
@@ -229,7 +229,7 @@ class BaseDataMisfit(L2ObjectiveFunction):
         if np.isnan(dpred).any():
             msg = (
                 f"The `{type(self.simulation).__name__}.dpred()` method "
-                "returned an array that contain nan's."
+                "returned an array that contains nan's."
             )
             raise ValueError(msg)
         return dpred - self.data.dobs

--- a/tests/base/test_data_misfit.py
+++ b/tests/base/test_data_misfit.py
@@ -87,8 +87,8 @@ class MockSimulation(simulation.BaseSimulation):
         return a
 
 
-class TestNaninResidual:
-    """Test errors if the simulation return dpred with nans."""
+class TestNanOrInfInResidual:
+    """Test errors if the simulation return dpred with nans or infs."""
 
     @pytest.fixture
     def n_data(self):

--- a/tests/base/test_data_misfit.py
+++ b/tests/base/test_data_misfit.py
@@ -74,7 +74,7 @@ class DataMisfitTest(unittest.TestCase):
 
 class MockSimulation(simulation.BaseSimulation):
     """
-    Mock simulation class that returns nan's in the dpred array.
+    Mock simulation class that returns nans or infs in the dpred array.
     """
 
     def __init__(self, invalid_value=np.nan):

--- a/tests/base/test_data_misfit.py
+++ b/tests/base/test_data_misfit.py
@@ -101,7 +101,7 @@ class TestNaninResidual:
         data = Data(sample_survey)
         dmisfit = data_misfit.BaseDataMisfit(data, mock_simulation)
         msg = re.escape(
-            "The `MockSimulation.dpred()` method returned an array that contain nan's."
+            "The `MockSimulation.dpred()` method returned an array that contains nan's."
         )
         with pytest.raises(ValueError, match=msg):
             dmisfit.residual(m=None)

--- a/tests/base/test_data_misfit.py
+++ b/tests/base/test_data_misfit.py
@@ -1,3 +1,5 @@
+import re
+import pytest
 import unittest
 
 import numpy as np
@@ -5,6 +7,7 @@ import discretize
 
 from simpeg import maps
 from simpeg import data_misfit, simulation, survey
+from simpeg import Data
 
 
 class DataMisfitTest(unittest.TestCase):
@@ -67,6 +70,41 @@ class DataMisfitTest(unittest.TestCase):
         self.data.relative_error = self.relative
         self.data.noise_floor = self.noise_floor
         self.dmis.test(x=self.model, random_seed=17)
+
+
+class MockSimulation(simulation.BaseSimulation):
+    """
+    Mock simulation class that returns nan's in the dpred array.
+    """
+
+    def dpred(self, m=None, f=None):
+        a = np.arange(4, dtype=np.float64)
+        a[1] = np.nan
+        return a
+
+
+class TestNaninResidual:
+    """Test errors if the simulation return dpred with nans."""
+
+    @pytest.fixture
+    def n_data(self):
+        return 4
+
+    @pytest.fixture
+    def sample_survey(self, n_data):
+        receivers = survey.BaseRx(np.zeros(n_data)[:, np.newaxis])
+        source = survey.BaseSrc([receivers])
+        return survey.BaseSurvey([source])
+
+    def test_error(self, sample_survey):
+        mock_simulation = MockSimulation()
+        data = Data(sample_survey)
+        dmisfit = data_misfit.BaseDataMisfit(data, mock_simulation)
+        msg = re.escape(
+            "The `MockSimulation.dpred()` method returned an array that contain nan's."
+        )
+        with pytest.raises(ValueError, match=msg):
+            dmisfit.residual(m=None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Summary

Make `BaseDataMisfit.residual` to raise an error if the simulation returns an array with `nan`s and/or `inf`s after calling the `dpred` method. Add tests to check if the errors are correctly raised. Remove error in case `BaseDataMisfit.data` is `None`: the `data` setter method doesn't allow `BaseDataMisfit.data` to be `None`, therefore the error will never be raised.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->

TODO:

- [x] raise errors in infs and -infs in dpred as well (not only nans)
