### PR TITLE
Add shift to discrete topography for NSEM

### DIFF
--- a/simpeg/electromagnetics/natural_source/utils/__init__.py
+++ b/simpeg/electromagnetics/natural_source/utils/__init__.py
@@ -31,3 +31,4 @@ from .test_utils import (
     blockInhalfSpace,
     twoLayer,
 )
+from .nsem_utils import shift_to_discrete_topography

--- a/simpeg/electromagnetics/natural_source/utils/nsem_utils.py
+++ b/simpeg/electromagnetics/natural_source/utils/nsem_utils.py
@@ -1,0 +1,37 @@
+from ...static.utils import drapeTopotoLoc
+
+def shift_to_discrete_topography(
+    locations,
+    mesh,
+    active_cells,
+    option="top",
+    height=0.
+):
+    """Shift locations relative to discrete surface topography.
+
+    Parameters
+    ----------
+    locations : (n, dim) numpy.ndarray
+        The original locations.
+    mesh : discretize.TensorMesh or discretize.TreeMesh
+        The mesh defining the discrete domain.
+    active_cells : numpy.ndarray of int or bool
+        Active topography cells.
+    option : {"top", "center"}
+        Define discrete topography at tops of cells or cell centers.
+    height : float or (n,) numpy.ndarray
+        Location height relative to surface topography.
+
+    Returns
+    -------
+    (n, dim) numpy.ndarray
+        The shifted locations.
+    """
+
+    locations_shifted = drapeTopotoLoc(
+        mesh, locations, active_cells=active_cells, option=option
+    )
+
+    locations_shifted[:, -1] += height
+
+    return locations_shifted

--- a/simpeg/electromagnetics/natural_source/utils/nsem_utils.py
+++ b/simpeg/electromagnetics/natural_source/utils/nsem_utils.py
@@ -1,11 +1,8 @@
 from ...static.utils import drapeTopotoLoc
 
+
 def shift_to_discrete_topography(
-    locations,
-    mesh,
-    active_cells,
-    option="top",
-    height=0.
+    locations, mesh, active_cells, option="top", height=0.0
 ):
     """Shift locations relative to discrete surface topography.
 


### PR DESCRIPTION
#### Summary
The PR adds a utility for shifting locations relative to discrete surface topography.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### What does this implement/fix?
We measure electric fields at the Earth's surface when performing MT surveys. Like DC/IP, the original measurement locations of the electric fields can end up in air cells when we define discrete surface topography. This utility allows the user to shift locations relative to discrete topography on Tensor and Tree meshes. For Airborne NSEM, this utility also allows the user to preserve the original flight heights.

#### Additional information
Unlike the DC/IP utility that alters a survey object, this utility is inputs the original locations and outputs the shifted ones. I could see us needing similar functionality for NSEM survey objects if they are created directly by loading some type of data file (like DC/IP).


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
