### PR TITLE
Make Logger a bit quieter when running pytest

### DIFF
--- a/tests/base/test_base_pde_sim.py
+++ b/tests/base/test_base_pde_sim.py
@@ -814,7 +814,7 @@ def test_bad_derivative_stash():
         sim.MeSigmaDeriv(u, v)
 
 
-def test_solver_defaults(caplog):
+def test_solver_defaults(caplog, info_logging):
     mesh = discretize.TensorMesh([2, 2, 2])
     sim = BasePDESimulation(mesh)
     # Check that logging.info was created

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import logging
 
 
 @pytest.fixture(scope="session", autouse=True)
-def quiet_logger_for_tests():
+def quiet_logger_for_tests(request):
     logger = get_logger()
 
     init_level = logger.level
@@ -12,6 +12,18 @@ def quiet_logger_for_tests():
     # set the logger to the higher WARNING level to
     # ignore the default solver messages.
     logger.setLevel(logging.WARNING)
+
+    yield
+
+    logger.setLevel(init_level)
+
+
+@pytest.fixture()
+def info_logging():
+    # provide a fixture to temporarily set the logging level to info
+    logger = get_logger()
+    init_level = logger.level
+    logger.setLevel(logging.INFO)
 
     yield
 


### PR DESCRIPTION
#### Summary
Make Logger a bit quieter when running pytest by using a session wide auto-used fixture. 

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.