### PR TITLE
Raise NotImplementedError on getJ for NSEM 1D simulations

### DIFF
--- a/simpeg/electromagnetics/natural_source/simulation.py
+++ b/simpeg/electromagnetics/natural_source/simulation.py
@@ -110,6 +110,23 @@ class Simulation1DElectricField(BaseFDEMSimulation):
             freq, u, v, adjoint
         )
 
+    def getJ(self, m, f=None):
+        r"""Generate the full sensitivity matrix.
+
+        .. important::
+
+            This method hasn't been implemented yet for this class.
+
+        Raises
+        -------
+        NotImplementedError
+        """
+        msg = (
+            "The getJ method hasn't been implemented for the "
+            f"{type(self).__name__} yet."
+        )
+        raise NotImplementedError(msg)
+
 
 class Simulation1DMagneticField(BaseFDEMSimulation):
     """
@@ -171,6 +188,23 @@ class Simulation1DMagneticField(BaseFDEMSimulation):
         return self.getADeriv_rho(freq, u, v, adjoint) + self.getADeriv_mu(
             freq, u, v, adjoint
         )
+
+    def getJ(self, m, f=None):
+        r"""Generate the full sensitivity matrix.
+
+        .. important::
+
+            This method hasn't been implemented yet for this class.
+
+        Raises
+        -------
+        NotImplementedError
+        """
+        msg = (
+            "The getJ method hasn't been implemented for the "
+            f"{type(self).__name__} yet."
+        )
+        raise NotImplementedError(msg)
 
 
 class Simulation1DPrimarySecondary(Simulation1DElectricField):

--- a/tests/em/nsem/forward/test_getJ_not_implemented.py
+++ b/tests/em/nsem/forward/test_getJ_not_implemented.py
@@ -1,0 +1,50 @@
+"""
+Test NotImplementedError on getJ for NSEM 1D finite volume simulations.
+"""
+
+import pytest
+import numpy as np
+import discretize
+from simpeg import maps
+from simpeg.electromagnetics import natural_source as nsem
+
+
+@pytest.fixture
+def mesh():
+    csz = 100
+    nc = 300
+    npad = 30
+    pf = 1.2
+    mesh = discretize.TensorMesh([[(csz, npad, -pf), (csz, nc), (csz, npad)]], "N")
+    mesh.x0 = np.r_[-mesh.h[0][:-npad].sum()]
+    return mesh
+
+
+@pytest.fixture
+def survey():
+    frequencies = np.logspace(-2, 1, 30)
+    receiver = nsem.receivers.Impedance(
+        [[0]], orientation="xy", component="apparent_resistivity"
+    )
+    sources = [nsem.sources.Planewave([receiver], frequency=f) for f in frequencies]
+    survey = nsem.survey.Survey(sources)
+    return survey
+
+
+@pytest.mark.parametrize(
+    "simulation_class", [nsem.Simulation1DElectricField, nsem.Simulation1DMagneticField]
+)
+def test_getJ_not_implemented(mesh, survey, simulation_class):
+    """
+    Test NotImplementedError on getJ for NSEM 1D simulations.
+    """
+    mapping = maps.IdentityMap()
+    simulation = simulation_class(
+        mesh=mesh,
+        survey=survey,
+        sigmaMap=mapping,
+    )
+    model = np.ones(survey.nD)
+    msg = "The getJ method hasn't been implemented"
+    with pytest.raises(NotImplementedError, match=msg):
+        simulation.getJ(model)


### PR DESCRIPTION
#### Summary

Overwrite the `getJ` method of the NSEM 1D finite volume simulations so they raise a `NotImplementedError`. Add tests for the new errors.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue

First step towards addressing #1541.

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
