### PR TITLE
TileMap --> use the discretize volume averaging

### DIFF
--- a/simpeg/maps/_base.py
+++ b/simpeg/maps/_base.py
@@ -8,7 +8,7 @@ import numpy as np
 import scipy.sparse as sp
 from scipy.sparse import csr_matrix as csr
 from discretize.tests import check_derivative
-from discretize.utils import Zero, Identity, mkvc, speye, sdiag
+from discretize.utils import Zero, Identity, mkvc, volume_average
 import uuid
 
 from ..utils import (
@@ -1292,31 +1292,22 @@ class TileMap(IdentityMap):
         Set the projection matrix with partial volumes
         """
         if getattr(self, "_P", None) is None:
-            in_local = self.local_mesh.get_containing_cells(
-                self.global_mesh.cell_centers
-            )
+            # Volume-averaging operator mapping the global mesh onto the local
+            # mesh. This weights by the true partial overlap volume of each
+            # pair of cells, so it is correct regardless of which mesh is finer
+            # in a given region (the center-assignment approach used previously
+            # broke down wherever the local mesh was finer than the global one).
+            vol_avg = volume_average(self.global_mesh, self.local_mesh)
 
-            P = (
-                sp.csr_matrix(
-                    (
-                        self.global_mesh.cell_volumes,
-                        (in_local, np.arange(self.global_mesh.nC)),
-                    ),
-                    shape=(self.local_mesh.nC, self.global_mesh.nC),
-                )
-                * speye(self.global_mesh.nC)[:, self.global_active]
-            )
+            # keep only the active cells of the global model
+            P = vol_avg[:, self.global_active]
 
-            self._local_active = mkvc(np.sum(P, axis=1) > 0)
+            # local cells that receive a contribution from active global cells
+            self._local_active = mkvc(np.asarray(P.sum(axis=1)).ravel() > self.tol)
 
             P = P[self.local_active, :]
 
-            self._P = sp.block_diag(
-                [
-                    sdiag(1.0 / self.local_mesh.cell_volumes[self.local_active]) * P
-                    for ii in range(self.components)
-                ]
-            )
+            self._P = sp.block_diag([P for _ in range(self.components)])
 
         return self._P
 

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -548,6 +548,38 @@ class MapTests(unittest.TestCase):
 
             self.assertTrue((local_mass - total_mass) / total_mass < 1e-8)
 
+    def test_Tile_finer_local(self):
+        """
+        TileMap should volume-average correctly even when the local mesh is
+        finer than the global mesh in part of the domain. The center-assignment
+        approach used previously left holes (cells dropped from local_active)
+        and scaled the surviving cells by the global/local volume ratio.
+        """
+        hx = np.ones(4)
+        global_mesh = discretize.TreeMesh([hx, hx], diagonal_balance=False)
+        global_mesh.refine(1, diagonal_balance=False)
+        local_mesh = discretize.TreeMesh([hx, hx], diagonal_balance=False)
+        local_mesh.refine(2, diagonal_balance=False)  # finer than the global mesh
+
+        active = np.ones(global_mesh.nC, dtype=bool)
+        tile_map = maps.TileMap(global_mesh, active, local_mesh)
+
+        # no holes: every local cell overlapping the (fully active) global mesh
+        # must remain active
+        self.assertEqual(tile_map.local_active.sum(), local_mesh.nC)
+
+        # a constant model must map to the same constant (no scaling blowup)
+        out = tile_map * np.ones(global_mesh.nC)
+        np.testing.assert_allclose(out, 1.0)
+
+        # mass is conserved
+        model = np.random.randn(int(active.sum()))
+        total_mass = (model * global_mesh.cell_volumes[active]).sum()
+        local_mass = (
+            (tile_map * model) * local_mesh.cell_volumes[tile_map.local_active]
+        ).sum()
+        self.assertAlmostEqual((local_mass - total_mass) / total_mass, 0.0, places=8)
+
     def test_logit_errors(self):
         nP = 10
         scalar_lower = -2


### PR DESCRIPTION
#### Summary
use the discretize volume averaging in the tile map so that it is robust to the scenario where the local mesh is finer than the global one

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.


#### What does this implement/fix?
Right now, if you ended up with a local mesh that had a higher level of refinement than the global mesh, the tile map will run, but produce nonsensical results. If we instead use the discretize volume averaging, it is more stable (test added to show this) 