### PR TITLE
Fix argument name in `UpdateSensitivityWeights` docs

### DIFF
--- a/simpeg/directives/_directives.py
+++ b/simpeg/directives/_directives.py
@@ -2349,7 +2349,7 @@ class UpdateSensitivityWeights(InversionDirective):
     every_iteration : bool
         When ``True``, update sensitivity weighting at every model update; non-linear problems.
         When ``False``, create sensitivity weights for starting model only; linear problems.
-    threshold : float
+    threshold_value : float
         Threshold value for smallest weighting value.
     threshold_method : {'amplitude', 'global', 'percentile'}
         Threshold method for how `threshold_value` is applied:


### PR DESCRIPTION
#### Summary

Fix the name of the `threshold_value` argument in the docstring of the `UpdateSensitivityWeights` directive.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
