### PR TITLE
Clean up Numba functions for potential field simulations

### DIFF
--- a/simpeg/potential_fields/gravity/_numba_functions.py
+++ b/simpeg/potential_fields/gravity/_numba_functions.py
@@ -639,20 +639,30 @@ def _sensitivity_gravity_2d_mesh(
             )
 
 
-# Define decorated versions of these functions
-_sensitivity_gravity_parallel = jit(nopython=True, parallel=True)(_sensitivity_gravity)
-_sensitivity_gravity_serial = jit(nopython=True, parallel=False)(_sensitivity_gravity)
-_forward_gravity_parallel = jit(nopython=True, parallel=True)(_forward_gravity)
-_forward_gravity_serial = jit(nopython=True, parallel=False)(_forward_gravity)
-_forward_gravity_2d_mesh_serial = jit(nopython=True, parallel=False)(
-    _forward_gravity_2d_mesh
-)
-_forward_gravity_2d_mesh_parallel = jit(nopython=True, parallel=True)(
-    _forward_gravity_2d_mesh
-)
-_sensitivity_gravity_2d_mesh_serial = jit(nopython=True, parallel=False)(
-    _sensitivity_gravity_2d_mesh
-)
-_sensitivity_gravity_2d_mesh_parallel = jit(nopython=True, parallel=True)(
-    _sensitivity_gravity_2d_mesh
-)
+# Define a dictionary with decorated versions of the Numba functions.
+NUMBA_FUNCTIONS = {
+    "sensitivity": {
+        parallel: jit(nopython=True, parallel=parallel)(_sensitivity_gravity)
+        for parallel in (True, False)
+    },
+    "forward": {
+        parallel: jit(nopython=True, parallel=True)(_forward_gravity)
+        for parallel in (True, False)
+    },
+    "sensitivity_2d_mesh": {
+        parallel: jit(nopython=True, parallel=True)(_sensitivity_gravity_2d_mesh)
+        for parallel in (True, False)
+    },
+    "forward_2d_mesh": {
+        parallel: jit(nopython=True, parallel=True)(_forward_gravity_2d_mesh)
+        for parallel in (True, False)
+    },
+    "diagonal_gtg": {
+        False: _diagonal_G_T_dot_G_serial,
+        True: _diagonal_G_T_dot_G_parallel,
+    },
+    "gt_dot_v": {
+        False: _sensitivity_gravity_t_dot_v_serial,
+        True: _sensitivity_gravity_t_dot_v_parallel,
+    },
+}

