### PR TITLE
Improve variable names in gravity test

### DIFF
--- a/tests/pf/test_forward_Grav_Linear.py
+++ b/tests/pf/test_forward_Grav_Linear.py
@@ -562,7 +562,7 @@ class TestJacobianGravity(BaseFixtures):
         model = mapping * densities
 
         vector = np.random.default_rng(seed=42).uniform(size=densities.size)
-        dpred = simulation.Jvec(model, vector)
+        result = simulation.Jvec(model, vector)
 
         identity_map = type(mapping) is maps.IdentityMap
         expected_jac = (
@@ -570,10 +570,10 @@ class TestJacobianGravity(BaseFixtures):
             if identity_map
             else simulation.G @ aslinearoperator(mapping.deriv(model))
         )
-        expected_dpred = expected_jac @ vector
+        expected = expected_jac @ vector
 
-        atol = np.max(np.abs(expected_dpred)) * self.atol_ratio
-        np.testing.assert_allclose(dpred, expected_dpred, atol=atol)
+        atol = np.max(np.abs(expected)) * self.atol_ratio
+        np.testing.assert_allclose(result, expected, atol=atol)
 
     @pytest.mark.parametrize(
         ("engine", "store_sensitivities"),


### PR DESCRIPTION
#### Summary

Avoid using `dpred` in the gravity test that might lead to confusion. When the mapping is not a linear function, the `J @ m` is just a first order approximation of the forward model and not equal to the `dpred`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
