### PR TITLE
Allow for list of int. Only project active times

### DIFF
--- a/simpeg/electromagnetics/time_domain/receivers.py
+++ b/simpeg/electromagnetics/time_domain/receivers.py
@@ -1,5 +1,5 @@
 import scipy.sparse as sp
-
+import numpy as np
 from ...utils import mkvc, validate_type, validate_direction
 from discretize.utils import Zero
 from ...survey import BaseTimeRx
@@ -120,6 +120,20 @@ class BaseRx(BaseTimeRx):
         projected_time_grid = f._TLoc(self.projField)
         return time_mesh.get_interpolation_matrix(self.times, projected_time_grid)
 
+    def active_times(self, projection):
+        """Get active times for the receiver.
+
+        Parameters
+        ----------
+        projection : Sparse matrix
+
+        Returns
+        -------
+        numpy.ndarray
+            Active times for the receiver.
+        """
+        return np.unique(sp.find(projection)[1])
+
     def getP(self, mesh, time_mesh, f):
         """Returns projection matrices as a list for all components collected by the receivers.
 
@@ -145,6 +159,7 @@ class BaseRx(BaseTimeRx):
 
         Ps = self.getSpatialP(mesh, f)
         Pt = self.getTimeP(time_mesh, f)
+        Pt = Pt[:, self.active_times(Pt)]
         P = sp.kron(Pt, Ps)
 
         if self.storeProjections:
@@ -172,7 +187,7 @@ class BaseRx(BaseTimeRx):
             Fields projected to the receiver(s)
         """
         P = self.getP(mesh, time_mesh, f)
-        f_part = mkvc(f[src, self.projField, :])
+        f_part = mkvc(f[src, self.projField, self.active_times(self.timeP)])
         return P * f_part
 
     def evalDeriv(self, src, mesh, time_mesh, f, v, adjoint=False):
@@ -293,7 +308,7 @@ class PointMagneticFluxTimeDerivative(BaseRx):
             )
 
         P = self.getP(mesh, time_mesh, f)
-        f_part = mkvc(f[src, "b", :])
+        f_part = mkvc(f[src, "b", self.active_times(self.timeP)])
         return P * f_part
 
     def getTimeP(self, time_mesh, f):

--- a/simpeg/electromagnetics/time_domain/receivers.py
+++ b/simpeg/electromagnetics/time_domain/receivers.py
@@ -187,7 +187,8 @@ class BaseRx(BaseTimeRx):
             Fields projected to the receiver(s)
         """
         P = self.getP(mesh, time_mesh, f)
-        f_part = mkvc(f[src, self.projField, self.active_times(self.timeP)])
+        time_proj = self.getTimeP(time_mesh, f)
+        f_part = mkvc(f[src, self.projField, self.active_times(time_proj)])
         return P * f_part
 
     def evalDeriv(self, src, mesh, time_mesh, f, v, adjoint=False):
@@ -308,7 +309,8 @@ class PointMagneticFluxTimeDerivative(BaseRx):
             )
 
         P = self.getP(mesh, time_mesh, f)
-        f_part = mkvc(f[src, "b", self.active_times(self.timeP)])
+        time_proj = self.getTimeP(time_mesh, f)
+        f_part = mkvc(f[src, "b", self.active_times(time_proj)])
         return P * f_part
 
     def getTimeP(self, time_mesh, f):

--- a/simpeg/fields.py
+++ b/simpeg/fields.py
@@ -501,7 +501,7 @@ class TimeFields(Fields):
             pointerFields = pointerFields.reshape(pointerShape, order="F")
 
             # First try to return the function as three arguments (without timeInd)
-            if timeInd == slice(None, None, None):
+            if isinstance(timeInd, slice) and timeInd == slice(None, None, None):
                 try:
                     # assume it will take care of integrating over all times
                     return func(pointerFields, srcInd)


### PR DESCRIPTION
(cherry picked from commit 1dfafa5b013d610fdc1d67589400b8fcc5ad8c5f)

#### Summary
This proposed change streamlines the compute of predicted data from time domain fields. Instead of looping over all dts, only loop over the times that needed by the projection of the receivers.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
