### PR TITLE
Fix bug on magnetic simulation `nD` property

### DIFF
--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -324,8 +324,7 @@ class Simulation3DIntegral(BasePFSimulation):
         """
         Number of data
         """
-        self._nD = self.survey.receiver_locations.shape[0]
-
+        self._nD = self.survey.nD if not self.is_amplitude_data else self.survey.nD // 3
         return self._nD
 
     @property


### PR DESCRIPTION
#### Summary

Make use of `survey.nD` instead of just using the total number of receiver locations. Add the special case where `is_amplitude_data` is `True`. Add tests.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
