### PR TITLE
Fix redirects links in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -552,7 +552,7 @@ def _get_source_target(old_fname: str) -> tuple[str, str]:
     for old_dir, new_dir in MAPS.items():
         if old_fname.startswith(old_dir):
             source = old_fname.removesuffix(".html")
-            n_parents = len(Path(old_fname).parents)
+            n_parents = len([p for p in Path(old_fname).parents if p != Path(".")])
             target = "../" * n_parents + old_fname.replace(old_dir, new_dir, 1)
             return source, target
     raise ValueError()


### PR DESCRIPTION
#### Summary

Fix the number of `../` should be pre-appended to the target link to generate the right redirect.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
