### PR TITLE
Add missing map classes to the API reference

### DIFF
--- a/simpeg/__init__.py
+++ b/simpeg/__init__.py
@@ -73,24 +73,32 @@ Mappings
   maps.ComboMap
   maps.ComplexMap
   maps.ExpMap
-  maps.LinearMap
   maps.IdentityMap
   maps.InjectActiveCells
-  maps.MuRelative
-  maps.LogMap
+  maps.LinearMap
   maps.LogisticSigmoidMap
+  maps.LogMap
+  maps.Mesh2Mesh
+  maps.MuRelative
   maps.ParametricBlock
+  maps.ParametricBlockInLayer
+  maps.ParametricCasingAndLayer
   maps.ParametricCircleMap
   maps.ParametricEllipsoid
   maps.ParametricLayer
   maps.ParametricPolyMap
+  maps.ParametricSplineMap
+  maps.PolynomialPetroClusterMap
   maps.Projection
   maps.ReciprocalMap
+  maps.SelfConsistentEffectiveMedium
   maps.SphericalSystem
+  maps.SumMap
   maps.Surject2Dto3D
   maps.SurjectFull
   maps.SurjectUnits
   maps.SurjectVertical1D
+  maps.TileMap
   maps.Weighting
   maps.Wires
 


### PR DESCRIPTION
#### Summary

Add missing classes in `maps.py` to the API Reference.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

Fixes #1671

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
