### PR TITLE
    Use `Impedance` and `Tipper` in examples and tests

### DIFF
--- a/examples/07-nsem/plot_fwd_nsem_MTTipper3D.py
+++ b/examples/07-nsem/plot_fwd_nsem_MTTipper3D.py
@@ -56,11 +56,19 @@ def run(plotIt=True):
     # Make a receiver list
     receiver_list = []
     for rx_orientation in ["xx", "xy", "yx", "yy"]:
-        receiver_list.append(NSEM.Rx.PointNaturalSource(rx_loc, rx_orientation, "real"))
-        receiver_list.append(NSEM.Rx.PointNaturalSource(rx_loc, rx_orientation, "imag"))
+        receiver_list.append(
+            NSEM.Rx.Impedance(rx_loc, orientation=rx_orientation, component="real")
+        )
+        receiver_list.append(
+            NSEM.Rx.Impedance(rx_loc, orientation=rx_orientation, component="imag")
+        )
     for rx_orientation in ["zx", "zy"]:
-        receiver_list.append(NSEM.Rx.Point3DTipper(rx_loc, rx_orientation, "real"))
-        receiver_list.append(NSEM.Rx.Point3DTipper(rx_loc, rx_orientation, "imag"))
+        receiver_list.append(
+            NSEM.Rx.Tipper(rx_loc, orientation=rx_orientation, component="real")
+        )
+        receiver_list.append(
+            NSEM.Rx.Tipper(rx_loc, orientation=rx_orientation, component="imag")
+        )
 
     # Source list
     source_list = [

--- a/simpeg/electromagnetics/natural_source/utils/data_utils.py
+++ b/simpeg/electromagnetics/natural_source/utils/data_utils.py
@@ -8,6 +8,8 @@ from simpeg.electromagnetics.natural_source.survey import Survey, Data
 from simpeg.electromagnetics.natural_source.receivers import (
     PointNaturalSource,
     Point3DTipper,
+    Impedance,
+    Tipper,
 )
 from simpeg.electromagnetics.natural_source.sources import PlanewaveXYPrimary
 from simpeg.electromagnetics.natural_source.utils import (
@@ -68,9 +70,9 @@ def extract_data_info(NSEMdata):
             src_rx_slice = survey_slices[src, rx]
             dL.append(NSEMdata.dobs[src_rx_slice])
             freqL.append(np.ones(rx.nD) * src.frequency)
-            if isinstance(rx, PointNaturalSource):
+            if isinstance(rx, (Impedance, PointNaturalSource)):
                 rxTL.extend((("z" + rx.orientation + " ") * rx.nD).split())
-            if isinstance(rx, Point3DTipper):
+            if isinstance(rx, (Tipper, Point3DTipper)):
                 rxTL.extend((("t" + rx.orientation + " ") * rx.nD).split())
     return np.concatenate(dL), np.concatenate(freqL), np.array(rxTL)
 
@@ -124,9 +126,9 @@ def resample_data(NSEMdata, locs="All", freqs="All", rxs="All", verbose=False):
         rx_comp = []
         for rxT in rxs:
             if "z" in rxT[0]:
-                rxtype = PointNaturalSource
+                rxtype = Impedance
             elif "t" in rxT[0]:
-                rxtype = Point3DTipper
+                rxtype = Tipper
             else:
                 raise IOError("Unknown rx type string")
             orient = rxT[1:3]
@@ -258,8 +260,8 @@ def convert3Dto1Dobject(NSEMdata, rxType3D="yx"):
     for loc in uniLocs:
         # Make the receiver list
         rx1DList = []
-        rx1DList.append(PointNaturalSource(simpeg.mkvc(loc, 2).T, "real"))
-        rx1DList.append(PointNaturalSource(simpeg.mkvc(loc, 2).T, "imag"))
+        rx1DList.append(Impedance(simpeg.mkvc(loc, 2).T, component="real"))
+        rx1DList.append(Impedance(simpeg.mkvc(loc, 2).T, component="imag"))
         # Source list
         locrecData = recData[
             np.sqrt(

--- a/simpeg/electromagnetics/natural_source/utils/test_utils.py
+++ b/simpeg/electromagnetics/natural_source/utils/test_utils.py
@@ -177,13 +177,13 @@ def setupSimpegNSEM_tests_location_assign_list(
                 if singleList:
                     rxList.append(
                         Impedance(
-                            [rx_loc],
+                            rx_loc,
                             orientation=rx_type,
                             component="apparent_resistivity",
                         )
                     )
                     rxList.append(
-                        Impedance([rx_loc], orientation=rx_type, component="phase")
+                        Impedance(rx_loc, orientation=rx_type, component="phase")
                     )
                 else:
                     rxList.append(
@@ -203,19 +203,17 @@ def setupSimpegNSEM_tests_location_assign_list(
                         )
                     )
             else:
-                rxList.append(
-                    Impedance([rx_loc], orientation=rx_type, component="real")
-                )
+                rxList.append(Impedance(rx_loc, orientation=rx_type, component="real"))
                 rxList.append(
                     Impedance(
-                        [rx_loc],
+                        rx_loc,
                         orientation=rx_type,
                         component="imag",
                     )
                 )
         if rx_type in ["zx", "zy"]:
-            rxList.append(Tipper([rx_loc], orientation=rx_type, component="real"))
-            rxList.append(Tipper([rx_loc], orientation=rx_type, component="imag"))
+            rxList.append(Tipper(rx_loc, orientation=rx_type, component="real"))
+            rxList.append(Tipper(rx_loc, orientation=rx_type, component="imag"))
 
     srcList = []
     if singleFreq:

--- a/simpeg/electromagnetics/natural_source/utils/test_utils.py
+++ b/simpeg/electromagnetics/natural_source/utils/test_utils.py
@@ -188,14 +188,16 @@ def setupSimpegNSEM_tests_location_assign_list(
                 else:
                     rxList.append(
                         Impedance(
-                            [rx_loc, rx_loc],
+                            locations_e=rx_loc,
+                            locations_h=rx_loc,
                             orientation=rx_type,
                             component="apparent_resistivity",
                         )
                     )
                     rxList.append(
                         Impedance(
-                            [rx_loc, rx_loc],
+                            locations_e=rx_loc,
+                            locations_h=rx_loc,
                             orientation=rx_type,
                             component="phase",
                         )

--- a/simpeg/electromagnetics/natural_source/utils/test_utils.py
+++ b/simpeg/electromagnetics/natural_source/utils/test_utils.py
@@ -4,8 +4,8 @@ import discretize
 from simpeg import maps, mkvc, utils
 from ....utils import unpack_widths
 from ..receivers import (
-    PointNaturalSource,
-    Point3DTipper,
+    Impedance,
+    Tipper,
 )
 from ..survey import Survey
 from ..sources import PlanewaveXYPrimary, Planewave
@@ -67,12 +67,8 @@ def setup1DSurvey(sigmaHalf, tD=False, structure=False):
 
     receiver_list = []
     for _ in range(len(["z1d", "z1d"])):
-        receiver_list.append(
-            PointNaturalSource(mkvc(np.array([0.0]), 2).T, component="real")
-        )
-        receiver_list.append(
-            PointNaturalSource(mkvc(np.array([0.0]), 2).T, component="imag")
-        )
+        receiver_list.append(Impedance(mkvc(np.array([0.0]), 2).T, component="real"))
+        receiver_list.append(Impedance(mkvc(np.array([0.0]), 2).T, component="imag"))
     # Source list
     source_list = []
     for freq in freqs:
@@ -113,8 +109,8 @@ def setup1DSurveyElectricMagnetic(sigmaHalf, tD=False, structure=False):
 
     rxList = []
     for _ in range(len(["z1d", "z1d"])):
-        rxList.append(PointNaturalSource(mkvc(np.array([0.0]), 2).T, component="real"))
-        rxList.append(PointNaturalSource(mkvc(np.array([0.0]), 2).T, component="imag"))
+        rxList.append(Impedance(mkvc(np.array([0.0]), 2).T, component="real"))
+        rxList.append(Impedance(mkvc(np.array([0.0]), 2).T, component="imag"))
     # Source list
     # srcList = []
     src_list = [Planewave([], frequency=f) for f in frequencies]
@@ -176,50 +172,44 @@ def setupSimpegNSEM_tests_location_assign_list(
             if comp == "Res":
                 if singleList:
                     rxList.append(
-                        PointNaturalSource(
-                            locations=[rx_loc],
+                        Impedance(
+                            [rx_loc],
                             orientation=rx_type,
                             component="apparent_resistivity",
                         )
                     )
                     rxList.append(
-                        PointNaturalSource(
-                            locations=[rx_loc], orientation=rx_type, component="phase"
-                        )
+                        Impedance([rx_loc], orientation=rx_type, component="phase")
                     )
                 else:
                     rxList.append(
-                        PointNaturalSource(
-                            locations=[rx_loc, rx_loc],
+                        Impedance(
+                            [rx_loc, rx_loc],
                             orientation=rx_type,
                             component="apparent_resistivity",
                         )
                     )
                     rxList.append(
-                        PointNaturalSource(
-                            locations=[rx_loc, rx_loc],
+                        Impedance(
+                            [rx_loc, rx_loc],
                             orientation=rx_type,
                             component="phase",
                         )
                     )
             else:
                 rxList.append(
-                    PointNaturalSource(
-                        orientation=rx_type, component="real", locations=[rx_loc]
-                    )
+                    Impedance([rx_loc], orientation=rx_type, component="real")
                 )
                 rxList.append(
-                    PointNaturalSource(
-                        orientation=rx_type, component="imag", locations=[rx_loc]
+                    Impedance(
+                        [rx_loc],
+                        orientation=rx_type,
+                        component="imag",
                     )
                 )
         if rx_type in ["zx", "zy"]:
-            rxList.append(
-                Point3DTipper(orientation=rx_type, component="real", locations=[rx_loc])
-            )
-            rxList.append(
-                Point3DTipper(orientation=rx_type, component="imag", locations=[rx_loc])
-            )
+            rxList.append(Tipper([rx_loc], orientation=rx_type, component="real"))
+            rxList.append(Tipper([rx_loc], orientation=rx_type, component="imag"))
 
     srcList = []
     if singleFreq:
@@ -328,23 +318,19 @@ def setupSimpegNSEM_PrimarySecondary(inputSetup, freqs, comp="Imp", singleFreq=F
         if rx_type in ["xx", "xy", "yx", "yy"]:
             if comp == "Res":
                 rxList.append(
-                    PointNaturalSource(
-                        locations=rx_loc,
+                    Impedance(
+                        rx_loc,
                         orientation=rx_type,
                         component="apparent_resistivity",
                     )
                 )
-                rxList.append(
-                    PointNaturalSource(
-                        locations=rx_loc, orientation=rx_type, component="phase"
-                    )
-                )
+                rxList.append(Impedance(rx_loc, orientation=rx_type, component="phase"))
             else:
-                rxList.append(PointNaturalSource(rx_loc, rx_type, "real"))
-                rxList.append(PointNaturalSource(rx_loc, rx_type, "imag"))
+                rxList.append(Impedance(rx_loc, orientation=rx_type, component="real"))
+                rxList.append(Impedance(rx_loc, orientation=rx_type, component="imag"))
         if rx_type in ["zx", "zy"]:
-            rxList.append(Point3DTipper(rx_loc, rx_type, "real"))
-            rxList.append(Point3DTipper(rx_loc, rx_type, "imag"))
+            rxList.append(Tipper(rx_loc, orientation=rx_type, component="real"))
+            rxList.append(Tipper(rx_loc, orientation=rx_type, component="imag"))
 
     srcList = []
     if singleFreq:
@@ -428,7 +414,7 @@ def setupSimpegNSEM_ePrimSec(inputSetup, comp="Imp", singleFreq=False, expMap=Tr
         if rx_type in ["xx", "xy", "yx", "yy"]:
             if comp == "Res":
                 receiver_list.append(
-                    PointNaturalSource(
+                    Impedance(
                         locations_e=rx_loc,
                         locations_h=rx_loc,
                         orientation=rx_type,
@@ -436,7 +422,7 @@ def setupSimpegNSEM_ePrimSec(inputSetup, comp="Imp", singleFreq=False, expMap=Tr
                     )
                 )
                 receiver_list.append(
-                    PointNaturalSource(
+                    Impedance(
                         locations_e=rx_loc,
                         locations_h=rx_loc,
                         orientation=rx_type,
@@ -444,11 +430,19 @@ def setupSimpegNSEM_ePrimSec(inputSetup, comp="Imp", singleFreq=False, expMap=Tr
                     )
                 )
             else:
-                receiver_list.append(PointNaturalSource(rx_loc, rx_type, "real"))
-                receiver_list.append(PointNaturalSource(rx_loc, rx_type, "imag"))
+                receiver_list.append(
+                    Impedance(rx_loc, orientation=rx_type, component="real")
+                )
+                receiver_list.append(
+                    Impedance(rx_loc, orientation=rx_type, component="imag")
+                )
         if rx_type in ["zx", "zy"]:
-            receiver_list.append(Point3DTipper(rx_loc, rx_type, "real"))
-            receiver_list.append(Point3DTipper(rx_loc, rx_type, "imag"))
+            receiver_list.append(
+                Impedance(rx_loc, orientation=rx_type, component="real")
+            )
+            receiver_list.append(
+                Impedance(rx_loc, orientation=rx_type, component="imag")
+            )
 
     # Source list
     source_list = []

--- a/simpeg/electromagnetics/natural_source/utils/test_utils.py
+++ b/simpeg/electromagnetics/natural_source/utils/test_utils.py
@@ -67,8 +67,12 @@ def setup1DSurvey(sigmaHalf, tD=False, structure=False):
 
     receiver_list = []
     for _ in range(len(["z1d", "z1d"])):
-        receiver_list.append(Impedance(mkvc(np.array([0.0]), 2).T, component="real"))
-        receiver_list.append(Impedance(mkvc(np.array([0.0]), 2).T, component="imag"))
+        receiver_list.append(
+            Impedance(mkvc(np.array([0.0]), 2).T, component="real", orientation="xy")
+        )
+        receiver_list.append(
+            Impedance(mkvc(np.array([0.0]), 2).T, component="imag", orientation="xy")
+        )
     # Source list
     source_list = []
     for freq in freqs:

--- a/tests/em/nsem/forward/test_1D_finite_volume.py
+++ b/tests/em/nsem/forward/test_1D_finite_volume.py
@@ -26,18 +26,14 @@ class FiniteVolume1DTest(unittest.TestCase):
         self.frequencies = np.logspace(-2, 1, 30)
 
         rx_list = [
-            nsem.receivers.PointNaturalSource(
+            nsem.receivers.Impedance(
                 [[0]], orientation="xy", component="apparent_resistivity"
             ),
-            nsem.receivers.PointNaturalSource(
-                [[0]], orientation="xy", component="phase"
-            ),
-            nsem.receivers.PointNaturalSource(
+            nsem.receivers.Impedance([[0]], orientation="xy", component="phase"),
+            nsem.receivers.Impedance(
                 [[0]], orientation="yx", component="apparent_resistivity"
             ),
-            nsem.receivers.PointNaturalSource(
-                [[0]], orientation="yx", component="phase"
-            ),
+            nsem.receivers.Impedance([[0]], orientation="yx", component="phase"),
         ]
         # simulation
         src_list = [

--- a/tests/em/nsem/forward/test_Recursive1D_VsAnalyticHalfspace.py
+++ b/tests/em/nsem/forward/test_Recursive1D_VsAnalyticHalfspace.py
@@ -13,10 +13,10 @@ import pytest
 
 def create_survey(freq):
     receivers_list = [
-        nsem.receivers.PointNaturalSource(component="real"),
-        nsem.receivers.PointNaturalSource(component="imag"),
-        nsem.receivers.PointNaturalSource(component="app_res"),
-        nsem.receivers.PointNaturalSource(component="phase"),
+        nsem.receivers.Impedance([[]], component="real"),
+        nsem.receivers.Impedance([[]], component="imag"),
+        nsem.receivers.Impedance([[]], component="app_res"),
+        nsem.receivers.Impedance([[]], component="phase"),
     ]
 
     source_list = [nsem.sources.Planewave(receivers_list, f) for f in freq]

--- a/tests/em/nsem/inversion/test_BC_Sims.py
+++ b/tests/em/nsem/inversion/test_BC_Sims.py
@@ -53,18 +53,18 @@ def create_simulation_1d(sim_type, deriv_type):
     frequencies = np.logspace(-2, 1, 30)
 
     rx_list = [
-        nsem.receivers.PointNaturalSource([[0]], orientation="xy", component="real"),
-        nsem.receivers.PointNaturalSource([[0]], orientation="xy", component="imag"),
-        nsem.receivers.PointNaturalSource(
+        nsem.receivers.Impedance([[0]], orientation="xy", component="real"),
+        nsem.receivers.Impedance([[0]], orientation="xy", component="imag"),
+        nsem.receivers.Impedance(
             [[0]], orientation="xy", component="apparent_resistivity"
         ),
-        nsem.receivers.PointNaturalSource([[0]], orientation="xy", component="phase"),
-        nsem.receivers.PointNaturalSource([[0]], orientation="yx", component="real"),
-        nsem.receivers.PointNaturalSource([[0]], orientation="yx", component="imag"),
-        nsem.receivers.PointNaturalSource(
+        nsem.receivers.Impedance([[0]], orientation="xy", component="phase"),
+        nsem.receivers.Impedance([[0]], orientation="yx", component="real"),
+        nsem.receivers.Impedance([[0]], orientation="yx", component="imag"),
+        nsem.receivers.Impedance(
             [[0]], orientation="yx", component="apparent_resistivity"
         ),
-        nsem.receivers.PointNaturalSource([[0]], orientation="yx", component="phase"),
+        nsem.receivers.Impedance([[0]], orientation="yx", component="phase"),
     ]
     src_list = [nsem.sources.Planewave(rx_list, frequency=f) for f in frequencies]
     survey = nsem.Survey(src_list)
@@ -169,18 +169,12 @@ def create_simulation_2d(sim_type, deriv_type, mesh_type, fixed_boundary=False):
             sim_kwargs["h_bc"] = h_bc
 
         rx_list = [
-            nsem.receivers.PointNaturalSource(
-                rx_locs, orientation="xy", component="real"
-            ),
-            nsem.receivers.PointNaturalSource(
-                rx_locs, orientation="xy", component="imag"
-            ),
-            nsem.receivers.PointNaturalSource(
+            nsem.receivers.Impedance(rx_locs, orientation="xy", component="real"),
+            nsem.receivers.Impedance(rx_locs, orientation="xy", component="imag"),
+            nsem.receivers.Impedance(
                 rx_locs, orientation="xy", component="apparent_resistivity"
             ),
-            nsem.receivers.PointNaturalSource(
-                rx_locs, orientation="xy", component="phase"
-            ),
+            nsem.receivers.Impedance(rx_locs, orientation="xy", component="phase"),
         ]
         src_list = [nsem.sources.Planewave(rx_list, frequency=f) for f in frequencies]
         survey = nsem.Survey(src_list)
@@ -219,18 +213,12 @@ def create_simulation_2d(sim_type, deriv_type, mesh_type, fixed_boundary=False):
             sim_kwargs["e_bc"] = e_bc
 
         rx_list = [
-            nsem.receivers.PointNaturalSource(
-                rx_locs, orientation="yx", component="real"
-            ),
-            nsem.receivers.PointNaturalSource(
-                rx_locs, orientation="yx", component="imag"
-            ),
-            nsem.receivers.PointNaturalSource(
+            nsem.receivers.Impedance(rx_locs, orientation="yx", component="real"),
+            nsem.receivers.Impedance(rx_locs, orientation="yx", component="imag"),
+            nsem.receivers.Impedance(
                 rx_locs, orientation="yx", component="apparent_resistivity"
             ),
-            nsem.receivers.PointNaturalSource(
-                rx_locs, orientation="yx", component="phase"
-            ),
+            nsem.receivers.Impedance(rx_locs, orientation="yx", component="phase"),
         ]
         src_list = [nsem.sources.Planewave(rx_list, frequency=f) for f in frequencies]
         survey = nsem.Survey(src_list)
@@ -291,10 +279,10 @@ class Sim_2D(unittest.TestCase):
         rx_locs = np.c_[np.linspace(-8000, 8000, 3), np.zeros(3)]
         mesh_1d = TensorMesh([5])
         mesh_2d = TensorMesh([5, 5])
-        r_xy = nsem.receivers.PointNaturalSource(
+        r_xy = nsem.receivers.Impedance(
             rx_locs, orientation="xy", component="apparent_resistivity"
         )
-        r_yx = nsem.receivers.PointNaturalSource(
+        r_yx = nsem.receivers.Impedance(
             rx_locs, orientation="yx", component="apparent_resistivity"
         )
         survey_xy = nsem.Survey([nsem.sources.Planewave([r_xy], frequency=10)])

--- a/tests/em/nsem/inversion/test_Problem1D_Adjoint.py
+++ b/tests/em/nsem/inversion/test_Problem1D_Adjoint.py
@@ -18,10 +18,10 @@ def JvecAdjointTest_1D(sigmaHalf, formulation="PrimSec"):
 
     # Define a receiver for each data type as a list
     receivers_list = [
-        nsem.receivers.PointNaturalSource(component="real"),
-        nsem.receivers.PointNaturalSource(component="imag"),
-        nsem.receivers.PointNaturalSource(component="app_res"),
-        nsem.receivers.PointNaturalSource(component="phase"),
+        nsem.receivers.Impedance([[]], component="real"),
+        nsem.receivers.Impedance([[]], component="imag"),
+        nsem.receivers.Impedance([[]], component="app_res"),
+        nsem.receivers.Impedance([[]], component="phase"),
     ]
 
     # Use a list to define the planewave source at each frequency and assign receivers

--- a/tests/em/nsem/inversion/test_Problem1D_Derivs.py
+++ b/tests/em/nsem/inversion/test_Problem1D_Derivs.py
@@ -16,10 +16,10 @@ def DerivJvecTest_1D(halfspace_value, freq=False, expMap=True):
 
     # Define a receiver for each data type as a list
     receivers_list = [
-        nsem.receivers.PointNaturalSource(component="real"),
-        nsem.receivers.PointNaturalSource(component="imag"),
-        nsem.receivers.PointNaturalSource(component="app_res"),
-        nsem.receivers.PointNaturalSource(component="phase"),
+        nsem.receivers.Impedance([[]], component="real"),
+        nsem.receivers.Impedance([[]], component="imag"),
+        nsem.receivers.Impedance([[]], component="app_res"),
+        nsem.receivers.Impedance([[]], component="phase"),
     ]
 
     # Use a list to define the planewave source at each frequency and assign receivers

--- a/tests/em/nsem/inversion/test_complex_resistivity.py
+++ b/tests/em/nsem/inversion/test_complex_resistivity.py
@@ -68,7 +68,9 @@ class ComplexResistivityTest(unittest.TestCase):
         rx_loc[:, 2] = -50
 
         # Make a receiver list
-        rxList = [ns.Rx.PointNaturalSource(rx_loc, rx_orientation, rx_type)]
+        rxList = [
+            ns.Rx.Impedance(rx_loc, orientation=rx_orientation, component=rx_type)
+        ]
 
         # Source list
         freqs = [10, 50, 200]
@@ -103,11 +105,11 @@ class ComplexResistivityTest(unittest.TestCase):
 
         # Make a receiver list
         rxList = [
-            ns.Rx.PointNaturalSource(
-                orientation=rx_orientation,
-                component=rx_type,
+            ns.Rx.Impedance(
                 locations_e=rx_loc,
                 locations_h=rx_loc,
+                orientation=rx_orientation,
+                component=rx_type,
             )
         ]
 
@@ -145,7 +147,9 @@ class ComplexResistivityTest(unittest.TestCase):
         rx_loc[:, 2] = -50
 
         # Make a receiver list
-        rxList = [ns.Rx.PointNaturalSource(rx_loc, rx_orientation, rx_type)]
+        rxList = [
+            ns.Rx.Impedance(rx_loc, orientation=rx_orientation, component=rx_type)
+        ]
 
         # give background a value
         x0 = self.mesh.x0
@@ -195,7 +199,9 @@ class ComplexResistivityTest(unittest.TestCase):
         rx_loc[:, 2] = -50
 
         # Make a receiver list
-        rxList = [ns.Rx.PointNaturalSource(rx_loc, rx_orientation, rx_type)]
+        rxList = [
+            ns.Rx.Impedance(rx_loc, orientation=rx_orientation, component=rx_type)
+        ]
 
         # Source list
         freqs = [10, 50, 200]


### PR DESCRIPTION
#### Summary

Replace the deprecated `PointNaturalSource` and `Point3DTipper`  NSEM receiver classes for their new counterparts (`Impedance` and `Tipper`) in examples and tests.


#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
