### PR TITLE
Fix Maxwell equation in FDEM module description

### DIFF
--- a/simpeg/electromagnetics/frequency_domain/__init__.py
+++ b/simpeg/electromagnetics/frequency_domain/__init__.py
@@ -10,7 +10,7 @@ Fourier convention is used, this module is used to solve problems of the form:
 
 .. math::
     \begin{aligned}
-    \nabla \times \vec{E} + i\omega \vec{B} &= - i \omega \vec{S}_m \\
+    \nabla \times \vec{E} + i\omega \vec{B} &= \vec{S}_m \\
     \nabla \times \vec{H} - \vec{J} &= \vec{S}_e
     \end{aligned}
 


### PR DESCRIPTION
Remove an extra $-i \omega$ term in the source term of the Faraday Law.

<!--
Thanks for contributing a pull request to SimPEG!
Remember to use a personal fork of SimPEG to propose changes.

Check out the stages of a pull request at
https://docs.simpeg.xyz/content/getting_started/contributing/pull-requests.html

Note that we are a team of volunteers and we appreciate your
patience during the review process.

Again, thanks for contributing!

Feel free to remove lines from this template that do not apply to you pull request.
-->

#### Summary
<!-- Add a summary of this Pull Request -->

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

This fix is related to the one made in #1774.

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
