### PR TITLE
Replace sklearn deprecated method for `validate_data` function

### DIFF
--- a/simpeg/utils/pgi_utils.py
+++ b/simpeg/utils/pgi_utils.py
@@ -14,7 +14,7 @@ try:
     from sklearn.mixture import GaussianMixture
     from sklearn.cluster import KMeans
     from sklearn.utils import check_array
-    from sklearn.utils.validation import check_is_fitted
+    from sklearn.utils.validation import check_is_fitted, validate_data
     from sklearn.mixture._gaussian_mixture import (
         _compute_precision_cholesky,
         _compute_log_det_cholesky,
@@ -541,7 +541,7 @@ class WeightedGaussianMixture(GaussianMixture if sklearn else object):
             Log probabilities of each data point in X.
         """
         check_is_fitted(self)
-        X = self._validate_data(X, reset=False)
+        X = validate_data(self, X, reset=False)
 
         return logsumexp(self._estimate_weighted_log_prob_with_sensW(X, sensW), axis=1)
 
@@ -1126,7 +1126,7 @@ class GaussianMixtureWithPrior(WeightedGaussianMixture):
         if self.verbose:
             print("modified from scikit-learn")
 
-        X = self._validate_data(X, dtype=[np.float64, np.float32], ensure_min_samples=2)
+        X = validate_data(self, X, dtype=[np.float64, np.float32], ensure_min_samples=2)
         if X.shape[0] < self.n_components:
             raise ValueError(
                 "Expected n_samples >= n_components "


### PR DESCRIPTION
#### Summary

Replace the deprecated `BaseEstimator._validate_data` for the `validate_data` provided by `skelarn.utils.validation`. The method will be removed in sklearn 1.7.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
