### PR TITLE
Fix definition of model in gravity J-related tests

### DIFF
--- a/tests/pf/test_forward_Grav_Linear.py
+++ b/tests/pf/test_forward_Grav_Linear.py
@@ -484,7 +484,9 @@ class TestJacobianGravity(BaseFixtures):
             store_sensitivities="ram",
             engine=engine,
         )
-        model = mapping * densities
+        is_identity_map = type(mapping) is maps.IdentityMap
+        model = densities if is_identity_map else np.log(densities)
+
         jac = simulation.getJ(model)
         assert isinstance(jac, np.ndarray)
         # With an identity mapping, the jacobian should be the same as G.
@@ -506,7 +508,9 @@ class TestJacobianGravity(BaseFixtures):
             store_sensitivities="forward_only",
             engine="choclo",
         )
-        model = mapping * densities
+        is_identity_map = type(mapping) is maps.IdentityMap
+        model = densities if is_identity_map else np.log(densities)
+
         jac = simulation.getJ(model)
         assert isinstance(jac, LinearOperator)
         result = jac @ model
@@ -526,7 +530,9 @@ class TestJacobianGravity(BaseFixtures):
             store_sensitivities="forward_only",
             engine="geoana",
         )
-        model = mapping * densities
+        is_identity_map = type(mapping) is maps.IdentityMap
+        model = densities if is_identity_map else np.log(densities)
+
         msg = re.escape(
             "Accessing matrix G with "
             'store_sensitivities="forward_only" and engine="geoana" '
@@ -559,7 +565,8 @@ class TestJacobianGravity(BaseFixtures):
             store_sensitivities=store_sensitivities,
             engine=engine,
         )
-        model = mapping * densities
+        is_identity_map = type(mapping) is maps.IdentityMap
+        model = densities if is_identity_map else np.log(densities)
 
         vector = np.random.default_rng(seed=42).uniform(size=densities.size)
         dpred = simulation.Jvec(model, vector)
@@ -599,7 +606,8 @@ class TestJacobianGravity(BaseFixtures):
             store_sensitivities=store_sensitivities,
             engine=engine,
         )
-        model = mapping * densities
+        is_identity_map = type(mapping) is maps.IdentityMap
+        model = densities if is_identity_map else np.log(densities)
 
         vector = np.random.default_rng(seed=42).uniform(size=survey.nD)
         result = simulation.Jtvec(model, vector)
@@ -648,8 +656,11 @@ class TestJacobianGravity(BaseFixtures):
                 vector_size = survey.nD
             case _:
                 raise ValueError(f"Invalid method '{method}'")
+
+        is_identity_map = type(mapping) is maps.IdentityMap
+        model = densities if is_identity_map else np.log(densities)
+
         vector = np.random.default_rng(seed=42).uniform(size=vector_size)
-        model = mapping * densities
         result_lo = getattr(simulation_lo, method)(model, vector)
         result_ram = getattr(simulation_ram, method)(model, vector)
         atol = np.max(np.abs(result_ram)) * self.atol_ratio
@@ -668,7 +679,9 @@ class TestJacobianGravity(BaseFixtures):
             store_sensitivities="ram",
             engine=engine,
         )
-        model = mapping * densities
+        is_identity_map = type(mapping) is maps.IdentityMap
+        model = densities if is_identity_map else np.log(densities)
+
         kwargs = {}
         if weights:
             w_matrix = diags(np.random.default_rng(seed=42).uniform(size=survey.nD))
@@ -711,7 +724,9 @@ class TestJacobianGravity(BaseFixtures):
             )
             for store in ("forward_only", "ram")
         )
-        model = mapping * densities
+        is_identity_map = type(mapping) is maps.IdentityMap
+        model = densities if is_identity_map else np.log(densities)
+
         kwargs = {}
         if weights:
             weights = np.random.default_rng(seed=42).uniform(size=survey.nD)
@@ -735,7 +750,9 @@ class TestJacobianGravity(BaseFixtures):
             engine=engine,
         )
         # Get diagonal of J.T @ J without any weight
-        model = mapping * densities
+        is_identity_map = type(mapping) is maps.IdentityMap
+        model = densities if is_identity_map else np.log(densities)
+
         jtj_diagonal_1 = simulation.getJtJdiag(model)
         assert hasattr(simulation, "_gtg_diagonal")
         assert hasattr(simulation, "_weights_sha256")


### PR DESCRIPTION
#### Summary

Fix of the definition of `model` in J-related tests for the gravity simulation: use the inverse of the mapping to define the `model` based on the sample `densities`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
