### PR TITLE
Improved right-hand side for NSEM primary secondary 

### DIFF
--- a/simpeg/electromagnetics/natural_source/sources.py
+++ b/simpeg/electromagnetics/natural_source/sources.py
@@ -3,7 +3,7 @@ import numpy as np
 from ... import maps
 from ..frequency_domain.sources import BaseFDEMSrc
 from ..utils import omega
-from .utils.source_utils import homo1DModelSource
+from .utils.source_utils import homo1DModelSource, primary_e_1d_solution, project_e_1d_to_e_primary
 import discretize
 from discretize.utils import volume_average
 
@@ -30,7 +30,7 @@ class Planewave(BaseFDEMSrc):
 
 
 # Need to implement such that it works for all dims.
-# Rename to be more descriptive
+# Rename to be more descriptive (I suggest PlanewavePrimarySecondary)
 class PlanewaveXYPrimary(Planewave):
     """
     NSEM planewave source for both polarizations (x and y)
@@ -106,9 +106,13 @@ class PlanewaveXYPrimary(Planewave):
         """
         if self._ePrimary is None:
             sigma_1d, _ = self._get_sigmas(simulation)
-            self._ePrimary = homo1DModelSource(
-                simulation.mesh, self.frequency, sigma_1d
+            # self._ePrimary = homo1DModelSource(
+            #     simulation.mesh, self.frequency, sigma_1d
+            # )
+            e_1d = primary_e_1d_solution(
+                simulation.mesh, sigma_1d, self.frequency
             )
+            self._ePrimary = project_e_1d_to_e_primary(simulation.mesh, e_1d)
         return self._ePrimary
 
     def bPrimary(self, simulation):


### PR DESCRIPTION
#### Summary
This PR is meant to improve the 3D NSEM primary secondary formulation. More suitable boundary conditions are implemented when solving the 1D problem that is used as the primary solution on the 3D mesh.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### What does this implement/fix?
The boundary conditions that are currently used to solve the 1D problem for the 3D primary-secondary simulation are sub-optimal. As a result, one needs to pad out excessively when using the 3D primary secondary formulation to obtain numerically accurate results. Here, more suitable boundary conditions are implemented to solve the 1D problem.
