### PR TITLE
Deprecate `components` in potential field surveys

### DIFF
--- a/simpeg/potential_fields/gravity/survey.py
+++ b/simpeg/potential_fields/gravity/survey.py
@@ -2,6 +2,14 @@ from ...survey import BaseSurvey
 from ...utils.code_utils import validate_type
 from .sources import SourceField
 
+try:
+    from warnings import deprecated
+except ImportError:
+    # Use the deprecated decorator provided by typing_extensions (which
+    # supports older versions of Python) if it cannot be imported from
+    # warnings.
+    from typing_extensions import deprecated
+
 
 class Survey(BaseSurvey):
     """Base Gravity Survey
@@ -75,8 +83,23 @@ class Survey(BaseSurvey):
         return sum(receiver.nD for receiver in self.source_field.receiver_list)
 
     @property
+    @deprecated(
+        "The `components` property is deprecated, "
+        "and will be removed in SimPEG v0.25.0. "
+        "Within a gravity survey, receivers can contain different components. "
+        "Iterate over the sources and receivers in the survey to get "
+        "information about their components.",
+        category=FutureWarning,
+    )
     def components(self):
         """Number of components measured at each receiver.
+
+        .. deprecated:: 0.24.0
+
+            The `components` property is deprecated, and will be removed in
+            SimPEG v0.25.0. Within a gravity survey, receivers can contain
+            different components. Iterate over the sources and receivers in the
+            survey to get information about their components.
 
         Returns
         -------

--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -1629,10 +1629,6 @@ class Simulation3DDifferential(BaseMagneticPDESimulation):
         components = receivers[0].components
         if not all(components == rx.components for rx in receivers):
             raise NotImplementedError()
-
-        # Cast to list so it always return a list of strings
-        if isinstance(components, str):
-            components = list(components)
         return components
 
     def projectFieldsAsVector(self, B):

--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -1621,16 +1621,16 @@ class Simulation3DDifferential(BaseMagneticPDESimulation):
         NotImplementedError
             If any receiver has a different set of components than the rest.
         """
-        receivers = (
-            rx for source in self.survey.source_list for rx in source.receiver_list
-        )
-        rx = next(receivers, None)
-        if rx is None:
+        receivers = self.survey.source_field.receiver_list
+        if not receivers:
             msg = "Found invalid survey without receivers."
             raise ValueError(msg)
-        components = rx.components
+
+        components = receivers[0].components
         if not all(components == rx.components for rx in receivers):
             raise NotImplementedError()
+
+        # Cast to list so it always return a list of strings
         if isinstance(components, str):
             components = list(components)
         return components

--- a/simpeg/potential_fields/magnetics/survey.py
+++ b/simpeg/potential_fields/magnetics/survey.py
@@ -3,6 +3,14 @@ from ...survey import BaseSurvey
 from ...utils.code_utils import validate_type
 from .sources import UniformBackgroundField
 
+try:
+    from warnings import deprecated
+except ImportError:
+    # Use the deprecated decorator provided by typing_extensions (which
+    # supports older versions of Python) if it cannot be imported from
+    # warnings.
+    from typing_extensions import deprecated
+
 
 class Survey(BaseSurvey):
     """Base Magnetics Survey
@@ -69,8 +77,23 @@ class Survey(BaseSurvey):
         return sum(rx.nD for rx in self.source_field.receiver_list)
 
     @property
+    @deprecated(
+        "The `components` property is deprecated, "
+        "and will be removed in SimPEG v0.25.0. "
+        "Within a magnetic survey, receivers can contain different components. "
+        "Iterate over the sources and receivers in the survey to get "
+        "information about their components.",
+        category=FutureWarning,
+    )
     def components(self):
         """Field components
+
+        .. deprecated:: 0.24.0
+
+            The `components` property is deprecated, and will be removed in
+            SimPEG v0.25.0. Within a magnetic survey, receivers can contain
+            different components. Iterate over the sources and receivers in the
+            survey to get information about their components.
 
         Returns
         -------

--- a/tests/pf/test_components.py
+++ b/tests/pf/test_components.py
@@ -166,7 +166,7 @@ class TestMagneticSimulationDifferential:
         Test ``projectFields`` and ``projectFieldsDeriv`` on invalid surveys.
         """
         # Override receivers in simulation's survey
-        if invalid_rx is None:
+        if invalid_rx == "no-rx":
             receivers = None
             msg = re.escape("Found invalid survey without receivers.")
         else:

