### PR TITLE
Improve landing page of docs

### DIFF
--- a/.ci/environment_test.yml
+++ b/.ci/environment_test.yml
@@ -26,6 +26,7 @@ dependencies:
   - sphinx-gallery>=0.1.13
   - sphinxcontrib-apidoc
   - sphinx-reredirects
+  - sphinx-design
   - pydata-sphinx-theme
   - nbsphinx
   - numpydoc

--- a/CITATION.rst
+++ b/CITATION.rst
@@ -1,13 +1,17 @@
+=============
 Citing SimPEG
--------------
+=============
 
-There is a `paper about SimPEG <http://dx.doi.org/10.1016/j.cageo.2015.09.015>`_, if you use this code, please help our scientific visibility by citing our work!
-
-
-    Cockett, R., Kang, S., Heagy, L. J., Pidlisecky, A., & Oldenburg, D. W. (2015). SimPEG: An open source framework for simulation and gradient based parameter estimation in geophysical applications. Computers & Geosciences.
+There is a paper about SimPEG! If you are using this library in your research,
+we greatly appreciate that the software gets cited!
 
 
-BibTex:
+    Cockett, R., Kang, S., Heagy, L. J., Pidlisecky, A., & Oldenburg, D. W.
+    (2015). SimPEG: An open source framework for simulation and gradient based
+    parameter estimation in geophysical applications. Computers & Geosciences.
+
+
+Here is a Bibtex entry to make things easier if you’re using Latex:
 
 .. code::
 
@@ -19,3 +23,24 @@ BibTex:
       publisher={Elsevier}
     }
 
