### PR TITLE
Use conda-forge as only channel in Azure pipelines

### DIFF
--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -11,7 +11,7 @@ then
   conda config --remove channels defaults
   # Update conda
   conda config --show channels
-  conda update --yes -n base conda
+  # conda update --yes -n base conda
 fi
 
 cp .ci/environment_test.yml environment_test_with_pyversion.yml

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -8,7 +8,7 @@ if ${is_azure}
 then
   conda config --show channels
   # Configure conda-forge as the only channel
-  conda config --remove channels default
+  conda config --remove channels defaults
   conda config --add channels conda-forge
   # Update conda
   conda update --yes -n base conda

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -11,7 +11,7 @@ then
   conda config --remove channels defaults
   # Update conda
   conda config --show channels
-  # conda update --yes -n base conda
+  conda update --yes -n base conda
 fi
 
 cp .ci/environment_test.yml environment_test_with_pyversion.yml

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -9,8 +9,7 @@ then
   # Add conda-forge as channel
   conda config --add channels conda-forge
   # Remove defaults channels
-  conda config --remove channels https://repo.anaconda.com/pkgs/main
-  conda config --remove channels https://repo.anaconda.com/pkgs/r
+  conda config --remove channels defaults
   conda config --show channels
   # Configure TOS conda-forge
   conda tos accept --override-channels --channel conda-forge

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -7,8 +7,8 @@ is_azure=$(echo "${TF_BUILD:-false}" | tr '[:upper:]' '[:lower:]')
 if ${is_azure}
 then
   # Configure conda-forge as the only channel
-  conda config --remove channels defaults
   conda config --add channels conda-forge
+  conda config --remove channels defaults
   # Update conda
   conda config --show channels
   conda update --yes -n base conda

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -6,7 +6,6 @@ is_azure=$(echo "${TF_BUILD:-false}" | tr '[:upper:]' '[:lower:]')
 
 if ${is_azure}
 then
-  conda config --show channels
   # Configure conda-forge as the only channel
   conda config --remove channels defaults
   conda config --add channels conda-forge

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -11,12 +11,9 @@ then
   # Remove defaults channels
   conda config --remove channels defaults --force
   conda config --show channels
-  echo "---------------"
-  conda info
-  echo "---------------"
-  echo "---------------"
-  conda tos view
-  echo "---------------"
+
+  conda config --show-sources
+
   # Update conda
   conda update --yes -c conda-forge -n base conda
 fi

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -11,6 +11,7 @@ then
   # Remove defaults channels
   conda config --remove channels defaults
   conda config --show channels
+  conda config --get
   # Configure TOS conda-forge
   conda tos accept --override-channels --channel conda-forge
   conda tos view

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -9,7 +9,7 @@ then
   # Add conda-forge as channel
   conda config --add channels conda-forge
   # Remove defaults channels
-  conda config --remove channels defaults --force
+  conda config --remove channels defaults --system
   conda config --show channels
 
   conda config --show-sources

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -6,9 +6,10 @@ is_azure=$(echo "${TF_BUILD:-false}" | tr '[:upper:]' '[:lower:]')
 
 if ${is_azure}
 then
-  # Configure conda-forge as the default channel
+  conda config --show channels
+  # Configure conda-forge as the only channel
+  conda config --remove channels default
   conda config --add channels conda-forge
-  conda config --set channel_priority disabled
   # Update conda
   conda update --yes -n base conda
 fi

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -9,14 +9,11 @@ then
   # Add conda-forge as channel
   conda config --add channels conda-forge
   # Remove defaults channels
-  conda config --remove channels defaults   # from ~/.condarc
-  conda config --remove channels defaults --system # from system's .condarc
-  conda config --show channels
-
-  conda config --show-sources
-
+  # (both from ~/.condarc and from /usr/share/miniconda/.condarc)
+  conda config --remove channels defaults
+  conda config --remove channels defaults --system
   # Update conda
-  conda update --yes -c conda-forge -n base conda
+  conda update --yes -n base conda
 fi
 
 cp .ci/environment_test.yml environment_test_with_pyversion.yml

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -6,6 +6,10 @@ is_azure=$(${TF_BUILD:-false} | tr '[:upper:]' '[:lower:]')
 
 if ${is_azure}
 then
+  # Configure conda-forge as the default channel
+  conda config --add channels conda-forge
+  conda config --set channel_priority disabled
+  # Update conda
   conda update --yes -n base conda
 fi
 

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -9,7 +9,7 @@ then
   # Add conda-forge as channel
   conda config --add channels conda-forge
   # Remove defaults channels
-  conda config remove --channel defaults
+  conda config --remove channels defaults
   conda config --show channels
   echo "---------------"
   conda info

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -10,6 +10,7 @@ then
   conda config --remove channels defaults
   conda config --add channels conda-forge
   # Update conda
