### PR TITLE
Standardize output directives and make the more reliable

### DIFF
--- a/simpeg/directives/directives.py
+++ b/simpeg/directives/directives.py
@@ -1839,7 +1839,7 @@ class SaveModelEveryIteration(SaveEveryIteration):
 
     @property
     def file_abs_path(self):
-        return self.directory / self._time_iter_file_name.with_suffix("npy")
+        return self.directory / self._time_iter_file_name.with_suffix(".npy")
 
     def endIter(self):
         self._mkdir_and_check_output_file(should_exist=False)
@@ -2101,7 +2101,7 @@ class SaveOutputDictEveryIteration(SaveEveryIteration):
     @property
     def file_abs_path(self):
         if self.on_disk:
-            return self.directory / self._time_iter_file_name.with_suffix("npz")
+            return self.directory / self._time_iter_file_name.with_suffix(".npz")
 
     def initialize(self):
         super(


### PR DESCRIPTION
#### Summary
Fixes and standardizes the `SaveEveryIteration` child directives. They now reliably use the passed `directory` argument, and this also adds a few more safeguards to the file writes.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### What does this implement/fix?
The `SaveEveryIteration` directives were not very reliable... Some always output the file to the current working directory, some had odd file names, They all had different parameter names which effectively controlled the same thing. Also there were potentially erroring write outs (if a user deleted an output directory in between iterations).

* This unifies the different parameter names that were controlling if the directive saved information to disk, now `on_disk` instead of `save_txt` and `saveOnDisk`.
* Uses the more portable `pathlib.Path` to describe the output directory and full file path.
* Notifies the user of the absolute file path where the output will be stored.
* Uses a bit more inheritance to reduce duplicated code.

Will add tests soon