+Electromagnetics
+----------------
+
+If you are using the :mod:`simpeg.electromagnetics` module, please also cite:
+
+    Lindsey J. Heagy, Rowan Cockett, Seogi Kang, Gudni K. Rosenkjaer, Douglas W. Oldenburg, A framework for simulation and inversion in electromagnetics, Computers & Geosciences, Volume 107, 2017, Pages 1-19, ISSN 0098-3004, http://dx.doi.org/10.1016/j.cageo.2017.06.018.
+
+Here is a Bibtex entry to make things easier if you’re using Latex:
+
+.. code::
+
+    @article{heagy2017,
+      title={A framework for simulation and inversion in electromagnetics},
+      author={Lindsey J. Heagy and Rowan Cockett and Seogi Kang and Gudni K. Rosenkjaer and Douglas W. Oldenburg},
+      journal={Computers & Geosciences},
+      volume={107},
+      pages={1 - 19},
+      year={2017},
+      issn={0098-3004},
+      doi={http://dx.doi.org/10.1016/j.cageo.2017.06.018}
+    }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "sphinx.ext.coverage",
     "sphinx.ext.doctest",
     "sphinx.ext.extlinks",
+    "sphinx_design",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx_gallery.gen_gallery",

--- a/docs/content/user-guide/getting-started/about-simpeg.rst
+++ b/docs/content/user-guide/getting-started/about-simpeg.rst
@@ -1,0 +1,44 @@
+.. _about_simpeg:
+
+==============
+What's SimPEG?
+==============
+
+SimPEG (Simulation and Parameter Estimation in Geophysics) is a
+**Python library** for simulations, inversions and parameter estimation for
+geophysical applications.
+
+The vision is to create a package for finite volume simulation with
+applications to geophysical imaging and subsurface flow. To enable the
+understanding of the many different components, this package has the following
+features:
+
+* Modular with respect to the spacial discretization, optimization routine, and
+  geophysical problem.
+* Built with the inverse problem in mind.
+* Provides a framework for geophysical and hydrogeologic problems.
+* Supports 1D, 2D and 3D problems.
+* Designed for large-scale inversions.
+
+Overview Talk at SciPy 2016
+---------------------------
+
+.. raw:: html
+
+    <iframe
+        width="720"
+        height="405"
+        src="https://www.youtube.com/embed/yUm01YsS9hQ?si=ccgut6rMZerTLYAm"
+        title="YouTube video player"
+        frameborder="0"
+        allow="accelerometer;
+        autoplay;
+        clipboard-write;
+        encrypted-media;
+        gyroscope;
+        picture-in-picture;
+        web-share"
+        referrerpolicy="strict-origin-when-cross-origin"
+        allowfullscreen
+    >
+    </iframe>

--- a/docs/content/user-guide/getting-started/big_picture.rst
+++ b/docs/content/user-guide/getting-started/big_picture.rst
@@ -133,15 +133,7 @@ be exploited through inheritance of base classes, and differences can be
 expressed through subtype polymorphism. Please look at the documentation here
 for more in-depth information.
 
-
-.. include:: ../../../CITATION.rst
-
-Authors
--------
-
-.. include:: ../../../AUTHORS.rst
-
 License
 -------
 
-.. include:: ../../../LICENSE
+.. include:: ../../../../LICENSE

--- a/docs/content/user-guide/getting-started/citing.rst
+++ b/docs/content/user-guide/getting-started/citing.rst
@@ -1,0 +1,3 @@
+.. _citing:
+
+.. include:: ../../../../CITATION.rst

--- a/docs/content/user-guide/index.rst
+++ b/docs/content/user-guide/index.rst
@@ -14,9 +14,11 @@ For details on the available classes and functions in SimPEG, please visit the
   :maxdepth: 1
   :caption: Getting Started
 
+  getting-started/about-simpeg.rst
   getting-started/big_picture
   getting-started/installing
   getting-started/contributing/index.rst
+  getting-started/citing.rst
 
 .. toctree::
   :glob:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,83 @@
-.. include:: ../README.rst
+:html_theme.sidebar_secondary.remove: true
+
+.. image:: ./images/simpeg-logo.png
+    :alt: SimPEG logo
+
+====================
+SimPEG Documentation
+====================
+
+Simulation and Parameter Estimation in Geophysics.
+An open-source Python library for simulation, inversion and parameter
+estimation for geophysical applications.
+
+**Useful links:**
+:ref:`Install <installing>` |
+`GitHub Repository <https://github.com/simpeg/simpeg>`_ |
+`Bugs and Issues <https://github.com/simpeg/simpeg/issues>`_ |
+`SimPEG website <https://simpeg.xyz/>`_
+
+.. grid:: 1 2 1 2
+    :margin: 5 5 0 0
+    :padding: 0 0 0 0
+    :gutter: 4
+
+    .. grid-item-card:: :fas:`book-open` User Guide
+        :text-align: center
+        :class-title: sd-fs-5
+        :class-card: sd-p-3
+
+        Learn how to use SimPEG.
+
+        .. button-ref:: user_guide
+            :ref-type: ref
+            :click-parent:
+            :color: primary
+            :outline:
+            :expand:
+
+    .. grid-item-card:: :fas:`book` User Tutorials
+        :text-align: center
+        :class-title: sd-fs-5
+        :class-card: sd-p-3
+
+        Apply SimPEG to geophysical problems.
+
+        .. button-link:: https://simpeg.xyz/user-tutorials
+            :click-parent:
+            :color: primary
+            :outline:
+            :expand:
+
+            Checkout the User Tutorials :octicon:`link-external`
+
+    .. grid-item-card:: :fas:`code` API Reference
+        :text-align: center
+        :class-title: sd-fs-5
+        :class-card: sd-p-3
+
+        A list of modules, classes and functions.
+
+        .. button-ref:: api
+            :ref-type: ref
+            :color: primary
+            :outline:
+            :expand:
+
+    .. grid-item-card:: :fas:`comments` Contact
+        :text-align: center
+        :class-title: sd-fs-5
+        :class-card: sd-p-3
+
+        Chat with the rest of the community.
+
+        .. button-link:: https://mattermost.softwareunderground.org/simpeg
+            :click-parent:
+            :color: primary
+            :outline:
+            :expand:
+
+            Join our Mattermost channel :octicon:`link-external`
 
 .. toctree::
     :maxdepth: 2
@@ -8,10 +87,3 @@
     User Guide <content/user-guide/index>
     API Reference <content/api/index>
     Release Notes <content/release/index>
-
-.. Project Index & Search
-.. ======================
-
-.. * :ref:`genindex`
-.. * :ref:`modindex`
-.. * :ref:`search`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,8 @@ estimation for geophysical applications.
 :ref:`Install <installing>` |
 `GitHub Repository <https://github.com/simpeg/simpeg>`_ |
 `Bugs and Issues <https://github.com/simpeg/simpeg/issues>`_ |
-`SimPEG website <https://simpeg.xyz/>`_
+`SimPEG website <https://simpeg.xyz/>`_ |
+`License <https://github.com/simpeg/simpeg/blob/main/LICENSE>`_
 
 .. grid:: 1 2 1 2
     :margin: 5 5 0 0

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ estimation for geophysical applications.
             :ref-type: ref
             :click-parent:
             :color: primary
-            :outline:
+            :shadow:
             :expand:
 
     .. grid-item-card:: :fas:`book` User Tutorials
@@ -47,7 +47,7 @@ estimation for geophysical applications.
         .. button-link:: https://simpeg.xyz/user-tutorials
             :click-parent:
             :color: primary
-            :outline:
+            :shadow:
             :expand:
 
             Checkout the User Tutorials :octicon:`link-external`
@@ -62,7 +62,7 @@ estimation for geophysical applications.
         .. button-ref:: api
             :ref-type: ref
             :color: primary
-            :outline:
+            :shadow:
             :expand:
 
     .. grid-item-card:: :fas:`comments` Contact
@@ -75,7 +75,7 @@ estimation for geophysical applications.
         .. button-link:: https://mattermost.softwareunderground.org/simpeg
             :click-parent:
             :color: primary
-            :outline:
+            :shadow:
             :expand:
 
             Join our Mattermost channel :octicon:`link-external`

--- a/environment.yml
+++ b/environment.yml
@@ -34,6 +34,7 @@ dependencies:
   - sphinx-gallery>=0.1.13
   - sphinxcontrib-apidoc
   - sphinx-reredirects
+  - sphinx-design
   - pydata-sphinx-theme
   - empymod>=2.0.0
   - nbsphinx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ docs = [
     "sphinx-gallery>=0.1.13",
     "sphinxcontrib-apidoc",
     "sphinx-reredirects",
+    "sphinx-design",
     "pydata-sphinx-theme",
     "nbsphinx",
     "empymod>=2.0.0",


### PR DESCRIPTION
#### Summary

Create a custom RST landing page using `sphinx-design` that includes cards to the main sections of the docs. Move some content from the old landing page (present in the `README.rst`) into new sections in the User Guide: `citing.rst` and `about-simpeg.rst`.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

Replaces the usage of the `README.rst` as the landing page of the docs. It's
better to keep them as separate documents with different purposes: the
`README.rst` should be more intended for contributors, while the landing page
of the docs should primarily target users and help them navigate through the
docs.

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
