### PR TITLE
Fix bug on `Impedance.eval` when orientation is "xx" or "yy"

### DIFF
--- a/simpeg/electromagnetics/natural_source/receivers.py
+++ b/simpeg/electromagnetics/natural_source/receivers.py
@@ -300,7 +300,7 @@ class Impedance(_ElectricAndMagneticReceiver):
 
     def _eval_impedance(self, src, mesh, f):
         if mesh.dim < 3 and self.orientation in ["xx", "yy"]:
-            return 0.0
+            return np.zeros((self.nD, 1), dtype=complex)
         e = f[src, "e"]
         h = f[src, "h"]
         if mesh.dim == 3:

--- a/simpeg/electromagnetics/natural_source/utils/test_utils.py
+++ b/simpeg/electromagnetics/natural_source/utils/test_utils.py
@@ -36,7 +36,7 @@ def getAppResPhs(NSEMdata, survey):
     ]
 
 
-def setup1DSurvey(sigmaHalf, tD=False, structure=False):
+def setup1DSurvey(sigmaHalf, tD=False, structure=False, rx_orientation="xy"):
     # Frequency
     num_frequencies = 33
     freqs = np.logspace(3, -3, num_frequencies)
@@ -68,10 +68,14 @@ def setup1DSurvey(sigmaHalf, tD=False, structure=False):
     receiver_list = []
     for _ in range(len(["z1d", "z1d"])):
         receiver_list.append(
-            Impedance(mkvc(np.array([0.0]), 2).T, component="real", orientation="xy")
+            Impedance(
+                mkvc(np.array([0.0]), 2).T, component="real", orientation=rx_orientation
+            )
         )
         receiver_list.append(
-            Impedance(mkvc(np.array([0.0]), 2).T, component="imag", orientation="xy")
+            Impedance(
+                mkvc(np.array([0.0]), 2).T, component="imag", orientation=rx_orientation
+            )
         )
     # Source list
     source_list = []

--- a/tests/em/nsem/forward/test_receiver_eval.py
+++ b/tests/em/nsem/forward/test_receiver_eval.py
@@ -1,0 +1,36 @@
+"""
+Test receiver's ``eval`` method.
+"""
+
+import numpy as np
+import pytest
+from simpeg.electromagnetics import natural_source as nsem
+from simpeg.electromagnetics.natural_source.utils.test_utils import setup1DSurvey
+from simpeg.utils.solver_utils import get_default_solver
+
+
+@pytest.mark.parametrize("orientation", ["xx", "yy"])
+def test_zero_value(orientation):
+    """
+    Test if ``Impedance.eval()`` returns an array of zeros on 1D problem
+    when orientation is ``"xx"`` or ``"yy"``.
+
+    Test bugfix introduced in #1692.
+    """
+    survey, sigma, _, mesh = setup1DSurvey(sigmaHalf=1e-2, rx_orientation=orientation)
+
+    # Define simulation and precompute fields
+    solver = get_default_solver()
+    simulation = nsem.Simulation1DPrimarySecondary(
+        mesh, sigmaPrimary=sigma, sigma=sigma, survey=survey, solver=solver
+    )
+    fields = simulation.fields()
+
+    # Check if calling eval on each receiver returns the expected result
+    sources_and_receivers = (
+        (src, rx) for src in survey.source_list for rx in src.receiver_list
+    )
+    for source, receiver in sources_and_receivers:
+        result = receiver.eval(source, mesh, fields)
+        np.testing.assert_allclose(result, 0)
+        assert result.shape == (receiver.nD, 1)


### PR DESCRIPTION
#### Summary
Fixes bug #1691 

#### Squash and Merge Summary

Make `Impedance.eval()` to return an array full of zeros in case that the receiver's orientation is `"xx"` or "`yy`" and the mesh is not 3D. This solves a bug that was causing the NSEM 1D simulation to error out after trying to cast the output of `eval()` into an array. Add test for the bugfix.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
Fixes bug #1691 

#### What does this implement/fix?
Eval for xx and yy receivers outputs a float instead of an appropriate array.