+  conda config --show channels
   conda update --yes -n base conda
 fi
 

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -6,14 +6,14 @@ is_azure=$(echo "${TF_BUILD:-false}" | tr '[:upper:]' '[:lower:]')
 
 if ${is_azure}
 then
-  # Configure conda-forge as the only channel
+  # Add conda-forge as channel
   conda config --add channels conda-forge
-  conda config --remove channels defaults
-  conda config --show channels
-  # Update conda
+  # Configure TOS for defaults and conda-forge
+  conda tos reject --override-channels --channel defaults
+  conda tos accept --override-channels --channel conda-forge
   conda tos view
-  conda tos reject defaults
-  conda update --yes -n base conda
+  # Update conda
+  conda update --yes -c conda-forge -n base conda
 fi
 
 cp .ci/environment_test.yml environment_test_with_pyversion.yml

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -9,7 +9,8 @@ then
   # Add conda-forge as channel
   conda config --add channels conda-forge
   # Remove defaults channels
-  conda config --remove channels defaults --system
+  conda config --remove channels defaults   # from ~/.condarc
+  conda config --remove channels defaults --system # from system's .condarc
   conda config --show channels
 
   conda config --show-sources

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -8,8 +8,11 @@ if ${is_azure}
 then
   # Add conda-forge as channel
   conda config --add channels conda-forge
-  # Configure TOS for defaults and conda-forge
-  conda tos reject --override-channels --channel defaults
+  # Remove defaults channels
+  conda config --remove channels https://repo.anaconda.com/pkgs/main
+  conda config --remove channels https://repo.anaconda.com/pkgs/r
+  conda config --show channels
+  # Configure TOS conda-forge
   conda tos accept --override-channels --channel conda-forge
   conda tos view
   # Update conda

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -11,10 +11,12 @@ then
   # Remove defaults channels
   conda config --remove channels defaults
   conda config --show channels
-  conda config --get
-  # Configure TOS conda-forge
-  conda tos accept --override-channels --channel conda-forge
+  echo "---------------"
+  conda info
+  echo "---------------"
+  echo "---------------"
   conda tos view
+  echo "---------------"
   # Update conda
   conda update --yes -c conda-forge -n base conda
 fi

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -2,8 +2,7 @@
 set -ex #echo on and exit if any line fails
 
 # TF_BUILD is set to True on azure pipelines.
-echo "${TF_BUILD}"
-is_azure=$(${TF_BUILD:-false} | tr '[:upper:]' '[:lower:]')
+is_azure=$(echo "${TF_BUILD:-false}" | tr '[:upper:]' '[:lower:]')
 
 if ${is_azure}
 then

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -2,6 +2,7 @@
 set -ex #echo on and exit if any line fails
 
 # TF_BUILD is set to True on azure pipelines.
+echo "${TF_BUILD}"
 is_azure=$(${TF_BUILD:-false} | tr '[:upper:]' '[:lower:]')
 
 if ${is_azure}

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -9,8 +9,10 @@ then
   # Configure conda-forge as the only channel
   conda config --add channels conda-forge
   conda config --remove channels defaults
-  # Update conda
   conda config --show channels
+  # Update conda
+  conda tos view
+  conda tos reject defaults
   conda update --yes -n base conda
 fi
 

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -9,7 +9,7 @@ then
   # Add conda-forge as channel
   conda config --add channels conda-forge
   # Remove defaults channels
-  conda config --remove channels defaults
+  conda config --remove channels defaults --force
   conda config --show channels
   echo "---------------"
   conda info

--- a/.ci/azure/setup_env.sh
+++ b/.ci/azure/setup_env.sh
@@ -9,7 +9,7 @@ then
   # Add conda-forge as channel
   conda config --add channels conda-forge
   # Remove defaults channels
-  conda config --remove channels defaults
+  conda config remove --channel defaults
   conda config --show channels
   echo "---------------"
   conda info

--- a/.ci/environment_test.yml
+++ b/.ci/environment_test.yml
@@ -45,4 +45,4 @@ dependencies:
 # PyPI uploading
   - wheel
   - twine
-  - build
+  - python-build


### PR DESCRIPTION
#### Summary
<!-- Add a summary of this Pull Request -->

Use `conda-forge` instead of `defaults` channel when setting up the environment in Azure pipelines. This avoid us having to accept Anaconda's ToS. Fix bash syntax when defining `is_azure` variable. Use `python-build` instead of `build` in `.ci/azure/setup_env.sh` since `build` is not available in `conda-forge`.


#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

This PR fixes tests not running in Azure due to unaccepted ToS.

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
