### PR TITLE
Move indexing of flat arrays to Survey classes

### DIFF
--- a/simpeg/data.py
+++ b/simpeg/data.py
@@ -328,12 +328,12 @@ class Data:
     ##########################
 
     def __setitem__(self, key, value):
-        index = self.index_dictionary[key[0]][key[1]]
-        self.dobs[index] = mkvc(value)
+        slice_obj = self.survey.get_slice(*key)
+        self.dobs[slice_obj] = mkvc(value)
 
     def __getitem__(self, key):
-        index = self.index_dictionary[key[0]][key[1]]
-        return self.dobs[index]
+        slice_obj = self.survey.get_slice(*key)
+        return self.dobs[slice_obj]
 
     def tovec(self):
         """Convert observed data to a vector


### PR DESCRIPTION
#### Summary

Add a new `get_slice` method to `BaseSurvey` that mimics the behaviour of indexing `Data` objects. The method returns a `slice` object that can be used to slice flat arrays like data or uncertainty arrays. Optimize the implementation by caching slices rather than Numpy arrays with indices. Add tests for the new method. Use new method in `Data`'s `__getitem__` and `__setitem__` instead of the `indexing_dictionary`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

This PR is part of the process of cleaning up the interface for `Data` objects. Moving the indexing functionalities to the `Survey` classes would allow users to build data arrays by part before having to define the `Data` object in advance. Check meeting notes of 2025-02-26 for more details on this discussion.