--- a/tests/pf/test_components.py
+++ b/tests/pf/test_components.py
@@ -1,0 +1,128 @@
+"""
+Test how potential field surveys and simulations access receiver components.
+"""
+
+# Things to test:
+#   - receivers with different components in the same survey
+#       - projectFields
+#       - projectFieldsDeriv
+#       - _get_components
+#   - deprecation error
+
+import re
+import pytest
+import numpy as np
+
+import discretize
+from simpeg import maps
+from simpeg.potential_fields import gravity, magnetics
+
+
+@pytest.fixture
+def receiver_locations():
+    x = np.linspace(-20.0, 20.0, 4)
+    x, y = np.meshgrid(x, x)
+    z = 5.0 * np.ones_like(x)
+    return np.vstack((x.ravel(), y.ravel(), z.ravel())).T
+
+
+@pytest.fixture
+def mesh():
+    dh = 5.0
+    hx = [(dh, 10)]
+    return discretize.TensorMesh([hx, hx, hx], "CCN")
+
+
+class TestComponentsGravitySurvey:
+
+    def test_deprecated_components(self, receiver_locations):
+        """
+        Test FutureError after deprecated ``components`` property.
+        """
+        receivers = gravity.receivers.Point(receiver_locations, components="gz")
+        source_field = gravity.sources.SourceField(receiver_list=[receivers])
+        survey = gravity.survey.Survey(source_field)
+        msg = re.escape("The `components` property is deprecated")
+        with pytest.warns(FutureWarning, match=msg):
+            survey.components
+
+
+class TestComponentsMagneticSurvey:
+
+    def test_deprecated_components(self, receiver_locations):
+        """
+        Test FutureError after deprecated ``components`` property.
+        """
+        receivers = magnetics.receivers.Point(receiver_locations, components="tmi")
+        source_field = magnetics.sources.UniformBackgroundField(
+            receiver_list=[receivers], amplitude=55_000, inclination=12, declination=35
+        )
+        survey = magnetics.survey.Survey(source_field)
+        msg = re.escape("The `components` property is deprecated")
+        with pytest.warns(FutureWarning, match=msg):
+            survey.components
+
+
+class TestComponentsMagneticSimulation:
+
+    def build_simluation_differential(self, mesh, receivers: list | None):
+        """
+        Build a sample simulation object.
+        """
+        source_field = magnetics.sources.UniformBackgroundField(
+            receiver_list=receivers, amplitude=55_000, inclination=12, declination=35
+        )
+        survey = magnetics.survey.Survey(source_field)
+        simulation = magnetics.Simulation3DDifferential(
+            mesh, survey=survey, muMap=maps.IdentityMap(mesh=mesh)
+        )
+        return simulation
+
+    @pytest.mark.parametrize("components", ["tmi", ["bx", "by", "bz"]])
+    def test_get_components(self, mesh, receiver_locations, components):
+        receivers = [
+            magnetics.receivers.Point(receiver_locations, components=components),
+            magnetics.receivers.Point(receiver_locations, components=components),
+        ]
+        simulation = self.build_simluation_differential(mesh, receivers)
+
+        expected = components if isinstance(components, list) else [components]
+        assert expected == simulation._get_components()
+
+    def test_get_components_no_receivers(self, mesh):
+        simulation = self.build_simluation_differential(mesh, receivers=None)
+        msg = re.escape("Found invalid survey without receivers.")
+        with pytest.raises(ValueError, match=msg):
+            simulation._get_components()
+
+    @pytest.mark.parametrize(
+        "method", ["_get_components", "projectFields", "projectFieldsDeriv"]
+    )
+    def test_different_components(self, mesh, receiver_locations, method):
+        """
+        Test NotImplementedError when receivers have different components.
+        """
+        # Define receivers with different components
+        receivers = [
+            magnetics.receivers.Point(receiver_locations, components="tmi"),
+            magnetics.receivers.Point(
+                receiver_locations, components=["bx", "by", "bz"]
+            ),
+        ]
+        simulation = self.build_simluation_differential(mesh, receivers)
+
+        # Compute fields from a random model
+        model = np.random.default_rng(seed=42).uniform(size=mesh.n_cells)
+        fields = simulation.fields(model)
+
+        # Test NotImplementedErrors
+        if method == "_get_components":
+            with pytest.raises(NotImplementedError, match=""):
+                simulation._get_components()
+        else:
+            msg = re.escape(
+                "Found receivers with different set of components in the survey."
+            )
+            method = getattr(simulation, method)
+            with pytest.raises(NotImplementedError, match=msg):
+                method(fields)

--- a/tests/pf/test_components.py
+++ b/tests/pf/test_components.py
@@ -151,7 +151,8 @@ class TestMagneticSimulationDifferential:
             msg = re.escape(
                 "Found invalid survey with receivers that have mixed components."
             )
-        sample_simulation.survey.source_field.receiver_list = receivers
+        # Override private attribute `_receiver_list` to bypass the setter
+        sample_simulation.survey.source_field._receiver_list = receivers
 
         # Try to get components
         with pytest.raises(ValueError, match=msg):
@@ -177,7 +178,8 @@ class TestMagneticSimulationDifferential:
             msg = re.escape(
                 "Found invalid survey with receivers that have mixed components."
             )
-        sample_simulation.survey.source_field.receiver_list = receivers
+        # Override private attribute `_receiver_list` to bypass the setter
+        sample_simulation.survey.source_field._receiver_list = receivers
 
         # Compute fields from a random model
         n_cells = sample_simulation.mesh.n_cells

--- a/tests/pf/test_forward_PFproblem.py
+++ b/tests/pf/test_forward_PFproblem.py
@@ -33,11 +33,11 @@ class MagFwdProblemTests(unittest.TestCase):
         yr = np.linspace(-300, 300, 41)
         X, Y = np.meshgrid(xr, yr)
         Z = np.ones((xr.size, yr.size)) * 150
-        components = ["bx", "by", "bz"]
+        self.components = ["bx", "by", "bz"]
         self.xr = xr
         self.yr = yr
         self.rxLoc = np.c_[utils.mkvc(X), utils.mkvc(Y), utils.mkvc(Z)]
-        receivers = mag.Point(self.rxLoc, components=components)
+        receivers = mag.Point(self.rxLoc, components=self.components)
         srcField = mag.UniformBackgroundField(
             receiver_list=[receivers],
             amplitude=Btot,
@@ -70,7 +70,7 @@ class MagFwdProblemTests(unittest.TestCase):
             "secondary",
         )
 
-        n_obs, n_comp = self.rxLoc.shape[0], len(self.survey.components)
+        n_obs, n_comp = self.rxLoc.shape[0], len(self.components)
         dx, dy, dz = dpred.reshape(n_comp, n_obs)
 
         err_x = np.linalg.norm(dx - bxa) / np.linalg.norm(bxa)


### PR DESCRIPTION
#### Summary

Deprecate the `components` properties in potential field surveys. These properties weren't returning the expected output. Since receivers within the same survey can have different components, returning the components of the first receiver is misleading.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Fixes #1609

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
