### PR TITLE
Fix bug in phase for recursive 1d NSEM simulation

### DIFF
--- a/simpeg/electromagnetics/natural_source/simulation_1d.py
+++ b/simpeg/electromagnetics/natural_source/simulation_1d.py
@@ -248,8 +248,7 @@ class Simulation1DRecursive(BaseSimulation):
                     )
                 elif rx.component == "phase":
                     d.append(
-                        (180.0 / np.pi)
-                        * np.arctan(np.imag(Z[i_freq]) / np.real(Z[i_freq]))
+                        (180.0 / np.pi) * np.angle(Z[i_freq]) 
                     )
 
         return np.array(d)

--- a/simpeg/electromagnetics/natural_source/simulation_1d.py
+++ b/simpeg/electromagnetics/natural_source/simulation_1d.py
@@ -247,9 +247,7 @@ class Simulation1DRecursive(BaseSimulation):
                         np.abs(Z[i_freq]) ** 2 / (2 * np.pi * src.frequency * mu_0)
                     )
                 elif rx.component == "phase":
-                    d.append(
-                        (180.0 / np.pi) * np.angle(Z[i_freq]) 
-                    )
+                    d.append((180.0 / np.pi) * np.arctan2(Z[i_freq].imag, Z[i_freq].real))
 
         return np.array(d)
 

--- a/simpeg/electromagnetics/natural_source/simulation_1d.py
+++ b/simpeg/electromagnetics/natural_source/simulation_1d.py
@@ -247,7 +247,9 @@ class Simulation1DRecursive(BaseSimulation):
                         np.abs(Z[i_freq]) ** 2 / (2 * np.pi * src.frequency * mu_0)
                     )
                 elif rx.component == "phase":
-                    d.append((180.0 / np.pi) * np.arctan2(Z[i_freq].imag, Z[i_freq].real))
+                    d.append(
+                        (180.0 / np.pi) * np.arctan2(Z[i_freq].imag, Z[i_freq].real)
+                    )
 
         return np.array(d)
 

--- a/tests/em/nsem/forward/test_Recursive1D_VsAnalyticHalfspace.py
+++ b/tests/em/nsem/forward/test_Recursive1D_VsAnalyticHalfspace.py
@@ -30,7 +30,7 @@ def true_solution(freq, sigma_half):
         -np.sqrt(np.pi * freq * mu_0 / sigma_half),
         -np.sqrt(np.pi * freq * mu_0 / sigma_half),
         1 / sigma_half,
-        45.0,
+        -135.0,
     ]
 
     return soln


### PR DESCRIPTION
The recursive solution exclusively computes the impedance, apparent resistivity and/or phase of the Zxy impedance at all frequencies. In the convention adopted by SimPEG, Zxy is in the lower-left quadrant of the complex plane. Using np.atan(imag/real) results in phase values between -90 and +90 which is wrong.

Suggest we use ``np.angle`` instead.

![image](https://github.com/user-attachments/assets/d751640b-1d23-419e-abe9-2e29fbb0f1af)

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.