### PR TITLE
Configure zizmor to pin reviewdog actions with tags

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,17 @@
+# Zizmor configuration
+# --------------------
+#
+# This file configures zizmor. This is not a workflow that gets run in GitHub
+# Actions.
+#
+# References: https://woodruffw.github.io/zizmor/configuration
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Mimic default behaviour: official actions can get pinned by tag.
+        actions/*: ref-pin
+        # Allow to use tags to pin reviewdog actions.
+        reviewdog/action-black: ref-pin
+        reviewdog/action-flake8: ref-pin


### PR DESCRIPTION
#### Summary

Add a new `.github/zizmor.yml` configuration file that allows zizmor to use tags to pin the two reviewdog actions we currently use: `reviewdog/action-flake8` and `reviewdog/action-black`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
