### PR TITLE
Allow use of `J` as `LinearOperator` in gravity equivalent layers

### DIFF
--- a/simpeg/potential_fields/gravity/_numba_functions.py
+++ b/simpeg/potential_fields/gravity/_numba_functions.py
@@ -749,7 +749,7 @@ def _g_t_dot_v_2d_mesh_parallel(
     """
     n_receivers = receivers.shape[0]
     n_cells = cells_bounds.shape[0]
-    for i in range(n_receivers):
+    for i in prange(n_receivers):
         # Allocate array for the current row of the sensitivity matrix
         local_row = np.empty(n_cells)
         for j in range(n_cells):

--- a/simpeg/potential_fields/gravity/simulation.py
+++ b/simpeg/potential_fields/gravity/simulation.py
@@ -310,7 +310,7 @@ class Simulation3DIntegral(BasePFSimulation):
                 msg = (
                     "Computing the diagonal of G.T @ G with "
                     'store_sensitivities="forward_only" and engine="geoana" '
-                    "hasn't been implemented yet."
+                    "hasn't been implemented yet. "
                     'Choose store_sensitivities="ram" or "disk", '
                     'or another engine, like "choclo".'
                 )
@@ -443,7 +443,7 @@ class Simulation3DIntegral(BasePFSimulation):
                     msg = (
                         "Accessing matrix G with "
                         'store_sensitivities="forward_only" and engine="geoana" '
-                        "hasn't been implemented yet."
+                        "hasn't been implemented yet. "
                         'Choose store_sensitivities="ram" or "disk", '
                         'or another engine, like "choclo".'
                     )

--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -276,7 +276,7 @@ class Simulation3DIntegral(BasePFSimulation):
                     msg = (
                         "Accessing matrix G with "
                         'store_sensitivities="forward_only" and engine="geoana" '
-                        "hasn't been implemented yet."
+                        "hasn't been implemented yet. "
                         'Choose store_sensitivities="ram" or "disk", '
                         'or another engine, like "choclo".'
                     )


### PR DESCRIPTION
#### Summary

Add Numba functions to compute `G.T @ v` and the diagonal of `G.T @ G` for the gravity equivalent sources without storing the `G` matrix in memory. Add needed private methods in the `SimulationEquivalentSourceLayer`. Add tests for the new functions.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue

Related to #1618 

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
