### PR TITLE
Make `simpeg.utils.download` respect the `verbose` argument

### DIFF
--- a/simpeg/utils/io_utils/io_utils_general.py
+++ b/simpeg/utils/io_utils/io_utils_general.py
@@ -146,10 +146,10 @@ def download(url, folder=".", overwrite=False, verbose=True):
     urllist = url if isinstance(url, list) else [url]
     for u, f in zip(urllist, downloadpath):
         if verbose:
-            print("Downloading {}".format(u))
+            print(f"Downloading {u}")
         urlretrieve(u, f)
         if verbose:
-            print("   saved to: " + f)
+            print(f"   saved to: {f}")
 
     if verbose:
         print("Download completed!")

--- a/simpeg/utils/io_utils/io_utils_general.py
+++ b/simpeg/utils/io_utils/io_utils_general.py
@@ -145,9 +145,12 @@ def download(url, folder=".", overwrite=False, verbose=True):
     # download files
     urllist = url if isinstance(url, list) else [url]
     for u, f in zip(urllist, downloadpath):
-        print("Downloading {}".format(u))
+        if verbose:
+            print("Downloading {}".format(u))
         urlretrieve(u, f)
-        print("   saved to: " + f)
+        if verbose:
+            print("   saved to: " + f)
 
-    print("Download completed!")
+    if verbose:
+        print("Download completed!")
     return downloadpath if isinstance(url, list) else downloadpath[0]

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import scipy.sparse as sp
 import os
 import shutil
+import urllib.request
 from simpeg.utils import (
     sdiag,
     sub2ind,
@@ -318,6 +319,38 @@ class TestDownload(unittest.TestCase):
         # clean up
         shutil.rmtree(os.path.expanduser("./test_urls"))
         shutil.rmtree(os.path.expanduser("./test_url"))
+
+
+class TestDownloadVerbose:
+    """
+    Tests for the verbose argument of the download function
+    """
+
+    URL = "https://example.com/simpeg/data.txt"
+
+    @pytest.fixture(autouse=True)
+    def mock_urlretrieve(self, monkeypatch):
+        def urlretrieve(url, filename):
+            with open(filename, "w") as fid:
+                fid.write("data")
+
+        monkeypatch.setattr(urllib.request, "urlretrieve", urlretrieve)
+
+    def test_silent(self, tmp_path, capsys):
+        download(self.URL, folder=str(tmp_path), verbose=False)
+        assert capsys.readouterr().out == ""
+
+    def test_silent_on_existing_file(self, tmp_path, capsys):
+        download(self.URL, folder=str(tmp_path), overwrite=True, verbose=False)
+        download(self.URL, folder=str(tmp_path), overwrite=True, verbose=False)
+        assert capsys.readouterr().out == ""
+
+    def test_verbose(self, tmp_path, capsys):
+        file_name = download(self.URL, folder=str(tmp_path), verbose=True)
+        output = capsys.readouterr().out
+        assert self.URL in output
+        assert file_name in output
+        assert "Download completed!" in output
 
 
 class TestCoterminalAngle:

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -328,7 +328,7 @@ class TestDownloadVerbose:
 
     URL = "https://example.com/simpeg/data.txt"
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture
     def mock_urlretrieve(self, monkeypatch):
         def urlretrieve(url, filename):
             with open(filename, "w") as fid:
@@ -336,16 +336,16 @@ class TestDownloadVerbose:
 
         monkeypatch.setattr(urllib.request, "urlretrieve", urlretrieve)
 
-    def test_silent(self, tmp_path, capsys):
+    def test_silent(self, tmp_path, capsys, mock_urlretrieve):
         download(self.URL, folder=str(tmp_path), verbose=False)
         assert capsys.readouterr().out == ""
 
-    def test_silent_on_existing_file(self, tmp_path, capsys):
+    def test_silent_on_existing_file(self, tmp_path, capsys, mock_urlretrieve):
         download(self.URL, folder=str(tmp_path), overwrite=True, verbose=False)
         download(self.URL, folder=str(tmp_path), overwrite=True, verbose=False)
         assert capsys.readouterr().out == ""
 
-    def test_verbose(self, tmp_path, capsys):
+    def test_verbose(self, tmp_path, capsys, mock_urlretrieve):
         file_name = download(self.URL, folder=str(tmp_path), verbose=True)
         output = capsys.readouterr().out
         assert self.URL in output


### PR DESCRIPTION
#### Summary
`simpeg.utils.download` printed its progress messages regardless of the `verbose` argument.

#### PR Checklist
* [x] Linted my code according to the style guides.
* [x] Added tests to verify changes to the code.

#### Reference issue
Closes #629

#### What does this implement/fix?
Only the messages about preexisting files were guarded by `verbose`. The "Downloading ...", "   saved to: ..." and "Download completed!" messages were printed unconditionally, so `verbose=False` did not silence the function. I put the three remaining prints behind the same check.

#### Additional information
The new tests mock `urllib.request.urlretrieve` so they don't hit the network, and use `capsys` to check the output. They live in a separate pytest class because the existing `TestDownload` is a `unittest.TestCase`, which can't take the `capsys` fixture. Both fail on main and pass with the change.

I kept the `verbose` flag instead of moving these messages to the SimPEG logger, to keep the change scoped to the issue. Happy to do that instead if you prefer.

### Squash and Merge Summary

Make `simpeg.utils.download` to only print out messages to stdout if `verbose` is True. Test the bugfix by mocking `urllib` to avoid requiring network connection.