### PR TITLE
Enhance robustness and error handling in multiprocessing simulations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ local_scheme = "node-and-date"
 [tool.coverage.run]
 branch = true
 source = ["simpeg", "tests", "examples", "tutorials"]
-concurrency = ["multiprocessing"]
+concurrency = ["thread", "multiprocessing"]
 parallel = true
 sigterm = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ local_scheme = "node-and-date"
 [tool.coverage.run]
 branch = true
 source = ["simpeg", "tests", "examples", "tutorials"]
-concurrency = ["thread", "multiprocessing"]
+concurrency = ["multiprocessing"]
 parallel = true
 sigterm = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,8 @@ name = 'simpeg'
 description = "SimPEG: Simulation and Parameter Estimation in Geophysics"
 readme = 'README.rst'
 requires-python = '>=3.11'
-authors = [
-  {name = 'SimPEG developers', email = 'rowanc1@gmail.com'},
-]
-keywords = [
-    'geophysics', 'inverse problem'
-]
+authors = [{ name = 'SimPEG developers', email = 'rowanc1@gmail.com' }]
+keywords = ['geophysics', 'inverse problem']
 dependencies = [
     "numpy>=1.22",
     "scipy>=1.12",
@@ -57,7 +53,7 @@ plotting = ["plotly"]
 sklearn = ["scikit-learn>=1.2"]
 pandas = ["pandas"]
 all = [
-    "simpeg[dask,choclo,plotting,reporting,sklearn,pandas]"
+    "simpeg[dask,choclo,plotting,reporting,sklearn,pandas]",
 ] # all optional *runtime* dependencies (not related to development)
 style = [
     "black==24.3.0",
@@ -84,14 +80,8 @@ docs = [
     "memory_profiler",
     "python-kaleido",
 ]
-tests = [
-    "simpeg[all,docs]",
-    "pytest",
-    "pytest-cov",
-]
-dev = [
-    "simpeg[all,style,docs,tests]",
-] # the whole kit and caboodle
+tests = ["simpeg[all,docs]", "pytest", "pytest-cov"]
+dev = ["simpeg[all,style,docs,tests]"] # the whole kit and caboodle
 
 [tool.setuptools]
 py-modules = ['SimPEG']
@@ -106,6 +96,10 @@ local_scheme = "node-and-date"
 [tool.coverage.run]
 branch = true
 source = ["simpeg", "tests", "examples", "tutorials"]
+concurrency = ["multiprocessing"]
+parallel = true
+sigterm = true
+
 
 [tool.coverage.report]
 ignore_errors = false
@@ -142,7 +136,14 @@ target-version = ['py310', 'py311', 'py312']
 [tool.flake8]
 extend-ignore = [
     # Default ignores by flake (added here for when ignore gets overwritten)
-    'E121','E123','E126','E226','E24','E704','W503','W504',
+    'E121',
+    'E123',
+    'E126',
+    'E226',
+    'E24',
+    'E704',
+    'W503',
+    'W504',
     # Too many leading '#' for block comment
     'E266',
     # Line too long (82 > 79 characters)
@@ -248,13 +249,7 @@ ignore = [
     'RST499',
 ]
 
-rst-roles = [
-    'class',
-    'func',
-    'mod',
-    'meth',
-    'ref',
-]
+rst-roles = ['class', 'func', 'mod', 'meth', 'ref']
 
 # pyproject.toml
 [tool.pytest.ini_options]

--- a/simpeg/meta/multiprocessing.py
+++ b/simpeg/meta/multiprocessing.py
@@ -1,8 +1,32 @@
+import atexit
+import threading
+from enum import Enum, auto
+from queue import Empty
 from multiprocessing import Process, Queue, cpu_count
 from simpeg.meta import MetaSimulation, SumMetaSimulation, RepeatedSimulation
 from simpeg.props import HasModel
 import uuid
 import numpy as np
+
+
+class _Op(Enum):
+    """The set of operations a `_SimulationProcess` understands.
+
+    Sent as the first element of each task tuple put on a process's
+    `task_queue`; members pickle by reference (name), so this only needs
+    to be importable from the same module path in both processes, which
+    it is since a spawned child re-imports this module.
+    """
+
+    SET_SIM = auto()
+    GET_ITEM = auto()
+    DEL_ITEM = auto()
+    STORE_MODEL = auto()
+    CREATE_FIELDS = auto()
+    DPRED = auto()
+    JVEC = auto()
+    JTVEC = auto()
+    JTJ_DIAG = auto()
 
 
 class SimpleFuture:
@@ -17,7 +41,7 @@ class SimpleFuture:
     # classes stash the simulation, so this requires serializing
     # the simulation (something we explicitly want to avoid in all cases).
     # def result(self):
-    #     self.t_queue.put(("get_item", (self.item_id,)))
+    #     self.t_queue.put((_Op.GET_ITEM, (self.item_id,)))
     #     item = self.r_queue.get()
     #     if isinstance(item, Exception):
     #         raise item
@@ -25,7 +49,7 @@ class SimpleFuture:
 
     def __del__(self):
         if self.sim_process.is_alive():
-            self.sim_process.task_queue.put(("del_item", (self.item_id,)))
+            self.sim_process.task_queue.put((_Op.DEL_ITEM, (self.item_id,)))
 
 
 class _SimulationProcess(Process):
@@ -46,6 +70,9 @@ class _SimulationProcess(Process):
         # everything here is local to the process
         # a place to cache items locally
         _cached_items = {}
+        # errors from fire-and-forget ops (no matching client-side `get()`),
+        # deferred until the next op that actually touches that sim_key.
+        _pending_errors = {}
 
         # The queues are shared between the head process and the worker processes
         # We use them to communicate between the two.
@@ -59,65 +86,101 @@ class _SimulationProcess(Process):
                 break
             op, args = task
             try:
-                if op == "set_sim":
+                if op == _Op.SET_SIM:
                     (sim,) = args
                     sim_key = uuid.uuid4().hex
                     _cached_items[sim_key] = sim
                     r_queue.put(sim_key)
-                elif op == "get_item":
+                elif op == _Op.GET_ITEM:
                     (key,) = args
                     r_queue.put(_cached_items[key])
-                elif op == "del_item":
+                elif op == _Op.DEL_ITEM:
                     (key,) = args
                     _cached_items.pop(key, None)
-                elif op == 0:
-                    # store_model
+                elif op == _Op.STORE_MODEL:
                     sim_key, m = args
+                    if sim_key in _pending_errors:
+                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
-                    sim.model = m
-                elif op == 1:
-                    # create fields
+                    try:
+                        sim.model = m
+                    except Exception as err:
+                        # No client code reads a result for this op, so we
+                        # can't put this on r_queue without desyncing the
+                        # protocol. Stash it and raise it on the next op
+                        # that touches this sim, which does have a reader.
+                        _pending_errors[sim_key] = err
+                elif op == _Op.CREATE_FIELDS:
                     (sim_key,) = args
+                    if sim_key in _pending_errors:
+                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
                     f_key = uuid.uuid4().hex
+                    # Put the key immediately so the client isn't blocked
+                    # waiting on this (possibly expensive) computation before
+                    # it can move on to dispatching work to other processes.
                     r_queue.put(f_key)
-                    fields = sim.fields(sim.model)
+                    try:
+                        fields = sim.fields(sim.model)
+                    except Exception as err:
+                        # Store the error itself in place of the fields, so
+                        # it surfaces the first time this key is actually
+                        # used, instead of appearing as a stray item here.
+                        fields = err
                     _cached_items[f_key] = fields
-                elif op == 2:
-                    # do dpred
+                elif op == _Op.DPRED:
                     sim_key, f_key = args
+                    if sim_key in _pending_errors:
+                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
                     fields = _cached_items[f_key]
+                    if isinstance(fields, Exception):
+                        raise fields
                     d_pred = sim.dpred(sim.model, fields)
                     r_queue.put(d_pred)
-                elif op == 3:
-                    # do jvec
+                elif op == _Op.JVEC:
                     sim_key, v, f_key = args
+                    if sim_key in _pending_errors:
+                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
                     fields = _cached_items[f_key]
+                    if isinstance(fields, Exception):
+                        raise fields
                     jvec = sim.Jvec(sim.model, v, fields)
                     r_queue.put(jvec)
-                elif op == 4:
-                    # do jtvec
+                elif op == _Op.JTVEC:
                     sim_key, v, f_key = args
+                    if sim_key in _pending_errors:
+                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
                     fields = _cached_items[f_key]
+                    if isinstance(fields, Exception):
+                        raise fields
                     jtvec = sim.Jtvec(sim.model, v, fields)
                     r_queue.put(jtvec)
-                elif op == 5:
-                    # do jtj_diag
+                elif op == _Op.JTJ_DIAG:
                     sim_key, w, f_key = args
+                    if sim_key in _pending_errors:
+                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
                     fields = _cached_items[f_key]
+                    if isinstance(fields, Exception):
+                        raise fields
                     jtj = sim.getJtJdiag(sim.model, w, fields)
                     r_queue.put(jtj)
             except Exception as err:
                 r_queue.put(err)
 
+    def _get_result(self):
+        item = self.result_queue.get()
+        if isinstance(item, Exception):
+            raise item
+        return item
+
     def set_sim(self, sim):
         self._check_closed()
-        self.task_queue.put(("set_sim", (sim,)))
-        key = self.result_queue.get()
+        self.task_queue.put((_Op.SET_SIM, (sim,)))
+        key = self._get_result()
         future = SimpleFuture(key, self)
         self._my_sim = future
         return future
@@ -125,37 +188,37 @@ class _SimulationProcess(Process):
     def store_model(self, m):
         self._check_closed()
         sim = self._my_sim
-        self.task_queue.put((0, (sim.item_id, m)))
+        self.task_queue.put((_Op.STORE_MODEL, (sim.item_id, m)))
 
     def get_fields(self):
         self._check_closed()
         sim = self._my_sim
-        self.task_queue.put((1, (sim.item_id,)))
-        key = self.result_queue.get()
+        self.task_queue.put((_Op.CREATE_FIELDS, (sim.item_id,)))
+        key = self._get_result()
         future = SimpleFuture(key, self)
         return future
 
     def start_dpred(self, f_future):
         self._check_closed()
         sim = self._my_sim
-        self.task_queue.put((2, (sim.item_id, f_future.item_id)))
+        self.task_queue.put((_Op.DPRED, (sim.item_id, f_future.item_id)))
 
     def start_j_vec(self, v, f_future):
         self._check_closed()
         sim = self._my_sim
-        self.task_queue.put((3, (sim.item_id, v, f_future.item_id)))
+        self.task_queue.put((_Op.JVEC, (sim.item_id, v, f_future.item_id)))
 
     def start_jt_vec(self, v, f_future):
         self._check_closed()
         sim = self._my_sim
-        self.task_queue.put((4, (sim.item_id, v, f_future.item_id)))
+        self.task_queue.put((_Op.JTVEC, (sim.item_id, v, f_future.item_id)))
 
     def start_jtj_diag(self, w, f_future):
         self._check_closed()
         sim = self._my_sim
         self.task_queue.put(
             (
-                5,
+                _Op.JTJ_DIAG,
                 (
                     sim.item_id,
                     w,
@@ -166,16 +229,38 @@ class _SimulationProcess(Process):
 
     def result(self):
         self._check_closed()
-        return self.result_queue.get()
+        return self._get_result()
 
     def join(self, timeout=None):
         self._check_closed()
         self.task_queue.put(None)
         self.task_queue.close()
-        self.result_queue.close()
         self.task_queue.join_thread()
+
+        # A result the caller never read (e.g. because an earlier
+        # collection loop raised before reaching this process) can block
+        # this process's result_queue feeder thread from flushing, which
+        # would otherwise deadlock the plain Process.join() below. Drain
+        # in the background while we wait so that can't happen.
+        stop_draining = threading.Event()
+
+        def _drain():
+            while not stop_draining.is_set():
+                try:
+                    self.result_queue.get(timeout=0.1)
+                except Empty:
+                    continue
+
+        drain_thread = threading.Thread(target=_drain, daemon=True)
+        drain_thread.start()
+        try:
+            super().join(timeout=timeout)
+        finally:
+            stop_draining.set()
+            drain_thread.join()
+
+        self.result_queue.close()
         self.result_queue.join_thread()
-        super().join(timeout=timeout)
 
 
 class MultiprocessingMetaSimulation(MetaSimulation):
@@ -225,6 +310,11 @@ class MultiprocessingMetaSimulation(MetaSimulation):
     >>> mp.set_start_method("spawn")
     """
 
+    # The type of simulation used to represent each process's chunk of the
+    # work. Subclasses whose combination semantics differ from plain
+    # concatenation (e.g. summing) must override this to match.
+    _chunk_sim_class = MetaSimulation
+
     def __init__(self, simulations, mappings, n_processes=None):
         super().__init__(simulations, mappings)
 
@@ -241,22 +331,40 @@ class MultiprocessingMetaSimulation(MetaSimulation):
         i_start = 0
         chunk_nd = []
         processes = []
-        for chunk in chunk_sizes:
-            if chunk == 0:
-                continue
-            i_end = i_start + chunk
-            sim_chunk = MetaSimulation(
-                self.simulations[i_start:i_end], self.mappings[i_start:i_end]
-            )
-            chunk_nd.append(sim_chunk.survey.nD)
-            p = _SimulationProcess()
-            processes.append(p)
-            p.start()
-            p.set_sim(sim_chunk)
-            i_start = i_end
+        try:
+            for chunk in chunk_sizes:
+                if chunk == 0:
+                    continue
+                i_end = i_start + chunk
+                sim_chunk = self._chunk_sim_class(
+                    self.simulations[i_start:i_end], self.mappings[i_start:i_end]
+                )
+                chunk_nd.append(sim_chunk.survey.nD)
+                p = _SimulationProcess()
+                processes.append(p)
+                p.start()
+                p.set_sim(sim_chunk)
+                i_start = i_end
+        except Exception:
+            for p in processes:
+                if p.is_alive():
+                    p.terminate()
+            raise
 
         self._sim_processes = processes
         self._data_offsets = np.cumsum(np.r_[0, chunk_nd])
+        atexit.register(self._atexit_cleanup)
+
+    def _atexit_cleanup(self):
+        # Best-effort fallback for interpreter shutdown when `.join()` was
+        # never called. Uses terminate() (immediate, no queue cooperation
+        # needed) rather than the graceful join() protocol, so this can't
+        # itself hang interpreter shutdown. This must never run as a
+        # side-effect of an error from a normal method call (dpred/Jvec/
+        # etc.) -- only atexit triggers it.
+        for p in getattr(self, "_sim_processes", ()):
+            if p.is_alive():
+                p.terminate()
 
     @MetaSimulation.model.setter
     def model(self, value):
@@ -347,6 +455,8 @@ class MultiprocessingMetaSimulation(MetaSimulation):
         for p in self._sim_processes:
             if p.is_alive():
                 p.join(timeout=timeout)
+        if not any(p.is_alive() for p in self._sim_processes):
+            atexit.unregister(self._atexit_cleanup)
 
 
 class MultiprocessingSumMetaSimulation(
@@ -371,6 +481,8 @@ class MultiprocessingSumMetaSimulation(
         to `multiprocessing.cpu_count()`. The number of processes spawned
         will be the minimum of this number and the number of simulations.
     """
+
+    _chunk_sim_class = SumMetaSimulation
 
     def dpred(self, m=None, f=None):
         if f is None:
@@ -462,19 +574,26 @@ class MultiprocessingRepeatedSimulation(
         processes = []
         i_start = 0
         chunk_nd = []
-        for chunk in chunk_sizes:
-            if chunk == 0:
-                continue
-            i_end = i_start + chunk
-            sim_chunk = RepeatedSimulation(
-                self.simulation, self.mappings[i_start:i_end]
-            )
-            chunk_nd.append(sim_chunk.survey.nD)
-            p = _SimulationProcess()
-            processes.append(p)
-            p.start()
-            p.set_sim(sim_chunk)
-            i_start = i_end
+        try:
+            for chunk in chunk_sizes:
+                if chunk == 0:
+                    continue
+                i_end = i_start + chunk
+                sim_chunk = RepeatedSimulation(
+                    self.simulation, self.mappings[i_start:i_end]
+                )
+                chunk_nd.append(sim_chunk.survey.nD)
+                p = _SimulationProcess()
+                processes.append(p)
+                p.start()
+                p.set_sim(sim_chunk)
+                i_start = i_end
+        except Exception:
+            for p in processes:
+                if p.is_alive():
+                    p.terminate()
+            raise
 
         self._data_offsets = np.cumsum(np.r_[0, chunk_nd])
         self._sim_processes = processes
+        atexit.register(self._atexit_cleanup)

--- a/simpeg/meta/multiprocessing.py
+++ b/simpeg/meta/multiprocessing.py
@@ -246,6 +246,59 @@ class _SimulationProcess(Process):
         self.result_queue.join_thread()
 
 
+def _spawn_chunk_processes(n_sim, n_processes, build_chunk):
+    """Split `n_sim` items into contiguous chunks, one worker process each.
+
+    Shared by every `Multiprocessing*Simulation.__init__`: they differ only
+    in how a chunk's combined simulation is built, which is supplied here
+    via `build_chunk`.
+
+    Parameters
+    ----------
+    n_sim : int
+        Total number of individual simulations to distribute.
+    n_processes : int
+        Number of worker processes to aim for. Chunks are sized as evenly
+        as possible; if `n_processes > n_sim` the extra, zero-sized chunks
+        are simply skipped, so fewer processes than requested may result.
+    build_chunk : callable
+        Called with `(i_start, i_end)` for each contiguous chunk and must
+        return the combined simulation to send to that chunk's process.
+
+    Returns
+    -------
+    processes : list of _SimulationProcess
+    data_offsets : numpy.ndarray
+    """
+    chunk_sizes = min(n_processes, n_sim) * [n_sim // n_processes]
+    for i in range(n_sim % n_processes):
+        chunk_sizes[i] += 1
+
+    i_start = 0
+    chunk_nd = []
+    processes = []
+    try:
+        for chunk in chunk_sizes:
+            if chunk == 0:
+                continue
+            i_end = i_start + chunk
+            sim_chunk = build_chunk(i_start, i_end)
+            chunk_nd.append(sim_chunk.survey.nD)
+            p = _SimulationProcess()
+            processes.append(p)
+            p.start()
+            p.set_sim(sim_chunk)
+            i_start = i_end
+    except Exception:
+        for p in processes:
+            if p.is_alive():
+                p.terminate()
+        raise
+
+    data_offsets = np.cumsum(np.r_[0, chunk_nd])
+    return processes, data_offsets
+
+
 class MultiprocessingMetaSimulation(MetaSimulation):
     """Multiprocessing version of simulation of simulations.
 
@@ -304,38 +357,14 @@ class MultiprocessingMetaSimulation(MetaSimulation):
         if n_processes is None:
             n_processes = cpu_count()
 
-        # split simulation,mappings up into chunks
-        # (Which are currently defined using MetaSimulations)
-        n_sim = len(simulations)
-        chunk_sizes = min(n_processes, n_sim) * [n_sim // n_processes]
-        for i in range(n_sim % n_processes):
-            chunk_sizes[i] += 1
+        def build_chunk(i_start, i_end):
+            return self._chunk_sim_class(
+                self.simulations[i_start:i_end], self.mappings[i_start:i_end]
+            )
 
-        i_start = 0
-        chunk_nd = []
-        processes = []
-        try:
-            for chunk in chunk_sizes:
-                if chunk == 0:
-                    continue
-                i_end = i_start + chunk
-                sim_chunk = self._chunk_sim_class(
-                    self.simulations[i_start:i_end], self.mappings[i_start:i_end]
-                )
-                chunk_nd.append(sim_chunk.survey.nD)
-                p = _SimulationProcess()
-                processes.append(p)
-                p.start()
-                p.set_sim(sim_chunk)
-                i_start = i_end
-        except Exception:
-            for p in processes:
-                if p.is_alive():
-                    p.terminate()
-            raise
-
-        self._sim_processes = processes
-        self._data_offsets = np.cumsum(np.r_[0, chunk_nd])
+        self._sim_processes, self._data_offsets = _spawn_chunk_processes(
+            len(simulations), n_processes, build_chunk
+        )
         atexit.register(self._atexit_cleanup)
 
     def _atexit_cleanup(self):
@@ -554,35 +583,10 @@ class MultiprocessingRepeatedSimulation(
         if n_processes is None:
             n_processes = cpu_count()
 
-        # split mappings up into chunks
-        n_sim = len(mappings)
-        chunk_sizes = min(n_processes, n_sim) * [n_sim // n_processes]
-        for i in range(n_sim % n_processes):
-            chunk_sizes[i] += 1
+        def build_chunk(i_start, i_end):
+            return RepeatedSimulation(self.simulation, self.mappings[i_start:i_end])
 
-        processes = []
-        i_start = 0
-        chunk_nd = []
-        try:
-            for chunk in chunk_sizes:
-                if chunk == 0:
-                    continue
-                i_end = i_start + chunk
-                sim_chunk = RepeatedSimulation(
-                    self.simulation, self.mappings[i_start:i_end]
-                )
-                chunk_nd.append(sim_chunk.survey.nD)
-                p = _SimulationProcess()
-                processes.append(p)
-                p.start()
-                p.set_sim(sim_chunk)
-                i_start = i_end
-        except Exception:
-            for p in processes:
-                if p.is_alive():
-                    p.terminate()
-            raise
-
-        self._data_offsets = np.cumsum(np.r_[0, chunk_nd])
-        self._sim_processes = processes
+        self._sim_processes, self._data_offsets = _spawn_chunk_processes(
+            len(mappings), n_processes, build_chunk
+        )
         atexit.register(self._atexit_cleanup)

--- a/simpeg/meta/multiprocessing.py
+++ b/simpeg/meta/multiprocessing.py
@@ -70,9 +70,6 @@ class _SimulationProcess(Process):
         # everything here is local to the process
         # a place to cache items locally
         _cached_items = {}
-        # errors from fire-and-forget ops (no matching client-side `get()`),
-        # deferred until the next op that actually touches that sim_key.
-        _pending_errors = {}
 
         # The queues are shared between the head process and the worker processes
         # We use them to communicate between the two.
@@ -99,21 +96,11 @@ class _SimulationProcess(Process):
                     _cached_items.pop(key, None)
                 elif op == _Op.STORE_MODEL:
                     sim_key, m = args
-                    if sim_key in _pending_errors:
-                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
-                    try:
-                        sim.model = m
-                    except Exception as err:
-                        # No client code reads a result for this op, so we
-                        # can't put this on r_queue without desyncing the
-                        # protocol. Stash it and raise it on the next op
-                        # that touches this sim, which does have a reader.
-                        _pending_errors[sim_key] = err
+                    sim.model = m
+                    r_queue.put(None)
                 elif op == _Op.CREATE_FIELDS:
                     (sim_key,) = args
-                    if sim_key in _pending_errors:
-                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
                     f_key = uuid.uuid4().hex
                     # Put the key immediately so the client isn't blocked
@@ -130,8 +117,6 @@ class _SimulationProcess(Process):
                     _cached_items[f_key] = fields
                 elif op == _Op.DPRED:
                     sim_key, f_key = args
-                    if sim_key in _pending_errors:
-                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
                     fields = _cached_items[f_key]
                     if isinstance(fields, Exception):
@@ -140,8 +125,6 @@ class _SimulationProcess(Process):
                     r_queue.put(d_pred)
                 elif op == _Op.JVEC:
                     sim_key, v, f_key = args
-                    if sim_key in _pending_errors:
-                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
                     fields = _cached_items[f_key]
                     if isinstance(fields, Exception):
@@ -150,8 +133,6 @@ class _SimulationProcess(Process):
                     r_queue.put(jvec)
                 elif op == _Op.JTVEC:
                     sim_key, v, f_key = args
-                    if sim_key in _pending_errors:
-                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
                     fields = _cached_items[f_key]
                     if isinstance(fields, Exception):
@@ -160,8 +141,6 @@ class _SimulationProcess(Process):
                     r_queue.put(jtvec)
                 elif op == _Op.JTJ_DIAG:
                     sim_key, w, f_key = args
-                    if sim_key in _pending_errors:
-                        raise _pending_errors.pop(sim_key)
                     sim = _cached_items[sim_key]
                     fields = _cached_items[f_key]
                     if isinstance(fields, Exception):
@@ -185,10 +164,14 @@ class _SimulationProcess(Process):
         self._my_sim = future
         return future
 
-    def store_model(self, m):
+    def start_store_model(self, m):
         self._check_closed()
         sim = self._my_sim
         self.task_queue.put((_Op.STORE_MODEL, (sim.item_id, m)))
+
+    def store_model(self, m):
+        self.start_store_model(m)
+        self._get_result()
 
     def get_fields(self):
         self._check_closed()
@@ -371,8 +354,14 @@ class MultiprocessingMetaSimulation(MetaSimulation):
         updated = HasModel.model.fset(self, value)
         # Only send the model to the internal simulations if it was updated.
         if updated:
+            # Dispatch to every process before waiting on any of them, so
+            # the workers validate the model in parallel; then check each
+            # result immediately so a failure surfaces from this assignment
+            # instead of being deferred to a later, unrelated op.
             for p in self._sim_processes:
-                p.store_model(self._model)
+                p.start_store_model(self._model)
+            for p in self._sim_processes:
+                p.result()
 
     def fields(self, m):
         """Create fields for every simulation.

--- a/tests/meta/test_multiprocessing_sim.py
+++ b/tests/meta/test_multiprocessing_sim.py
@@ -1,4 +1,10 @@
+import subprocess
+import sys
+import textwrap
+import time
+
 import numpy as np
+import pytest
 
 from simpeg.potential_fields import gravity
 from simpeg.electromagnetics.static import resistivity as dc
@@ -14,6 +20,25 @@ from simpeg.meta import (
     MultiprocessingSumMetaSimulation,
     MultiprocessingRepeatedSimulation,
 )
+from simpeg.meta.multiprocessing import _SimulationProcess
+
+
+class _FlakyFieldsSimulation(dc.Simulation3DNodal):
+    """A test double whose `fields` call fails exactly once.
+
+    Used to exercise the worker-process error path: the first call raises
+    while its process is mid-request, and a later call on the same worker
+    must still succeed cleanly (proving the request/response queue wasn't
+    left desynced by the earlier failure).
+    """
+
+    _fields_call_count = 0
+
+    def fields(self, m=None, calcJ=True):
+        self._fields_call_count += 1
+        if self._fields_call_count == 1:
+            raise RuntimeError("synthetic fields failure")
+        return super().fields(m, calcJ=calcJ)
 
 
 def test_meta_correctness():
@@ -190,6 +215,180 @@ def test_sum_correctness():
         raise err
     finally:
         parallel_sim.join()
+
+
+def test_sum_correctness_more_sims_than_processes():
+    # Regression test: MultiprocessingSumMetaSimulation must build each
+    # per-process chunk as a SumMetaSimulation (summing), not the default
+    # MetaSimulation (concatenating). With only 1 sim per process (as in
+    # test_sum_correctness) that distinction never showed up: concatenating
+    # a single array is a no-op. Here we use twice as many sims as
+    # processes so each worker owns >1 sim and the bug would either crash
+    # (unequal chunk shapes) or silently sum wrong values (equal chunk
+    # shapes, concatenated-then-summed instead of summed).
+    mesh = TensorMesh([16, 16, 16], origin="CCN")
+    rx_locs = np.mgrid[-0.25:0.25:5j, -0.25:0.25:5j, 0:1:1j].reshape(3, -1).T
+    rx = gravity.Point(rx_locs, components=["gz"])
+    survey = gravity.Survey(gravity.SourceField(rx))
+
+    n_layers = 4
+    edges = np.linspace(0, mesh.shape_cells[2], n_layers + 1, dtype=int)
+    layer_meshes = [
+        TensorMesh(
+            [mesh.h[0], mesh.h[1], mesh.h[2][edges[i] : edges[i + 1]]],
+            origin=[mesh.origin[0], mesh.origin[1], mesh.nodes_z[edges[i]]],
+        )
+        for i in range(n_layers)
+    ]
+
+    g_mappings = [maps.Mesh2Mesh((m, mesh)) for m in layer_meshes]
+    g_sims = [
+        gravity.Simulation3DIntegral(
+            m, survey=survey, rhoMap=maps.IdentityMap(), n_processes=1
+        )
+        for m in layer_meshes
+    ]
+
+    m_test = np.arange(mesh.n_cells) / mesh.n_cells + 0.1
+
+    serial_sim = SumMetaSimulation(g_sims, g_mappings)
+    # 4 sims over 2 processes -> chunk_sizes = [2, 2]
+    parallel_sim = MultiprocessingSumMetaSimulation(g_sims, g_mappings, n_processes=2)
+
+    try:
+        d_full = serial_sim.dpred(m_test)
+        d_mult = parallel_sim.dpred(m_test)
+        np.testing.assert_allclose(d_full, d_mult, rtol=1e-06)
+    finally:
+        parallel_sim.join()
+
+
+def test_worker_error_propagation():
+    # Regression test: an exception raised inside a worker process while
+    # computing fields must (a) be raised in the caller as a real
+    # exception, and (b) not leave the worker's request/response queue
+    # desynced for later, unrelated calls on the same process.
+    mesh = TensorMesh([8, 8, 8], origin="CCN")
+    rx_locs = np.mgrid[-0.25:0.25:3j, -0.25:0.25:3j, 0:1:1j].reshape(3, -1).T
+    rxs = dc.receivers.Pole(rx_locs)
+    source_locs = np.mgrid[-0.5:0.5:4j, 0:1:1j, 0:1:1j].reshape(3, -1).T
+    src_list = [dc.sources.Pole([rxs], location=loc) for loc in source_locs]
+    survey = dc.Survey(src_list)
+
+    flaky_sim = _FlakyFieldsSimulation(mesh, survey=survey, sigmaMap=maps.IdentityMap())
+    reference_sim = dc.Simulation3DNodal(
+        mesh, survey=survey, sigmaMap=maps.IdentityMap()
+    )
+
+    m_test = np.arange(mesh.n_cells) / mesh.n_cells + 0.1
+
+    parallel_sim = MultiprocessingMetaSimulation(
+        [flaky_sim], [maps.IdentityMap()], n_processes=1
+    )
+    serial_sim = MetaSimulation([reference_sim], [maps.IdentityMap()])
+
+    try:
+        with pytest.raises(RuntimeError, match="synthetic fields failure"):
+            parallel_sim.dpred(m_test)
+
+        # The same worker process just failed a request; a fresh call must
+        # still succeed and match the serial reference, proving no stray
+        # item was left behind in the result queue by the earlier failure.
+        d_mult = parallel_sim.dpred(m_test)
+        d_full = serial_sim.dpred(m_test)
+        np.testing.assert_allclose(d_full, d_mult, rtol=1e-06)
+    finally:
+        parallel_sim.join()
+
+
+class _BigResultSimulation:
+    """Minimal test double (not a real BaseSimulation): `fields()` is a
+    no-op and `dpred()` returns a large array. Used to check that a result
+    left unread in a worker's result_queue doesn't deadlock `.join()`.
+    """
+
+    def __init__(self, size):
+        self.size = size
+        self.model = None
+
+    def fields(self, m):
+        return None
+
+    def dpred(self, m, f):
+        return np.zeros(self.size)
+
+
+def test_join_does_not_hang_on_unread_result():
+    # Regression test: if a caller dispatches work to a worker and then
+    # never reads its result (e.g. because an earlier collection loop
+    # raised before getting to it), the worker's feeder thread can be
+    # left blocked flushing that result once the OS pipe buffer fills up.
+    # A plain Process.join() would then hang forever. `.join()` must
+    # drain in the background instead, so it completes promptly.
+    p = _SimulationProcess()
+    p.start()
+    elapsed = None
+    try:
+        p.set_sim(_BigResultSimulation(size=2_000_000))  # ~16 MB of float64
+        p.store_model(np.zeros(1))
+        fields_future = p.get_fields()
+        p.start_dpred(fields_future)
+        # Deliberately never call p.result() here.
+
+        start = time.monotonic()
+        p.join(timeout=10)
+        elapsed = time.monotonic() - start
+    finally:
+        if p.is_alive():
+            p.terminate()
+
+    assert elapsed is not None and elapsed < 10
+    assert not p.is_alive()
+
+
+def test_atexit_cleanup_without_join():
+    # Regression test: if a script builds a MultiprocessingMetaSimulation
+    # and exits (or an exception propagates to the top level) without ever
+    # calling .join(), the worker processes are non-daemonic and would
+    # otherwise block Python's own atexit machinery from letting the
+    # interpreter exit. The atexit fallback registered at construction
+    # time must terminate them so the process exits promptly on its own.
+    script = textwrap.dedent(
+        """
+        import numpy as np
+        from discretize import TensorMesh
+        from simpeg import maps
+        from simpeg.electromagnetics.static import resistivity as dc
+        from simpeg.meta import MultiprocessingMetaSimulation
+
+        if __name__ == "__main__":
+            mesh = TensorMesh([4, 4, 4], origin="CCN")
+            rx_locs = np.mgrid[-0.25:0.25:2j, -0.25:0.25:2j, 0:1:1j].reshape(3, -1).T
+            rxs = dc.receivers.Pole(rx_locs)
+            source_locs = np.mgrid[-0.5:0.5:2j, 0:1:1j, 0:1:1j].reshape(3, -1).T
+            src_list = [
+                dc.sources.Pole([rxs], location=loc) for loc in source_locs
+            ]
+            survey = dc.Survey(src_list)
+            sim = dc.Simulation3DNodal(
+                mesh, survey=survey, sigmaMap=maps.IdentityMap()
+            )
+
+            parallel_sim = MultiprocessingMetaSimulation(
+                [sim], [maps.IdentityMap()], n_processes=1
+            )
+            # Intentionally do NOT call parallel_sim.join(): the atexit
+            # fallback must still let this process exit promptly.
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        timeout=60,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_repeat_correctness():

--- a/tests/meta/test_multiprocessing_sim.py
+++ b/tests/meta/test_multiprocessing_sim.py
@@ -301,6 +301,122 @@ def test_worker_error_propagation():
         parallel_sim.join()
 
 
+class _FlakyModelSimulation:
+    """Minimal test double (not a real BaseSimulation) whose `model`
+    setter fails exactly once. Used to check that a failure storing the
+    model on a worker process is raised immediately by `store_model`,
+    instead of being deferred until a later, unrelated op touches that
+    worker.
+    """
+
+    _set_count = 0
+
+    def __init__(self):
+        self._model = None
+
+    @property
+    def model(self):
+        return self._model
+
+    @model.setter
+    def model(self, value):
+        self._set_count += 1
+        if self._set_count == 1:
+            raise ValueError("synthetic model failure")
+        self._model = value
+
+    def fields(self, m):
+        return None
+
+    def dpred(self, m, f):
+        return np.zeros(1)
+
+
+def test_store_model_error_propagation():
+    # Regression test: a failure while storing the model on a worker
+    # process must be raised immediately by `store_model` itself, not
+    # deferred until a later op (e.g. `get_fields`/`dpred`) happens to
+    # touch that worker.
+    p = _SimulationProcess()
+    p.start()
+    try:
+        p.set_sim(_FlakyModelSimulation())
+        with pytest.raises(ValueError, match="synthetic model failure"):
+            p.store_model(np.zeros(1))
+
+        # The same worker just failed a request; a later, unrelated
+        # request must still succeed cleanly, proving the request/
+        # response queue wasn't left desynced by the earlier failure.
+        p.store_model(np.zeros(1))
+        fields_future = p.get_fields()
+        p.start_dpred(fields_future)
+        d = p.result()
+        np.testing.assert_allclose(d, np.zeros(1))
+    finally:
+        p.join()
+
+
+class _FlakyModelDCSimulation(dc.Simulation3DNodal):
+    """A test double whose `model` setter fails exactly once.
+
+    Used to exercise `MultiprocessingMetaSimulation`'s model setter:
+    assigning `.model` on the meta-simulation must raise immediately
+    when a worker fails to store it, rather than deferring the error to
+    the next unrelated call (e.g. `dpred`).
+    """
+
+    _model_set_count = 0
+
+    @dc.Simulation3DNodal.model.setter
+    def model(self, value):
+        if value is not None:
+            self._model_set_count += 1
+            if self._model_set_count == 1:
+                raise ValueError("synthetic model failure")
+        dc.Simulation3DNodal.model.fset(self, value)
+
+
+def test_model_assignment_error_propagation():
+    # Regression test: a failure storing the model on a worker process
+    # must be raised immediately by the `.model = ...` assignment that
+    # triggered it, not deferred until a later, unrelated call.
+    mesh = TensorMesh([8, 8, 8], origin="CCN")
+    rx_locs = np.mgrid[-0.25:0.25:3j, -0.25:0.25:3j, 0:1:1j].reshape(3, -1).T
+    rxs = dc.receivers.Pole(rx_locs)
+    source_locs = np.mgrid[-0.5:0.5:4j, 0:1:1j, 0:1:1j].reshape(3, -1).T
+    src_list = [dc.sources.Pole([rxs], location=loc) for loc in source_locs]
+    survey = dc.Survey(src_list)
+
+    flaky_sim = _FlakyModelDCSimulation(
+        mesh, survey=survey, sigmaMap=maps.IdentityMap()
+    )
+    reference_sim = dc.Simulation3DNodal(
+        mesh, survey=survey, sigmaMap=maps.IdentityMap()
+    )
+
+    m_test = np.arange(mesh.n_cells) / mesh.n_cells + 0.1
+
+    parallel_sim = MultiprocessingMetaSimulation(
+        [flaky_sim], [maps.IdentityMap()], n_processes=1
+    )
+    serial_sim = MetaSimulation([reference_sim], [maps.IdentityMap()])
+
+    try:
+        with pytest.raises(ValueError, match="synthetic model failure"):
+            parallel_sim.model = m_test
+
+        # A fresh assignment (of a genuinely different model, so it isn't
+        # skipped as a no-op update) must succeed, and later calls must
+        # match the serial reference, proving no stray item was left
+        # behind in the worker's result queue by the earlier failure.
+        m_retry = m_test * 2
+        d_mult = parallel_sim.dpred(m_retry)
+        d_full = serial_sim.dpred(m_retry)
+        np.testing.assert_allclose(d_full, d_mult, rtol=1e-06)
+    finally:
+        parallel_sim.join()
+
+
 class _BigResultSimulation:
     """Minimal test double (not a real BaseSimulation): `fields()` is a
     no-op and `dpred()` returns a large array. Used to check that a result


### PR DESCRIPTION
#### Summary
Refactors inter-process communication with an enum for clarity and safety. Corrects chunking in `MultiprocessingSumMetaSimulation` to use `SumMetaSimulation` for proper accumulation. Adds comprehensive worker error propagation and prevents `join()` deadlocks by draining unread results. Ensures graceful shutdown of worker processes with `atexit` fallback cleanup.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.


#### What does this implement/fix?
We've always had a few hanging errors related to the multiprocessing meta simulation that I was never able to identify on my own. I took the opportunity to let Claude Code analyze it to look for possible deadlocks and race conditions.

#### Additional information
I've also replaced the (easy to get wrong) communication messages between the main process and the child processes with enums instead of specific values.