--- a/simpeg/potential_fields/gravity/_numba_functions.py
+++ b/simpeg/potential_fields/gravity/_numba_functions.py
@@ -646,15 +646,15 @@ NUMBA_FUNCTIONS = {
         for parallel in (True, False)
     },
     "forward": {
-        parallel: jit(nopython=True, parallel=True)(_forward_gravity)
+        parallel: jit(nopython=True, parallel=parallel)(_forward_gravity)
         for parallel in (True, False)
     },
     "sensitivity_2d_mesh": {
-        parallel: jit(nopython=True, parallel=True)(_sensitivity_gravity_2d_mesh)
+        parallel: jit(nopython=True, parallel=parallel)(_sensitivity_gravity_2d_mesh)
         for parallel in (True, False)
     },
     "forward_2d_mesh": {
-        parallel: jit(nopython=True, parallel=True)(_forward_gravity_2d_mesh)
+        parallel: jit(nopython=True, parallel=parallel)(_forward_gravity_2d_mesh)
         for parallel in (True, False)
     },
     "diagonal_gtg": {

--- a/simpeg/potential_fields/gravity/simulation.py
+++ b/simpeg/potential_fields/gravity/simulation.py
@@ -815,7 +815,7 @@ class SimulationEquivalentSourceLayer(
             n_components = len(components)
             n_elements = n_components * receivers.shape[0]
             for i, component in enumerate(components):
-                forward_func = CHOCLO_FORWARD_FUNCS[component]
+                choclo_forward_func = CHOCLO_FORWARD_FUNCS[component]
                 conversion_factor = _get_conversion_factor(component)
                 vector_slice = slice(
                     index_offset + i, index_offset + n_elements, n_components
@@ -827,7 +827,7 @@ class SimulationEquivalentSourceLayer(
                     self.cell_z_bottom,
                     densities,
                     fields[vector_slice],
-                    forward_func,
+                    choclo_forward_func,
                     conversion_factor,
                 )
             index_offset += n_elements
@@ -863,7 +863,7 @@ class SimulationEquivalentSourceLayer(
             n_components = len(components)
             n_rows = n_components * receivers.shape[0]
             for i, component in enumerate(components):
-                forward_func = CHOCLO_FORWARD_FUNCS[component]
+                choclo_forward_func = CHOCLO_FORWARD_FUNCS[component]
                 conversion_factor = _get_conversion_factor(component)
                 matrix_slice = slice(
                     index_offset + i, index_offset + n_rows, n_components
@@ -874,7 +874,7 @@ class SimulationEquivalentSourceLayer(
                     self.cell_z_top,
                     self.cell_z_bottom,
                     sensitivity_matrix[matrix_slice, :],
-                    forward_func,
+                    choclo_forward_func,
                     conversion_factor,
                 )
             index_offset += n_rows

--- a/simpeg/potential_fields/magnetics/_numba_functions.py
+++ b/simpeg/potential_fields/magnetics/_numba_functions.py
@@ -3292,51 +3292,93 @@ def _sensitivity_tmi_derivative_2d_mesh(
                 )
 
 
-_sensitivity_tmi_serial = jit(nopython=True, parallel=False)(_sensitivity_tmi)
-_sensitivity_tmi_parallel = jit(nopython=True, parallel=True)(_sensitivity_tmi)
-_forward_tmi_serial = jit(nopython=True, parallel=False)(_forward_tmi)
-_forward_tmi_parallel = jit(nopython=True, parallel=True)(_forward_tmi)
-_forward_mag_serial = jit(nopython=True, parallel=False)(_forward_mag)
-_forward_mag_parallel = jit(nopython=True, parallel=True)(_forward_mag)
-_sensitivity_mag_serial = jit(nopython=True, parallel=False)(_sensitivity_mag)
-_sensitivity_mag_parallel = jit(nopython=True, parallel=True)(_sensitivity_mag)
-_forward_tmi_derivative_parallel = jit(nopython=True, parallel=True)(
-    _forward_tmi_derivative
-)
-_forward_tmi_derivative_serial = jit(nopython=True, parallel=False)(
-    _forward_tmi_derivative
-)
-_sensitivity_tmi_derivative_parallel = jit(nopython=True, parallel=True)(
-    _sensitivity_tmi_derivative
-)
-_sensitivity_tmi_derivative_serial = jit(nopython=True, parallel=False)(
-    _sensitivity_tmi_derivative
-)
-_forward_tmi_2d_mesh_serial = jit(nopython=True, parallel=False)(_forward_tmi_2d_mesh)
-_forward_tmi_2d_mesh_parallel = jit(nopython=True, parallel=True)(_forward_tmi_2d_mesh)
-_forward_mag_2d_mesh_serial = jit(nopython=True, parallel=False)(_forward_mag_2d_mesh)
-_forward_mag_2d_mesh_parallel = jit(nopython=True, parallel=True)(_forward_mag_2d_mesh)
-_forward_tmi_derivative_2d_mesh_serial = jit(nopython=True, parallel=False)(
-    _forward_tmi_derivative_2d_mesh
-)
-_forward_tmi_derivative_2d_mesh_parallel = jit(nopython=True, parallel=True)(
-    _forward_tmi_derivative_2d_mesh
-)
-_sensitivity_mag_2d_mesh_serial = jit(nopython=True, parallel=False)(
-    _sensitivity_mag_2d_mesh
-)
-_sensitivity_mag_2d_mesh_parallel = jit(nopython=True, parallel=True)(
-    _sensitivity_mag_2d_mesh
-)
-_sensitivity_tmi_2d_mesh_serial = jit(nopython=True, parallel=False)(
-    _sensitivity_tmi_2d_mesh
-)
-_sensitivity_tmi_2d_mesh_parallel = jit(nopython=True, parallel=True)(
-    _sensitivity_tmi_2d_mesh
-)
-_sensitivity_tmi_derivative_2d_mesh_serial = jit(nopython=True, parallel=False)(
-    _sensitivity_tmi_derivative_2d_mesh
-)
-_sensitivity_tmi_derivative_2d_mesh_parallel = jit(nopython=True, parallel=True)(
-    _sensitivity_tmi_derivative_2d_mesh
-)
+NUMBA_FUNCTIONS = {
+    "forward": {
+        "tmi": {
+            parallel: jit(nopython=True, parallel=parallel)(_forward_tmi)
+            for parallel in (True, False)
+        },
+        "magnetic_component": {
+            parallel: jit(nopython=True, parallel=parallel)(_forward_mag)
+            for parallel in (True, False)
+        },
+        "tmi_derivative": {
+            parallel: jit(nopython=True, parallel=parallel)(_forward_tmi_derivative)
+            for parallel in (True, False)
+        },
+    },
+    "sensitivity": {
+        "tmi": {
+            parallel: jit(nopython=True, parallel=parallel)(_sensitivity_tmi)
+            for parallel in (True, False)
+        },
+        "magnetic_component": {
+            parallel: jit(nopython=True, parallel=parallel)(_sensitivity_mag)
+            for parallel in (True, False)
+        },
+        "tmi_derivative": {
+            parallel: jit(nopython=True, parallel=parallel)(_sensitivity_tmi_derivative)
+            for parallel in (True, False)
+        },
+    },
+    "forward_2d_mesh": {
+        "tmi": {
+            parallel: jit(nopython=True, parallel=parallel)(_forward_tmi_2d_mesh)
+            for parallel in (True, False)
+        },
+        "magnetic_component": {
+            parallel: jit(nopython=True, parallel=parallel)(_forward_mag_2d_mesh)
+            for parallel in (True, False)
+        },
+        "tmi_derivative": {
+            parallel: jit(nopython=True, parallel=parallel)(
+                _forward_tmi_derivative_2d_mesh
+            )
+            for parallel in (True, False)
+        },
+    },
+    "sensitivity_2d_mesh": {
+        "tmi": {
+            parallel: jit(nopython=True, parallel=parallel)(_sensitivity_tmi_2d_mesh)
+            for parallel in (True, False)
+        },
+        "magnetic_component": {
+            parallel: jit(nopython=True, parallel=parallel)(_sensitivity_mag_2d_mesh)
+            for parallel in (True, False)
+        },
+        "tmi_derivative": {
+            parallel: jit(nopython=True, parallel=parallel)(
+                _sensitivity_tmi_derivative_2d_mesh
+            )
+            for parallel in (True, False)
+        },
+    },
+    "gt_dot_v": {
+        "tmi": {
+            False: _tmi_sensitivity_t_dot_v_serial,
+            True: _tmi_sensitivity_t_dot_v_parallel,
+        },
+        "magnetic_component": {
+            False: _mag_sensitivity_t_dot_v_serial,
+            True: _mag_sensitivity_t_dot_v_parallel,
+        },
+        "tmi_derivative": {
+            False: _tmi_derivative_sensitivity_t_dot_v_serial,
+            True: _tmi_derivative_sensitivity_t_dot_v_parallel,
+        },
+    },
+    "diagonal_gtg": {
+        "tmi": {
+            False: _diagonal_G_T_dot_G_tmi_serial,
+            True: _diagonal_G_T_dot_G_tmi_parallel,
+        },
+        "magnetic_component": {
+            False: _diagonal_G_T_dot_G_mag_serial,
+            True: _diagonal_G_T_dot_G_mag_parallel,
+        },
+        "tmi_derivative": {
+            False: _diagonal_G_T_dot_G_tmi_deriv_serial,
+            True: _diagonal_G_T_dot_G_tmi_deriv_serial,
+        },
+    },
+}

--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -25,45 +25,7 @@ from ..base import BaseEquivalentSourceLayerSimulation, BasePFSimulation
 from .analytics import CongruousMagBC
 from .survey import Survey
 
-from ._numba_functions import (
-    choclo,
-    _sensitivity_tmi_parallel,
-    _sensitivity_tmi_serial,
-    _sensitivity_mag_parallel,
-    _sensitivity_mag_serial,
-    _forward_tmi_parallel,
-    _forward_tmi_serial,
-    _forward_mag_parallel,
-    _forward_mag_serial,
-    _forward_tmi_2d_mesh_serial,
-    _forward_tmi_2d_mesh_parallel,
-    _forward_mag_2d_mesh_serial,
-    _forward_mag_2d_mesh_parallel,
-    _forward_tmi_derivative_2d_mesh_serial,
-    _forward_tmi_derivative_2d_mesh_parallel,
-    _sensitivity_mag_2d_mesh_serial,
-    _sensitivity_mag_2d_mesh_parallel,
-    _sensitivity_tmi_2d_mesh_serial,
-    _sensitivity_tmi_2d_mesh_parallel,
-    _forward_tmi_derivative_parallel,
-    _forward_tmi_derivative_serial,
-    _sensitivity_tmi_derivative_parallel,
-    _sensitivity_tmi_derivative_serial,
-    _sensitivity_tmi_derivative_2d_mesh_serial,
-    _sensitivity_tmi_derivative_2d_mesh_parallel,
-    _mag_sensitivity_t_dot_v_serial,
-    _mag_sensitivity_t_dot_v_parallel,
-    _tmi_sensitivity_t_dot_v_serial,
-    _tmi_sensitivity_t_dot_v_parallel,
-    _tmi_derivative_sensitivity_t_dot_v_serial,
-    _tmi_derivative_sensitivity_t_dot_v_parallel,
-    _diagonal_G_T_dot_G_mag_serial,
-    _diagonal_G_T_dot_G_mag_parallel,
-    _diagonal_G_T_dot_G_tmi_serial,
-    _diagonal_G_T_dot_G_tmi_parallel,
-    _diagonal_G_T_dot_G_tmi_deriv_serial,
-    _diagonal_G_T_dot_G_tmi_deriv_parallel,
-)
+from ._numba_functions import choclo, NUMBA_FUNCTIONS
 
 if choclo is not None:
     CHOCLO_SUPPORTED_COMPONENTS = {
@@ -233,42 +195,6 @@ class Simulation3DIntegral(BasePFSimulation):
                 stacklevel=1,
             )
             self.n_processes = None
-
-        if self.engine == "choclo":
-            if self.numba_parallel:
-                self._sensitivity_tmi = _sensitivity_tmi_parallel
-                self._sensitivity_mag = _sensitivity_mag_parallel
-                self._forward_tmi = _forward_tmi_parallel
-                self._forward_mag = _forward_mag_parallel
-                self._forward_tmi_derivative = _forward_tmi_derivative_parallel
-                self._sensitivity_tmi_derivative = _sensitivity_tmi_derivative_parallel
-                self._mag_sensitivity_t_dot_v = _mag_sensitivity_t_dot_v_parallel
-                self._tmi_sensitivity_t_dot_v = _tmi_sensitivity_t_dot_v_parallel
-                self._tmi_derivative_sensitivity_t_dot_v = (
-                    _tmi_derivative_sensitivity_t_dot_v_parallel
-                )
-                self._diagonal_G_T_dot_G_mag = _diagonal_G_T_dot_G_mag_parallel
-                self._diagonal_G_T_dot_G_tmi = _diagonal_G_T_dot_G_tmi_parallel
-                self._diagonal_G_T_dot_G_tmi_deriv = (
-                    _diagonal_G_T_dot_G_tmi_deriv_parallel
-                )
-            else:
-                self._sensitivity_tmi = _sensitivity_tmi_serial
-                self._sensitivity_mag = _sensitivity_mag_serial
-                self._forward_tmi = _forward_tmi_serial
-                self._forward_mag = _forward_mag_serial
-                self._forward_tmi_derivative = _forward_tmi_derivative_serial
-                self._sensitivity_tmi_derivative = _sensitivity_tmi_derivative_serial
-                self._mag_sensitivity_t_dot_v = _mag_sensitivity_t_dot_v_serial
-                self._tmi_sensitivity_t_dot_v = _tmi_sensitivity_t_dot_v_serial
-                self._tmi_derivative_sensitivity_t_dot_v = (
-                    _tmi_derivative_sensitivity_t_dot_v_serial
-                )
-                self._diagonal_G_T_dot_G_mag = _diagonal_G_T_dot_G_mag_serial
-                self._diagonal_G_T_dot_G_tmi = _diagonal_G_T_dot_G_tmi_serial
-                self._diagonal_G_T_dot_G_tmi_deriv = (
-                    _diagonal_G_T_dot_G_tmi_deriv_serial
-                )
 
     @property
     def model_type(self):
@@ -956,7 +882,10 @@ class Simulation3DIntegral(BasePFSimulation):
                     index_offset + i, index_offset + n_rows, n_components
                 )
                 if component == "tmi":
-                    self._forward_tmi(
+                    forward_func = NUMBA_FUNCTIONS["forward"]["tmi"][
+                        self.numba_parallel
+                    ]
+                    forward_func(
                         receivers,
                         active_nodes,
                         model,
@@ -970,7 +899,10 @@ class Simulation3DIntegral(BasePFSimulation):
                     kernel_xx, kernel_yy, kernel_zz, kernel_xy, kernel_xz, kernel_yz = (
                         CHOCLO_KERNELS[component]
                     )
-                    self._forward_tmi_derivative(
+                    forward_func = NUMBA_FUNCTIONS["forward"]["tmi_derivative"][
+                        self.numba_parallel
+                    ]
+                    forward_func(
                         receivers,
                         active_nodes,
                         model,
@@ -988,7 +920,10 @@ class Simulation3DIntegral(BasePFSimulation):
                     )
                 else:
                     kernel_x, kernel_y, kernel_z = CHOCLO_KERNELS[component]
-                    self._forward_mag(
+                    forward_func = NUMBA_FUNCTIONS["forward"]["magnetic_component"][
+                        self.numba_parallel
+                    ]
+                    forward_func(
                         receivers,
                         active_nodes,
                         model,
@@ -1047,7 +982,10 @@ class Simulation3DIntegral(BasePFSimulation):
                     index_offset + i, index_offset + n_rows, n_components
                 )
                 if component == "tmi":
-                    self._sensitivity_tmi(
+                    sensitivity_func = NUMBA_FUNCTIONS["sensitivity"]["tmi"][
+                        self.numba_parallel
+                    ]
+                    sensitivity_func(
                         receivers,
                         active_nodes,
                         sensitivity_matrix[matrix_slice, :],
@@ -1057,10 +995,13 @@ class Simulation3DIntegral(BasePFSimulation):
                         scalar_model,
                     )
                 elif component in ("tmi_x", "tmi_y", "tmi_z"):
+                    sensitivity_func = NUMBA_FUNCTIONS["sensitivity"]["tmi_derivative"][
+                        self.numba_parallel
+                    ]
                     kernel_xx, kernel_yy, kernel_zz, kernel_xy, kernel_xz, kernel_yz = (
                         CHOCLO_KERNELS[component]
                     )
-                    self._sensitivity_tmi_derivative(
+                    sensitivity_func(
                         receivers,
                         active_nodes,
                         sensitivity_matrix[matrix_slice, :],
@@ -1076,8 +1017,11 @@ class Simulation3DIntegral(BasePFSimulation):
                         scalar_model,
                     )
                 else:
+                    sensitivity_func = NUMBA_FUNCTIONS["sensitivity"][
+                        "magnetic_component"
+                    ][self.numba_parallel]
                     kernel_x, kernel_y, kernel_z = CHOCLO_KERNELS[component]
-                    self._sensitivity_mag(
+                    sensitivity_func(
                         receivers,
                         active_nodes,
                         sensitivity_matrix[matrix_slice, :],
@@ -1150,7 +1094,10 @@ class Simulation3DIntegral(BasePFSimulation):
                     index_offset + i, index_offset + n_rows, n_components
                 )
                 if component == "tmi":
-                    self._tmi_sensitivity_t_dot_v(
+                    gt_dot_v_func = NUMBA_FUNCTIONS["gt_dot_v"]["tmi"][
+                        self.numba_parallel
+                    ]
+                    gt_dot_v_func(
                         receivers,
                         active_nodes,
                         active_cell_nodes,
@@ -1164,7 +1111,10 @@ class Simulation3DIntegral(BasePFSimulation):
                     kernel_xx, kernel_yy, kernel_zz, kernel_xy, kernel_xz, kernel_yz = (
                         CHOCLO_KERNELS[component]
                     )
-                    self._tmi_derivative_sensitivity_t_dot_v(
+                    gt_dot_v_func = NUMBA_FUNCTIONS["gt_dot_v"]["tmi_derivative"][
+                        self.numba_parallel
+                    ]
+                    gt_dot_v_func(
                         receivers,
                         active_nodes,
                         active_cell_nodes,
@@ -1182,7 +1132,10 @@ class Simulation3DIntegral(BasePFSimulation):
                     )
                 else:
                     kernel_x, kernel_y, kernel_z = CHOCLO_KERNELS[component]
-                    self._mag_sensitivity_t_dot_v(
+                    gt_dot_v_func = NUMBA_FUNCTIONS["gt_dot_v"]["magnetic_component"][
+                        self.numba_parallel
+                    ]
+                    gt_dot_v_func(
                         receivers,
                         active_nodes,
                         active_cell_nodes,
@@ -1233,7 +1186,10 @@ class Simulation3DIntegral(BasePFSimulation):
                 )
             for component in components:
                 if component == "tmi":
-                    self._diagonal_G_T_dot_G_tmi(
+                    diagonal_gtg_func = NUMBA_FUNCTIONS["diagonal_gtg"]["tmi"][
+                        self.numba_parallel
+                    ]
+                    diagonal_gtg_func(
                         receivers,
                         active_nodes,
                         active_cell_nodes,
@@ -1247,7 +1203,10 @@ class Simulation3DIntegral(BasePFSimulation):
                     kernel_xx, kernel_yy, kernel_zz, kernel_xy, kernel_xz, kernel_yz = (
                         CHOCLO_KERNELS[component]
                     )
-                    self._diagonal_G_T_dot_G_tmi_deriv(
+                    diagonal_gtg_func = NUMBA_FUNCTIONS["diagonal_gtg"][
+                        "tmi_derivative"
+                    ][self.numba_parallel]
+                    diagonal_gtg_func(
                         receivers,
                         active_nodes,
                         active_cell_nodes,
@@ -1265,7 +1224,10 @@ class Simulation3DIntegral(BasePFSimulation):
                     )
                 else:
                     kernel_x, kernel_y, kernel_z = CHOCLO_KERNELS[component]
-                    self._diagonal_G_T_dot_G_mag(
+                    diagonal_gtg_func = NUMBA_FUNCTIONS["diagonal_gtg"][
+                        "magnetic_component"
+                    ][self.numba_parallel]
+                    diagonal_gtg_func(
                         receivers,
                         active_nodes,
                         active_cell_nodes,
@@ -1324,26 +1286,6 @@ class SimulationEquivalentSourceLayer(
             **kwargs,
         )
 
-        if self.engine == "choclo":
-            if self.numba_parallel:
-                self._sensitivity_tmi = _sensitivity_tmi_2d_mesh_parallel
-                self._sensitivity_mag = _sensitivity_mag_2d_mesh_parallel
-                self._forward_tmi = _forward_tmi_2d_mesh_parallel
-                self._forward_mag = _forward_mag_2d_mesh_parallel
-                self._forward_tmi_derivative = _forward_tmi_derivative_2d_mesh_parallel
-                self._sensitivity_tmi_derivative = (
-                    _sensitivity_tmi_derivative_2d_mesh_parallel
-                )
-            else:
-                self._sensitivity_tmi = _sensitivity_tmi_2d_mesh_serial
-                self._sensitivity_mag = _sensitivity_mag_2d_mesh_serial
-                self._forward_tmi = _forward_tmi_2d_mesh_serial
-                self._forward_mag = _forward_mag_2d_mesh_serial
-                self._forward_tmi_derivative = _forward_tmi_derivative_2d_mesh_serial
-                self._sensitivity_tmi_derivative = (
-                    _sensitivity_tmi_derivative_2d_mesh_serial
-                )
-
     def _forward(self, model):
         """
         Forward model the fields of active cells in the mesh on receivers.
@@ -1387,7 +1329,10 @@ class SimulationEquivalentSourceLayer(
                     index_offset + i, index_offset + n_rows, n_components
                 )
                 if component == "tmi":
-                    self._forward_tmi(
+                    forward_func = NUMBA_FUNCTIONS["forward_2d_mesh"]["tmi"][
+                        self.numba_parallel
+                    ]
+                    forward_func(
                         receivers,
                         cells_bounds_active,
                         self.cell_z_top,
@@ -1401,7 +1346,10 @@ class SimulationEquivalentSourceLayer(
                     kernel_xx, kernel_yy, kernel_zz, kernel_xy, kernel_xz, kernel_yz = (
                         CHOCLO_KERNELS[component]
                     )
-                    self._forward_tmi_derivative(
+                    forward_func = NUMBA_FUNCTIONS["forward_2d_mesh"]["tmi_derivative"][
+                        self.numba_parallel
+                    ]
+                    forward_func(
                         receivers,
                         cells_bounds_active,
                         self.cell_z_top,
@@ -1418,8 +1366,11 @@ class SimulationEquivalentSourceLayer(
                         scalar_model,
                     )
                 else:
-                    forward_func = CHOCLO_FORWARD_FUNCS[component]
-                    self._forward_mag(
+                    choclo_forward_func = CHOCLO_FORWARD_FUNCS[component]
+                    forward_func = NUMBA_FUNCTIONS["forward_2d_mesh"][
+                        "magnetic_component"
+                    ][self.numba_parallel]
+                    forward_func(
                         receivers,
                         cells_bounds_active,
                         self.cell_z_top,
@@ -1427,7 +1378,7 @@ class SimulationEquivalentSourceLayer(
                         model,
                         fields[vector_slice],
                         regional_field,
-                        forward_func,
+                        choclo_forward_func,
                         scalar_model,
                     )
             index_offset += n_rows
@@ -1474,7 +1425,10 @@ class SimulationEquivalentSourceLayer(
                     index_offset + i, index_offset + n_rows, n_components
                 )
                 if component == "tmi":
-                    self._sensitivity_tmi(
+                    sensitivity_func = NUMBA_FUNCTIONS["sensitivity_2d_mesh"]["tmi"][
+                        self.numba_parallel
+                    ]
+                    sensitivity_func(
                         receivers,
                         cells_bounds_active,
                         self.cell_z_top,
@@ -1487,7 +1441,10 @@ class SimulationEquivalentSourceLayer(
                     kernel_xx, kernel_yy, kernel_zz, kernel_xy, kernel_xz, kernel_yz = (
                         CHOCLO_KERNELS[component]
                     )
-                    self._sensitivity_tmi_derivative(
+                    sensitivity_func = NUMBA_FUNCTIONS["sensitivity_2d_mesh"][
+                        "tmi_derivative"
+                    ][self.numba_parallel]
+                    sensitivity_func(
                         receivers,
                         cells_bounds_active,
                         self.cell_z_top,
@@ -1504,7 +1461,10 @@ class SimulationEquivalentSourceLayer(
                     )
                 else:
                     kernel_x, kernel_y, kernel_z = CHOCLO_KERNELS[component]
-                    self._sensitivity_mag(
+                    sensitivity_func = NUMBA_FUNCTIONS["sensitivity_2d_mesh"][
+                        "magnetic_component"
+                    ][self.numba_parallel]
+                    sensitivity_func(
                         receivers,
                         cells_bounds_active,
                         self.cell_z_top,

--- a/tests/pf/test_forward_Grav_Linear.py
+++ b/tests/pf/test_forward_Grav_Linear.py
@@ -556,7 +556,9 @@ class TestJacobianGravity(BaseFixtures):
             pytest.param(
                 "geoana",
                 "forward_only",
-                marks=pytest.mark.xfail(reason="not implemented"),
+                marks=pytest.mark.xfail(
+                    raises=NotImplementedError, reason="not implemented"
+                ),
             ),
         ],
     )
@@ -596,7 +598,9 @@ class TestJacobianGravity(BaseFixtures):
             pytest.param(
                 "geoana",
                 "forward_only",
-                marks=pytest.mark.xfail(reason="not implemented"),
+                marks=pytest.mark.xfail(
+                    raises=NotImplementedError, reason="not implemented"
+                ),
             ),
         ],
     )
@@ -631,7 +635,12 @@ class TestJacobianGravity(BaseFixtures):
         "engine",
         [
             "choclo",
-            pytest.param("geoana", marks=pytest.mark.xfail(reason="not implemented")),
+            pytest.param(
+                "geoana",
+                marks=pytest.mark.xfail(
+                    raises=NotImplementedError, reason="not implemented"
+                ),
+            ),
         ],
     )
     @pytest.mark.parametrize("method", ["Jvec", "Jtvec"])
@@ -707,7 +716,12 @@ class TestJacobianGravity(BaseFixtures):
         "engine",
         [
             "choclo",
-            pytest.param("geoana", marks=pytest.mark.xfail(reason="not implemented")),
+            pytest.param(
+                "geoana",
+                marks=pytest.mark.xfail(
+                    raises=NotImplementedError, reason="not implemented"
+                ),
+            ),
         ],
     )
     @pytest.mark.parametrize("weights", [True, False])

--- a/tests/pf/test_forward_Mag_Linear.py
+++ b/tests/pf/test_forward_Mag_Linear.py
@@ -1243,7 +1243,9 @@ class TestJacobian(BaseFixtures):
             pytest.param(
                 "geoana",
                 "forward_only",
-                marks=pytest.mark.xfail(reason="not implemented"),
+                marks=pytest.mark.xfail(
+                    reason="not implemented", raises=NotImplementedError
+                ),
             ),
         ],
     )
@@ -1295,7 +1297,9 @@ class TestJacobian(BaseFixtures):
             pytest.param(
                 "geoana",
                 "forward_only",
-                marks=pytest.mark.xfail(reason="not implemented"),
+                marks=pytest.mark.xfail(
+                    reason="not implemented", raises=NotImplementedError
+                ),
             ),
         ],
     )
@@ -1342,7 +1346,12 @@ class TestJacobian(BaseFixtures):
         "engine",
         [
             "choclo",
-            pytest.param("geoana", marks=pytest.mark.xfail(reason="not implemented")),
+            pytest.param(
+                "geoana",
+                marks=pytest.mark.xfail(
+                    reason="not implemented", raises=NotImplementedError
+                ),
+            ),
         ],
     )
     @pytest.mark.parametrize("method", ["Jvec", "Jtvec"])
@@ -1602,7 +1611,9 @@ class TestJacobianAmplitudeData(BaseFixtures):
             pytest.param(
                 "geoana",
                 "forward_only",
-                marks=pytest.mark.xfail(reason="not implemented"),
+                marks=pytest.mark.xfail(
+                    reason="not implemented", raises=NotImplementedError
+                ),
             ),
         ],
     )
@@ -1688,7 +1699,9 @@ class TestJacobianAmplitudeData(BaseFixtures):
             pytest.param(
                 "geoana",
                 "forward_only",
-                marks=pytest.mark.xfail(reason="not implemented"),
+                marks=pytest.mark.xfail(
+                    reason="not implemented", raises=NotImplementedError
+                ),
             ),
         ],
     )


### PR DESCRIPTION
#### Summary

Declutter the potential field simulations by defining dictionaries with Numba functions for gravity and magnetics. This way the simulations don't need to define private attributes for each one of them: they can just get the desired function in a single line. Raise `NotImplementedError` on diagonal of G.T @ G when `"forward_only"` and using `geoana` as engine. Specify which type of error should be raised in the `xfail` parameters present in some tests.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
