### PR TITLE
Add allow-unsafe-pr-checkout: true

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,4 +1,4 @@
-name : Reviewdog PR Annotations
+name: Reviewdog PR Annotations
 
 # =========
 # IMPORTANT
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Python env
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dependencies to run the flake8 checks
         run: .ci/install_style.sh
@@ -66,6 +66,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           path: pr_source
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - name: flake8 review
         uses: reviewdog/action-flake8@v3
@@ -90,7 +91,7 @@ jobs:
       - name: Setup Python env
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: "3.11"
 
       - name: Install dependencies to run the black checks
         run: .ci/install_style.sh
@@ -101,11 +102,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          path: 'pr_source'
+          path: "pr_source"
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
 
       - uses: reviewdog/action-black@v3
         with:
-          workdir: 'pr_source'
+          workdir: "pr_source"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review


### PR DESCRIPTION
#### Summary
Adds to the PR code checkout step of the `pull_request` github action that analyzes the pull request code. Neither black, nor flake8 execute the code they analyze here, so this should be safe to do. 

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
Github recently disallowed checking out pull request code from these types of actions unless specifically opted into.

#### Additional information
See [securely-using-pull_request_target](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target).
