### PR TITLE
Transfer functions

### DIFF
--- a/simpeg/__init__.py
+++ b/simpeg/__init__.py
@@ -68,10 +68,12 @@ Mappings
 .. autosummary::
   :toctree: generated/
 
+  maps.ArctanMap
   maps.BaseParametric
   maps.ChiMap
   maps.ComboMap
   maps.ComplexMap
+  maps.ErfMap
   maps.ExpMap
   maps.IdentityMap
   maps.InjectActiveCells
@@ -88,10 +90,13 @@ Mappings
   maps.ParametricLayer
   maps.ParametricPolyMap
   maps.ParametricSplineMap
+  maps.PiecewiseLinearMap
   maps.PolynomialPetroClusterMap
   maps.Projection
   maps.ReciprocalMap
+  maps.ScaledLogisticSigmoidMap
   maps.SelfConsistentEffectiveMedium
+  maps.SineTransferMap
   maps.SphericalSystem
   maps.SumMap
   maps.Surject2Dto3D

--- a/simpeg/maps/__init__.py
+++ b/simpeg/maps/__init__.py
@@ -11,15 +11,20 @@ from ._base import (
 from ._clustering import PolynomialPetroClusterMap
 from ._injection import Mesh2Mesh, InjectActiveCells
 from ._property_maps import (
+    ArctanMap,
     ChiMap,
     ComplexMap,
     EffectiveSusceptibilityMap,
+    ErfMap,
     ExpMap,
     LogisticSigmoidMap,
     LogMap,
     MuRelative,
+    PiecewiseLinearMap,
     ReciprocalMap,
+    ScaledLogisticSigmoidMap,
     SelfConsistentEffectiveMedium,
+    SineTransferMap,
     Weighting,
 )
 from ._parametric import (

--- a/simpeg/maps/_property_maps.py
+++ b/simpeg/maps/_property_maps.py
@@ -1527,6 +1527,53 @@ class SelfConsistentEffectiveMedium(IdentityMap):
 
 
 class ScaledLogisticSigmoidMap(LogisticSigmoidMap):
+    r"""Logistic sigmoid mapping parameterized by the width of its transition zone.
+
+    ``ScaledLogisticSigmoidMap`` behaves like :class:`.LogisticSigmoidMap`, except that
+    instead of using the natural width of the logistic sigmoid, the model is rescaled so
+    that ``half_width`` directly controls how wide the transition between
+    ``lower_bound`` and ``upper_bound`` is. Where :math:`\mathbf{m}` is a set of model
+    parameters, the mapping is defined as:
+
+    .. math::
+        \mathbf{u}(\mathbf{m}) = \textrm{lower\_bound} +
+        (\textrm{upper\_bound} - \textrm{lower\_bound}) \cdot
+        \textrm{sigmoid} \! \left( \frac{w_0}{\textrm{half\_width}} \, \mathbf{m} \right)
+
+    where :math:`\textrm{sigmoid}(x) = 1/(1 + e^{-x})` and
+    :math:`w_0 = 2 \log(3 + 2\sqrt{2})` is the full width at half maximum (FWHM) of the
+    derivative of the standard logistic sigmoid. Because of this normalization,
+    ``half_width`` is the full width (in model space, centered on 0) over which the
+    derivative of :math:`\mathbf{u}(\mathbf{m})` remains at least half of its peak value;
+    smaller values of ``half_width`` produce a sharper, more step-like transition between
+    the bounds.
+
+    Parameters
+    ----------
+    half_width : float
+        Full width (centered at 0) of the region over which the derivative of the mapping
+        is at least half of its peak value; controls the sharpness of the transition
+        between ``lower_bound`` and ``upper_bound``. Must be strictly positive.
+        Default is 1.
+    deriv_half_width : None or float
+        Half-width used when evaluating :py:meth:`deriv`. If ``None`` (default), the
+        value of ``half_width`` is used. Setting this independently of ``half_width``
+        allows the derivative used during inversion to be smoothed or widened relative
+        to the forward transform.
+    lower_bound, upper_bound, mesh, nP
+        See :class:`.LogisticSigmoidMap`.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from simpeg.maps import ScaledLogisticSigmoidMap
+
+    >>> mapping = ScaledLogisticSigmoidMap(nP=5, half_width=2.0)
+    >>> m = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+    >>> mapping * m
+    array([0.02859548, 0.14644661, 0.5       , 0.85355339, 0.97140452])
+    """
+
     _base_half_width = 2 * np.log(3 + 2 * np.sqrt(2))
 
     def __init__(self, half_width=1.0, deriv_half_width=None, **kwargs):
@@ -1559,6 +1606,57 @@ class ScaledLogisticSigmoidMap(LogisticSigmoidMap):
 
 
 class ArctanMap(IdentityMap):
+    r"""Mapping that transforms model parameters through a scaled arctangent transfer function.
+
+    Where :math:`\mathbf{m}` is a set of model parameters, ``ArctanMap`` creates a mapping
+    :math:`\mathbf{u}(\mathbf{m})` that passes each parameter through an arctangent, then
+    scales and shifts the result:
+
+    .. math::
+        \mathbf{u}(\mathbf{m}) = \textrm{shift} + \textrm{scale} \cdot
+        \arctan \! \left( \frac{2}{\textrm{half\_width}} \, \mathbf{m} \right)
+
+    As :math:`m_i \rightarrow \pm \infty`, :math:`\arctan` saturates at :math:`\pm \pi/2`, so
+    ``ArctanMap`` maps the model onto the bounded interval
+    :math:`(\textrm{shift} - \textrm{scale}\, \pi/2,\ \textrm{shift} + \textrm{scale}\, \pi/2)`.
+    With the default ``scale = 1/pi`` and ``shift = 0.5``, this interval is :math:`(0, 1)`.
+
+    The ``half_width`` parameter controls how quickly the mapping transitions between its
+    bounds: it is the full width (in model space, centered on 0) over which the derivative
+    of the mapping remains at least half of its peak value. Smaller ``half_width`` values
+    produce a steeper, more step-like transfer function.
+
+    Parameters
+    ----------
+    half_width : float
+        Full width (centered at 0) of the region over which the derivative of the mapping
+        is at least half of its peak value; controls the sharpness of the transition.
+        Must be strictly positive. Default is 1.
+    scale : float
+        Scales the output of the arctangent transfer function. Default is :math:`1/\pi`.
+    shift : float
+        Shifts the (scaled) output of the arctangent transfer function. Default is 0.5.
+    deriv_half_width : None or float
+        Half-width used when evaluating :py:meth:`deriv`. If ``None`` (default), the
+        value of ``half_width`` is used. Setting this independently of ``half_width``
+        allows the derivative used during inversion to be smoothed or widened relative
+        to the forward transform.
+    mesh : discretize.BaseMesh
+        The number of parameters accepted by the mapping is set to equal the number
+        of mesh cells.
+    nP : int
+        Set the number of parameters accepted by the mapping directly.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from simpeg.maps import ArctanMap
+
+    >>> mapping = ArctanMap(nP=5, half_width=2.0)
+    >>> m = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+    >>> mapping * m
+    array([0.14758362, 0.25      , 0.5       , 0.75      , 0.85241638])
+    """
 
     def __init__(
         self, half_width=1, scale=1 / np.pi, shift=0.5, deriv_half_width=None, **kwargs
@@ -1600,6 +1698,52 @@ class ArctanMap(IdentityMap):
 
 
 class PiecewiseLinearMap(IdentityMap):
+    r"""Mapping that transforms model parameters through a piecewise-linear transfer function.
+
+    Where :math:`\mathbf{m}` is a set of model parameters and :math:`(\mathbf{x}_p,
+    \mathbf{f}_p)` are a set of ``n`` control points sorted by :math:`\mathbf{x}_p`,
+    ``PiecewiseLinearMap`` creates a mapping :math:`\mathbf{u}(\mathbf{m})` that linearly
+    interpolates between the control points, holding the output constant outside of the
+    range spanned by :math:`\mathbf{x}_p`:
+
+    .. math::
+        u(m) =
+        \begin{cases}
+            (f_p)_1 & m \leq (x_p)_1 \\[4pt]
+            (f_p)_i + \dfrac{(f_p)_{i+1} - (f_p)_i}{(x_p)_{i+1} - (x_p)_i}
+                \big(m - (x_p)_i\big) & (x_p)_i < m \leq (x_p)_{i+1} \\[8pt]
+            (f_p)_n & m > (x_p)_n
+        \end{cases}
+
+    applied element-wise to every entry of :math:`\mathbf{m}`. This is equivalent to
+    :func:`numpy.interp` evaluated at each :math:`m_i`, but is used here as a
+    differentiable transfer function.
+
+    Parameters
+    ----------
+    xp : (n) array_like
+        The x-locations of the control points defining the piecewise-linear function.
+        They do not need to be sorted; they are sorted internally along with ``fp``.
+    fp : (n) array_like
+        The function values at each of the control points in ``xp``.
+    mesh : discretize.BaseMesh
+        The number of parameters accepted by the mapping is set to equal the number
+        of mesh cells.
+    nP : int
+        Set the number of parameters accepted by the mapping directly.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from simpeg.maps import PiecewiseLinearMap
+
+    >>> xp = np.array([0.0, 1.0, 2.0])
+    >>> fp = np.array([0.0, 10.0, 10.0])
+    >>> mapping = PiecewiseLinearMap(xp, fp, nP=6)
+    >>> m = np.array([-1.0, 0.0, 0.5, 1.0, 1.5, 3.0])
+    >>> mapping * m
+    array([ 0.,  0.,  5., 10., 10., 10.])
+    """
 
     def __init__(self, xp, fp, **kwargs):
         xp = np.asarray(xp, dtype=float)
@@ -1638,6 +1782,61 @@ class PiecewiseLinearMap(IdentityMap):
 
 
 class SineTransferMap(IdentityMap):
+    r"""Mapping that transforms model parameters through a raised-cosine transfer function.
+
+    Where :math:`\mathbf{m}` is a set of model parameters, ``SineTransferMap`` creates a
+    mapping :math:`\mathbf{u}(\mathbf{m})` whose derivative is a raised-cosine (Hann-like)
+    window of full width ``half_width`` centered on 0; :math:`\mathbf{u}(\mathbf{m})` is
+    therefore the (scaled and shifted) integral of that window:
+
+    .. math::
+        \mathbf{u}(\mathbf{m}) = \textrm{shift} + \frac{\textrm{scale}}{2}
+        \Big( \sin(\mathbf{x}) + \mathbf{x} \Big), \quad
+        \mathbf{x} = \textrm{clip}\!\left(
+        \frac{\pi}{\textrm{half\_width}} \, \mathbf{m},\ -\pi,\ \pi \right)
+
+    Because :math:`x` is clipped to :math:`[-\pi, \pi]`, the mapping saturates outside of
+    :math:`|m| = \textrm{half\_width}/2`, giving the bounded output range
+    :math:`(\textrm{shift} - \textrm{scale}\, \pi/2,\ \textrm{shift} + \textrm{scale}\, \pi/2)`.
+    With the default ``scale = 1/pi`` and ``shift = 0.5``, this range is :math:`(0, 1)`.
+    ``half_width`` is the full width (in model space, centered on 0) over which the
+    derivative of the mapping is at least half of its peak value, and also marks where the
+    mapping saturates; smaller values produce a steeper, more step-like transition.
+
+    Because the mapping is constant for :math:`|m| \geq \textrm{half\_width}/2`, it is not
+    globally invertible; calling :py:meth:`inverse` raises ``NotImplementedError``.
+
+    Parameters
+    ----------
+    half_width : float
+        Full width (centered at 0) of the region over which the mapping transitions
+        between its bounds. Must be strictly positive. Default is 1.
+    scale : float
+        Scales the output of the transfer function. Default is :math:`1/\pi`.
+    shift : float
+        Shifts the (scaled) output of the transfer function. Default is 0.5.
+    deriv_half_width : None or float
+        Half-width used when evaluating :py:meth:`deriv`. If ``None`` (default), the
+        value of ``half_width`` is used. Setting this independently of ``half_width``
+        allows the derivative used during inversion to be smoothed or widened relative
+        to the forward transform.
+    mesh : discretize.BaseMesh
+        The number of parameters accepted by the mapping is set to equal the number
+        of mesh cells.
+    nP : int
+        Set the number of parameters accepted by the mapping directly.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from simpeg.maps import SineTransferMap
+
+    >>> mapping = SineTransferMap(nP=5, half_width=4.0)
+    >>> m = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+    >>> mapping * m
+    array([0.09084506, 0.26246046, 0.5       , 0.73753954, 0.90915494])
+    """
+
     _base_half_width = np.pi
 
     def __init__(
@@ -1683,6 +1882,60 @@ class SineTransferMap(IdentityMap):
 
 
 class ErfMap(IdentityMap):
+    r"""Mapping that transforms model parameters through a scaled error-function transfer function.
+
+    Where :math:`\mathbf{m}` is a set of model parameters, ``ErfMap`` creates a mapping
+    :math:`\mathbf{u}(\mathbf{m})` that passes each parameter through the Gauss error
+    function, then scales and shifts the result:
+
+    .. math::
+        \mathbf{u}(\mathbf{m}) = \textrm{shift} + \frac{\textrm{scale}}{2}
+        \,\textrm{erf} \! \left( \frac{w_0}{\textrm{half\_width}} \, \mathbf{m} \right),
+        \quad w_0 = 2\sqrt{\ln 2}
+
+    As :math:`m_i \rightarrow \pm \infty`, :math:`\textrm{erf}` saturates at :math:`\pm 1`,
+    so ``ErfMap`` maps the model onto the bounded interval
+    :math:`(\textrm{shift} - \textrm{scale}/2,\ \textrm{shift} + \textrm{scale}/2)`. With
+    the default ``scale = 1`` and ``shift = 0.5``, this interval is :math:`(0, 1)`.
+
+    The constant :math:`w_0 = 2\sqrt{\ln 2}` is the full width at half maximum (FWHM) of
+    the derivative of the unscaled error function, which is a Gaussian. Because of this
+    normalization, ``half_width`` is the full width (in model space, centered on 0) over
+    which the derivative of the mapping remains at least half of its peak value; smaller
+    ``half_width`` values produce a steeper, more step-like transfer function.
+
+    Parameters
+    ----------
+    half_width : float
+        Full width (centered at 0) of the region over which the derivative of the mapping
+        is at least half of its peak value; controls the sharpness of the transition.
+        Must be strictly positive. Default is 1.
+    scale : float
+        Scales the output of the error-function transfer function. Default is 1.
+    shift : float
+        Shifts the (scaled) output of the error-function transfer function. Default is 0.5.
+    deriv_half_width : None or float
+        Half-width used when evaluating :py:meth:`deriv`. If ``None`` (default), the
+        value of ``half_width`` is used. Setting this independently of ``half_width``
+        allows the derivative used during inversion to be smoothed or widened relative
+        to the forward transform.
+    mesh : discretize.BaseMesh
+        The number of parameters accepted by the mapping is set to equal the number
+        of mesh cells.
+    nP : int
+        Set the number of parameters accepted by the mapping directly.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from simpeg.maps import ErfMap
+
+    >>> mapping = ErfMap(nP=5, half_width=2.0)
+    >>> m = np.array([-2.0, -1.0, 0.0, 1.0, 2.0])
+    >>> mapping * m
+    array([0.00926584, 0.11951595, 0.5       , 0.88048405, 0.99073416])
+    """
+
     _base_half_width = 2 * np.sqrt(np.log(2))
 
     def __init__(

--- a/simpeg/maps/_property_maps.py
+++ b/simpeg/maps/_property_maps.py
@@ -7,7 +7,7 @@ from numbers import Real
 import numpy as np
 import scipy.sparse as sp
 from scipy.constants import mu_0
-from scipy.special import expit, logit
+from scipy.special import expit, logit, erf, erfinv
 from discretize.utils import mkvc, sdiag, rotation_matrix_from_normals
 
 from ._base import IdentityMap
@@ -1524,3 +1524,185 @@ class SelfConsistentEffectiveMedium(IdentityMap):
     @property
     def is_linear(self):
         return False
+
+
+class ScaledLogisticSigmoidMap(LogisticSigmoidMap):
+    _base_half_width = 2 * np.log(3 + 2 * np.sqrt(2))
+
+    def __init__(self, half_width=1.0, deriv_half_width=None, **kwargs):
+        super().__init__(**kwargs)
+        self._half_width = validate_float(
+            "half_width", half_width, min_val=0.0, inclusive_min=False
+        )
+        self._deriv_half_width = (
+            self._half_width
+            if deriv_half_width is None
+            else validate_float(
+                "deriv_half_width", deriv_half_width, min_val=0.0, inclusive_min=False
+            )
+        )
+
+    def _transform(self, x):
+        m_scale = self._base_half_width / self._half_width
+        return super()._transform(x * m_scale)
+
+    def inverse(self, y):
+        m_scale = self._base_half_width / self._half_width
+        return super().inverse(y) / m_scale
+
+    def deriv(self, m, v=None):
+        m_scale = self._base_half_width / self._deriv_half_width
+        dm_v = super().deriv(m * m_scale, v)
+        if v is not None:
+            return dm_v * m_scale
+        return sp.diags(np.full_like(m, m_scale)) @ dm_v
+
+
+class ArctanMap(IdentityMap):
+
+    def __init__(
+        self, half_width=1, scale=1 / np.pi, shift=0.5, deriv_half_width=None, **kwargs
+    ):
+        self._half_width = validate_float(
+            "half_width", half_width, min_val=0.0, inclusive_min=False
+        )
+        self._deriv_half_width = (
+            self._half_width
+            if deriv_half_width is None
+            else validate_float(
+                "deriv_half_width", deriv_half_width, min_val=0.0, inclusive_min=False
+            )
+        )
+        self._scale = validate_float("scale", scale)
+        self._shift = validate_float("shift", shift)
+        super().__init__(**kwargs)
+
+    def _transform(self, x):
+        x_scale = 2 / self._half_width
+        return self._scale * np.arctan(x * x_scale) + self._shift
+
+    def inverse(self, y):
+        x_scale = 2 / self._half_width
+        return np.tan((y - self._shift) / self._scale) / x_scale
+
+    def deriv(self, m, v=None):
+        x_scale = 2 / self._deriv_half_width
+        x = m * x_scale
+        dtan = self._scale * x_scale / (x * x + 1)
+        if v is not None:
+            return dtan * v
+        else:
+            return sp.diags(dtan)
+
+
+class PiecewiseLinearMap(IdentityMap):
+
+    def __init__(self, xp, fp, **kwargs):
+        xp = np.asarray(xp, dtype=float)
+        fp = np.asarray(fp, dtpye=float)
+        xp_sort = np.argsort(xp)
+        self._xp = np.r_[-np.inf, xp[xp_sort], np.inf]
+        fp = fp[xp_sort]
+        self._fp = np.r_[fp[0], fp, fp[-1]]
+
+        # construct linear interpolator function
+        self._df = np.diff(self._fp) / np.diff(self._xp)
+        super().__init__(**kwargs)
+
+    def _transform(self, x):
+        intervals = np.searchsorted(self._xp, x)
+        n_ps = len(self._xp) - 2
+        xp = self._xp[np.minimum(intervals, n_ps)]
+        fp = self._fp[intervals]
+        df = self._df[intervals - 1]
+        y = df * (x - xp) + fp
+        return y
+
+    def inverse(self, y):
+        raise NotImplementedError("Cannot uniquely invert a piecewise linear map")
+
+    def deriv(self, m, v=None):
+        intervals = np.searchsorted(self._xp, m)
+        df = self._df[intervals - 1]
+        if v is not None:
+            return df * v
+        return sp.diags(df)
+
+
+class SineTransferMap(IdentityMap):
+    _base_half_width = np.pi
+
+    def __init__(
+        self, half_width=1, scale=1 / np.pi, shift=0.5, deriv_half_width=None, **kwargs
+    ):
+        self._half_width = validate_float(
+            "half_width", half_width, min_val=0.0, inclusive_min=False
+        )
+        self._deriv_half_width = (
+            self._half_width
+            if deriv_half_width is None
+            else validate_float(
+                "deriv_half_width", deriv_half_width, min_val=0.0, inclusive_min=False
+            )
+        )
+        self._scale = validate_float("scale", scale)
+        self._shift = validate_float("shift", shift)
+        super().__init__(**kwargs)
+
+    def _transform(self, x):
+        x_scale = self._base_half_width / self._half_width
+        x = x_scale * x
+        np.maximum(x, -np.pi, out=x)
+        np.minimum(x, np.pi, out=x)
+        return self._scale / 2 * (np.sin(x) + x) + self._shift
+
+    def inverse(self, y):
+        raise NotImplementedError("Cannot uniquely invert a cosine transfer map")
+
+    def deriv(self, m, v=None):
+        x_scale = self._base_half_width / self._deriv_half_width
+        x = x_scale * m
+        np.maximum(x, -np.pi, out=x)
+        np.minimum(x, np.pi, out=x)
+        d_map = self._scale * x_scale / 2 * (np.cos(x) + 1)
+        if v is not None:
+            return d_map * v
+        return sp.diags(d_map)
+
+
+class ErfMap(IdentityMap):
+    _base_half_width = 2 * np.sqrt(np.log(2))
+
+    def __init__(
+        self, half_width=1, scale=1, shift=0.5, deriv_half_width=None, **kwargs
+    ):
+        self._half_width = validate_float(
+            "half_width", half_width, min_val=0.0, inclusive_min=False
+        )
+        self._deriv_half_width = (
+            self._half_width
+            if deriv_half_width is None
+            else validate_float(
+                "deriv_half_width", deriv_half_width, min_val=0.0, inclusive_min=False
+            )
+        )
+        self._scale = validate_float("scale", scale)
+        self._shift = validate_float("shift", shift)
+        super().__init__(**kwargs)
+
+    def _transform(self, x):
+        x_scale = self._base_half_width / self.half_width
+        return self.scale / 2 * erf(x * x_scale) + self.shift
+
+    def inverse(self, y):
+        x_scale = self._base_half_width / self.half_width
+        return erfinv((y - self.shift) / self.scale) / x_scale
+
+    def deriv(self, m, v=None):
+        x_scale = self._base_half_width / self.deriv_half_width
+        m = x_scale * m
+
+        d_erf = (self.scale * x_scale / np.sqrt(np.pi)) * np.exp(-m * m)
+        if v is not None:
+            return d_erf * v
+        return sp.diags(d_erf)

--- a/simpeg/maps/_property_maps.py
+++ b/simpeg/maps/_property_maps.py
@@ -1594,12 +1594,16 @@ class ArctanMap(IdentityMap):
         else:
             return sp.diags(dtan)
 
+    @property
+    def is_linear(self):
+        return False
+
 
 class PiecewiseLinearMap(IdentityMap):
 
     def __init__(self, xp, fp, **kwargs):
         xp = np.asarray(xp, dtype=float)
-        fp = np.asarray(fp, dtpye=float)
+        fp = np.asarray(fp, dtype=float)
         xp_sort = np.argsort(xp)
         self._xp = np.r_[-np.inf, xp[xp_sort], np.inf]
         fp = fp[xp_sort]
@@ -1627,6 +1631,10 @@ class PiecewiseLinearMap(IdentityMap):
         if v is not None:
             return df * v
         return sp.diags(df)
+
+    @property
+    def is_linear(self):
+        return False  # because the derivative value depends on "m" (even though the function used by this is piecwise linear)
 
 
 class SineTransferMap(IdentityMap):
@@ -1669,6 +1677,10 @@ class SineTransferMap(IdentityMap):
             return d_map * v
         return sp.diags(d_map)
 
+    @property
+    def is_linear(self):
+        return False
+
 
 class ErfMap(IdentityMap):
     _base_half_width = 2 * np.sqrt(np.log(2))
@@ -1691,18 +1703,22 @@ class ErfMap(IdentityMap):
         super().__init__(**kwargs)
 
     def _transform(self, x):
-        x_scale = self._base_half_width / self.half_width
-        return self.scale / 2 * erf(x * x_scale) + self.shift
+        x_scale = self._base_half_width / self._half_width
+        return self._scale / 2 * erf(x * x_scale) + self._shift
 
     def inverse(self, y):
-        x_scale = self._base_half_width / self.half_width
-        return erfinv((y - self.shift) / self.scale) / x_scale
+        x_scale = self._base_half_width / self._half_width
+        return erfinv(2 * (y - self._shift) / self._scale) / x_scale
 
     def deriv(self, m, v=None):
-        x_scale = self._base_half_width / self.deriv_half_width
+        x_scale = self._base_half_width / self._deriv_half_width
         m = x_scale * m
 
-        d_erf = (self.scale * x_scale / np.sqrt(np.pi)) * np.exp(-m * m)
+        d_erf = (self._scale * x_scale / np.sqrt(np.pi)) * np.exp(-m * m)
         if v is not None:
             return d_erf * v
         return sp.diags(d_erf)
+
+    @property
+    def is_linear(self):
+        return False

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -29,62 +29,78 @@ REMOVED_IGNORE = [
     "ActiveCells",
 ]
 
-MAPS_TO_EXCLUDE_2D = [
-    "ComboMap",
-    "ActiveCells",
-    "EffectiveSusceptibilityMap",
-    "InjectActiveCells",
-    "LogMap",
-    "LinearMap",
-    "ReciprocalMap",
-    "PolynomialPetroClusterMap",
-    "Surject2Dto3D",
-    "Map2Dto3D",
-    "Mesh2Mesh",
-    "ParametricPolyMap",
-    "PolyMap",
-    "ParametricSplineMap",
-    "SplineMap",
-    "BaseParametric",
-    "ParametricBlock",
-    "ParametricEllipsoid",
-    "ParametricCasingAndLayer",
-    "ParametricLayer",
-    "ParametricBlockInLayer",
-    "Projection",
-    "SelfConsistentEffectiveMedium",
-    "SumMap",
-    "SurjectUnits",
-    "TileMap",
-] + REMOVED_IGNORE
-MAPS_TO_EXCLUDE_3D = [
-    "ComboMap",
-    "ActiveCells",
-    "EffectiveSusceptibilityMap",
-    "InjectActiveCells",
-    "LogMap",
-    "LinearMap",
-    "ReciprocalMap",
-    "PolynomialPetroClusterMap",
-    "CircleMap",
-    "ParametricCircleMap",
-    "Mesh2Mesh",
-    "BaseParametric",
-    "ParametricBlock",
-    "ParametricEllipsoid",
-    "ParametricPolyMap",
-    "PolyMap",
-    "ParametricSplineMap",
-    "SplineMap",
-    "ParametricCasingAndLayer",
-    "ParametricLayer",
-    "ParametricBlockInLayer",
-    "Projection",
-    "SelfConsistentEffectiveMedium",
-    "SumMap",
-    "SurjectUnits",
-    "TileMap",
-] + REMOVED_IGNORE
+TRANSFER_FUNCTION_MAPS = [
+    "ArctanMap",
+    "ErfMap",
+    "PiecewiseLinearMap",
+    "ScaledLogisticSigmoidMap",
+    "SineTransferMap",
+]
+
+MAPS_TO_EXCLUDE_2D = (
+    [
+        "ComboMap",
+        "ActiveCells",
+        "EffectiveSusceptibilityMap",
+        "InjectActiveCells",
+        "LogMap",
+        "LinearMap",
+        "ReciprocalMap",
+        "PolynomialPetroClusterMap",
+        "Surject2Dto3D",
+        "Map2Dto3D",
+        "Mesh2Mesh",
+        "ParametricPolyMap",
+        "PolyMap",
+        "ParametricSplineMap",
+        "SplineMap",
+        "BaseParametric",
+        "ParametricBlock",
+        "ParametricEllipsoid",
+        "ParametricCasingAndLayer",
+        "ParametricLayer",
+        "ParametricBlockInLayer",
+        "Projection",
+        "SelfConsistentEffectiveMedium",
+        "SumMap",
+        "SurjectUnits",
+        "TileMap",
+    ]
+    + REMOVED_IGNORE
+    + TRANSFER_FUNCTION_MAPS
+)
+MAPS_TO_EXCLUDE_3D = (
+    [
+        "ComboMap",
+        "ActiveCells",
+        "EffectiveSusceptibilityMap",
+        "InjectActiveCells",
+        "LogMap",
+        "LinearMap",
+        "ReciprocalMap",
+        "PolynomialPetroClusterMap",
+        "CircleMap",
+        "ParametricCircleMap",
+        "Mesh2Mesh",
+        "BaseParametric",
+        "ParametricBlock",
+        "ParametricEllipsoid",
+        "ParametricPolyMap",
+        "PolyMap",
+        "ParametricSplineMap",
+        "SplineMap",
+        "ParametricCasingAndLayer",
+        "ParametricLayer",
+        "ParametricBlockInLayer",
+        "Projection",
+        "SelfConsistentEffectiveMedium",
+        "SumMap",
+        "SurjectUnits",
+        "TileMap",
+    ]
+    + REMOVED_IGNORE
+    + TRANSFER_FUNCTION_MAPS
+)
 
 
 def test_IdentityMap_init():
@@ -640,6 +656,110 @@ def test_logit_limits():
     assert logit_map * np.r_[50] == np.r_[-1]
 
 
+@pytest.mark.parametrize(
+    "map_class, kwargs",
+    [
+        (maps.ArctanMap, {}),
+        (maps.ArctanMap, {"half_width": 2.5, "scale": 2.0, "shift": -1.0}),
+        (maps.ErfMap, {}),
+        (maps.ErfMap, {"half_width": 0.5, "scale": 3.0, "shift": 1.0}),
+        (maps.ScaledLogisticSigmoidMap, {}),
+        (maps.ScaledLogisticSigmoidMap, {"half_width": 3.0}),
+        (maps.SineTransferMap, {}),
+        (maps.SineTransferMap, {"half_width": 2.0, "scale": 2.0, "shift": -1.0}),
+    ],
+)
+def test_transfer_function_maps_derivative(map_class, kwargs):
+    """
+    Test the derivative of the bounded transfer function maps (ArctanMap, ErfMap,
+    ScaledLogisticSigmoidMap and SineTransferMap) against a numerical derivative check.
+    """
+    nP = 8
+    mapping = map_class(nP=nP, **kwargs)
+    rng = np.random.default_rng(seed=52)
+    m = rng.normal(scale=2.0, size=nP)
+    assert mapping.test(m=m, random_seed=52)
+
+
+@pytest.mark.parametrize(
+    "map_class", [maps.ArctanMap, maps.ErfMap, maps.ScaledLogisticSigmoidMap]
+)
+def test_transfer_function_maps_inverse(map_class):
+    """
+    Test that the transfer function maps with a closed-form inverse recover the
+    original model.
+    """
+    nP = 6
+    mapping = map_class(nP=nP)
+    rng = np.random.default_rng(seed=53)
+    m = rng.normal(scale=1.0, size=nP)
+    d = mapping * m
+    m_rec = mapping.inverse(d)
+    np.testing.assert_allclose(m, m_rec, atol=1e-8)
+
+
+def test_transfer_function_maps_saturate():
+    """
+    ArctanMap, ErfMap, ScaledLogisticSigmoidMap and SineTransferMap should saturate
+    to shift +/- scale * (their theoretical bound) as the model goes to +/- infinity.
+    """
+    m = np.array([-1e6, 1e6])
+
+    mapping = maps.ArctanMap(nP=2)
+    np.testing.assert_allclose(mapping * m, [0.0, 1.0], atol=1e-6)
+
+    mapping = maps.ErfMap(nP=2)
+    np.testing.assert_allclose(mapping * m, [0.0, 1.0], atol=1e-6)
+
+    mapping = maps.ScaledLogisticSigmoidMap(nP=2)
+    np.testing.assert_allclose(mapping * m, [0.0, 1.0], atol=1e-6)
+
+    mapping = maps.SineTransferMap(nP=2)
+    np.testing.assert_allclose(mapping * m, [0.0, 1.0])
+
+
+def test_sine_transfer_map_not_invertible():
+    """SineTransferMap is not globally invertible; it should raise NotImplementedError."""
+    mapping = maps.SineTransferMap(nP=3)
+    with pytest.raises(NotImplementedError):
+        mapping.inverse(np.array([0.1, 0.2, 0.3]))
+
+
+class TestPiecewiseLinearMap:
+    """Tests for ``PiecewiseLinearMap``."""
+
+    def test_transform(self):
+        xp = np.array([0.0, 5.0, 10.0])
+        fp = np.array([0.0, 10.0, 10.0])
+        mapping = maps.PiecewiseLinearMap(xp, fp, nP=6)
+        m = np.array([-1.0, 0.0, 2.5, 5.0, 7.5, 15.0])
+        expected = np.array([0.0, 0.0, 5.0, 10.0, 10.0, 10.0])
+        np.testing.assert_allclose(mapping * m, expected)
+
+    def test_transform_unsorted_control_points(self):
+        """``xp``/``fp`` do not need to be pre-sorted."""
+        xp = np.array([2.0, 0.0, 1.0])
+        fp = np.array([10.0, 0.0, 10.0])
+        mapping = maps.PiecewiseLinearMap(xp, fp, nP=4)
+        m = np.array([-1.0, 0.5, 1.5, 3.0])
+        expected = np.array([0.0, 5.0, 10.0, 10.0])
+        np.testing.assert_allclose(mapping * m, expected)
+
+    def test_deriv(self):
+        xp = np.array([0.0, 5.0, 10.0])
+        fp = np.array([0.0, 10.0, 10.0])
+        mapping = maps.PiecewiseLinearMap(xp, fp, nP=4)
+        m = np.array([-2.0, 2.5, 7.5, 12.0])
+        assert mapping.test(m=m, random_seed=54)
+
+    def test_inverse_not_implemented(self):
+        xp = np.array([0.0, 1.0, 2.0])
+        fp = np.array([0.0, 10.0, 10.0])
+        mapping = maps.PiecewiseLinearMap(xp, fp, nP=3)
+        with pytest.raises(NotImplementedError):
+            mapping.inverse(np.array([1.0, 2.0, 3.0]))
+
+
 class TestWires(unittest.TestCase):
     def test_basic(self):
         mesh = discretize.TensorMesh([10, 10, 10])
@@ -794,6 +914,11 @@ def test_linearity():
         maps.PolynomialPetroClusterMap(),
         maps.IdentityMap() + maps.ExpMap(),  # A simple SumMap
         maps.ChiMap() * maps.ExpMap(),  # A simple ComboMap
+        maps.ArctanMap(),
+        maps.ErfMap(),
+        maps.ScaledLogisticSigmoidMap(),
+        maps.SineTransferMap(),
+        maps.PiecewiseLinearMap(np.r_[0.0, 1.0, 2.0], np.r_[0.0, 1.0, 1.0]),
     ]
 
     assert all(m.is_linear for m in linear_maps)

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -682,6 +682,35 @@ def test_transfer_function_maps_derivative(map_class, kwargs):
 
 
 @pytest.mark.parametrize(
+    "map_class, kwargs",
+    [
+        (maps.ArctanMap, {}),
+        (maps.ArctanMap, {"half_width": 2.5, "scale": 2.0, "shift": -1.0}),
+        (maps.ErfMap, {}),
+        (maps.ErfMap, {"half_width": 0.5, "scale": 3.0, "shift": 1.0}),
+        (maps.ScaledLogisticSigmoidMap, {}),
+        (maps.ScaledLogisticSigmoidMap, {"half_width": 3.0}),
+        (maps.SineTransferMap, {}),
+        (maps.SineTransferMap, {"half_width": 2.0, "scale": 2.0, "shift": -1.0}),
+    ],
+)
+def test_transfer_function_maps_deriv_v(map_class, kwargs):
+    """
+    Test the ``v`` argument of ``deriv`` for the transfer function maps.
+
+    ``deriv(m, v=v)`` should return the same result as multiplying the full
+    derivative matrix returned by ``deriv(m)`` (i.e. with ``v=None``) by ``v``.
+    """
+    nP = 8
+    mapping = map_class(nP=nP, **kwargs)
+    rng = np.random.default_rng(seed=55)
+    m = rng.normal(scale=2.0, size=nP)
+    v = rng.normal(size=nP)
+    derivative = mapping.deriv(m)
+    np.testing.assert_allclose(derivative @ v, mapping.deriv(m, v=v))
+
+
+@pytest.mark.parametrize(
     "map_class", [maps.ArctanMap, maps.ErfMap, maps.ScaledLogisticSigmoidMap]
 )
 def test_transfer_function_maps_inverse(map_class):
@@ -751,6 +780,20 @@ class TestPiecewiseLinearMap:
         mapping = maps.PiecewiseLinearMap(xp, fp, nP=4)
         m = np.array([-2.0, 2.5, 7.5, 12.0])
         assert mapping.test(m=m, random_seed=54)
+
+    def test_deriv_v(self):
+        """
+        ``deriv(m, v=v)`` should return the same result as multiplying the full
+        derivative matrix returned by ``deriv(m)`` (i.e. with ``v=None``) by ``v``.
+        """
+        xp = np.array([0.0, 5.0, 10.0])
+        fp = np.array([0.0, 10.0, 10.0])
+        mapping = maps.PiecewiseLinearMap(xp, fp, nP=4)
+        m = np.array([-2.0, 2.5, 7.5, 12.0])
+        rng = np.random.default_rng(seed=56)
+        v = rng.normal(size=4)
+        derivative = mapping.deriv(m)
+        np.testing.assert_allclose(derivative @ v, mapping.deriv(m, v=v))
 
     def test_inverse_not_implemented(self):
         xp = np.array([0.0, 1.0, 2.0])


### PR DESCRIPTION
#### Summary
Adds many transfer functions I've been using in some of my own experiments regarding level set inversions. Basically these are all slightly ways of limiting the values, just with all slightly different shapes.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Additional information
In general, I'm referring to transfer functions as mapping the full number line from -inf to inf, to be between two numbers in a smooth way (think the arctan function). These functions allow a bit more control over some of the previous in terms of how *fast* they transfer between the extreme values. I found the natural way for me to think about this was by using the "half-width" of the derivative. I.e. the width of the derivative at half it's maximum amplitude. They also generally allow you to set a `deriv_half_width` parameter if you want to separately control the derivative and the transformation, (e.g. the mapping itself is very sharp, but you want to use a "smoothed" version of it when calculating derivatives). 