### PR TITLE
Fix LaTeX equations in `Simulation3DDifferential`

### DIFF
--- a/simpeg/potential_fields/magnetics/simulation.py
+++ b/simpeg/potential_fields/magnetics/simulation.py
@@ -1686,15 +1686,17 @@ class Simulation3DDifferential(BaseMagneticPDESimulation):
     This simulation solves for the magnetostatic PDE:
 
     .. math::
-        \nabla \cdot \Vec{B} = 0
+
+        \nabla \cdot \mathbf{B} = 0
 
     where the constitutive relation is specified as:
 
     .. math::
-        \Vec{B} = \mu\Vec{H} + \mu_0\Vec{M_r}
 
-    where :math:`\Vec{M_r}` is a fixed magnetization unaffected by the inducing field
-    and :math:`\mu\Vec{H}` is the induced magnetization.
+        \mathbf{B} = \mu\mathbf{H} + \mu_0\mathbf{M_r}
+
+    where :math:`\mathbf{M_r}` is a fixed magnetization unaffected by the inducing field
+    and :math:`\mu\mathbf{H}` is the induced magnetization.
     """
 
     _Ainv = None


### PR DESCRIPTION
#### Summary

Fix a few LaTeX equations in `simpeg.potential_fields.magnetics.Simulation3DDifferential` that weren't rendering correctly.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
