### PR TITLE
Add rotation invariant transfer functions

### DIFF
--- a/simpeg/electromagnetics/natural_source/receivers.py
+++ b/simpeg/electromagnetics/natural_source/receivers.py
@@ -1,3 +1,5 @@
+"""Natural source EM receivers."""
+
 from ...utils.code_utils import (
     validate_string,
     validate_type,
@@ -1132,24 +1134,1010 @@ class Admittance(_ElectricAndMagneticReceiver):
         )
 
 
-class ApparentConductivity(_ElectricAndMagneticReceiver):
+class _BaseOrientationInvariant(BaseNaturalSourceRx):
+
+    _loc_names = ("First", "Second")
+
+    def __init__(  # noqa: D107
+        self,
+        locations1,
+        locations2=None,
+        base_type="magnetic",
+        storeProjections=False,
+    ):
+        super().__init__(
+            locations1=locations1,
+            locations2=locations2,
+            storeProjections=storeProjections,
+        )
+        self.base_type = base_type
+
+    @property
+    def base_type(self):
+        r"""Whether a 'magnetic' or 'electric' base station is used.
+
+        Returns
+        -------
+        str
+            Base station type; i.e. "magnetic" or "electric"
+        """
+        return self._base_type
+
+    @base_type.setter
+    def base_type(self, var):
+        self._base_type = validate_string("base_type", var, ["magnetic", "electric"])
+
+    def _eval_root_gram_determinant(self, src, mesh, f):
+
+        if mesh.dim < 3:
+            raise NotImplementedError(
+                "'RootGramDeterminant' transfer function only for 3D simulation."
+            )
+
+        h = f[src, "h"]
+        hx = self.getP(mesh, "Fx", 0) @ h
+        hy = self.getP(mesh, "Fy", 0) @ h
+        hz = self.getP(mesh, "Fz", 0) @ h
+
+        if self.base_type == "magnetic":
+            bx = self.getP(mesh, "Fx", 1) @ h
+            by = self.getP(mesh, "Fy", 1) @ h
+
+        else:
+            e = f[src, "e"]
+            bx = self.getP(mesh, "Ex", 1) @ e
+            by = self.getP(mesh, "Ey", 1) @ e
+
+        # abs(det(H H*))
+        top = (
+            (np.abs(hx[:, 0] ** 2) + np.abs(hy[:, 0] ** 2) + np.abs(hz[:, 0] ** 2))
+            * (np.abs(hx[:, 1] ** 2) + np.abs(hy[:, 1] ** 2) + np.abs(hz[:, 1] ** 2))
+        ) - np.abs(
+            hx[:, 0] * hx[:, 1].conjugate()
+            + hy[:, 0] * hy[:, 1].conjugate()
+            + hz[:, 0] * hz[:, 1].conjugate()
+        ) ** 2
+
+        # abs(det(B B*)) = abs(det(B))**2
+        bot = np.abs(bx[:, 0] * by[:, 1] - bx[:, 1] * by[:, 0]) ** 2
+
+        return np.sqrt(top / bot)
+
+    def _eval_root_gram_determinant_deriv(
+        self, src, mesh, f, du_dm_v=None, v=None, adjoint=False
+    ):
+
+        if mesh.dim < 3:
+            raise NotImplementedError(
+                "'AmplitudeSquared' transfer function only for 3D simulation."
+            )
+
+        h = f[src, "h"]
+        Phx = self.getP(mesh, "Fx", 0)
+        Phy = self.getP(mesh, "Fy", 0)
+        Phz = self.getP(mesh, "Fz", 0)
+
+        hx = Phx @ h
+        hy = Phy @ h
+        hz = Phz @ h
+
+        if self.base_type == "magnetic":
+
+            Pbx = self.getP(mesh, "Fx", 1)
+            Pby = self.getP(mesh, "Fy", 1)
+
+            bx = Pbx @ h
+            by = Pby @ h
+
+        else:
+
+            Pbx = self.getP(mesh, "Ex", 1)
+            Pby = self.getP(mesh, "Ey", 1)
+
+            e = f[src, "e"]
+            bx = Pbx @ e
+            by = Pby @ e
+
+        # Entries of HH*. Note that vec_h21 = conj(vec_h12)
+        vec_h11 = np.abs(hx[:, 0]) ** 2 + np.abs(hy[:, 0]) ** 2 + np.abs(hz[:, 0]) ** 2
+        vec_h22 = np.abs(hx[:, 1]) ** 2 + np.abs(hy[:, 1]) ** 2 + np.abs(hz[:, 1]) ** 2
+        vec_h12 = (
+            hx[:, 0] * hx[:, 1].conjugate()
+            + hy[:, 0] * hy[:, 1].conjugate()
+            + hz[:, 0] * hz[:, 1].conjugate()
+        )
+        top = vec_h11 * vec_h22 - np.abs(vec_h12) ** 2  # abs(det(H H*))
+
+        vec_b11 = np.abs(bx[:, 0]) ** 2 + np.abs(by[:, 0]) ** 2
+        vec_b22 = np.abs(bx[:, 1]) ** 2 + np.abs(by[:, 1]) ** 2
+        vec_b12 = bx[:, 0] * bx[:, 1].conjugate() + by[:, 0] * by[:, 1].conjugate()
+        bot = vec_b11 * vec_b22 - np.abs(vec_b12) ** 2  # abs(det(H H*))
+
+        scale = 0.5 / np.sqrt(top / bot)
+        # Scale by w*mu_0
+        if isinstance(self, ApparentConductivity):
+            scale /= _alpha(src)
+
+        # ADJOINT
+        if adjoint:
+
+            # J_T * v = d_top_T * a_v + d_bot_T * b
+            a_v = scale * v / bot  # term 1
+            b_v = -scale * top * v / bot**2  # term 2
+
+            a_v = np.repeat(mkvc(a_v, n_dims=2), 2, axis=-1)
+            b_v = np.repeat(mkvc(b_v, n_dims=2), 2, axis=-1)
+
+            # derivatives for det(HH*)
+            px = (
+                np.c_[
+                    vec_h22 * hx[:, 0].conjugate() - (vec_h12 * hx[:, 1]).conjugate(),
+                    vec_h11 * hx[:, 1].conjugate() - vec_h12 * hx[:, 0].conjugate(),
+                ]
+                * a_v
+            )
+            py = (
+                np.c_[
+                    vec_h22 * hy[:, 0].conjugate() - (vec_h12 * hy[:, 1]).conjugate(),
+                    vec_h11 * hy[:, 1].conjugate() - vec_h12 * hy[:, 0].conjugate(),
+                ]
+                * a_v
+            )
+            pz = (
+                np.c_[
+                    vec_h22 * hz[:, 0].conjugate() - (vec_h12 * hz[:, 1]).conjugate(),
+                    vec_h11 * hz[:, 1].conjugate() - vec_h12 * hz[:, 0].conjugate(),
+                ]
+                * a_v
+            )
+
+            # derivatives for det(BB*)
+            qx = (
+                np.c_[
+                    vec_b22 * bx[:, 0].conjugate() - (vec_b12 * bx[:, 1]).conjugate(),
+                    vec_b11 * bx[:, 1].conjugate() - vec_b12 * bx[:, 0].conjugate(),
+                ]
+                * b_v
+            )
+            qy = (
+                np.c_[
+                    vec_b22 * by[:, 0].conjugate() - (vec_b12 * by[:, 1]).conjugate(),
+                    vec_b11 * by[:, 1].conjugate() - vec_b12 * by[:, 0].conjugate(),
+                ]
+                * b_v
+            )
+
+            h_v = 2 * (Phx.T @ px + Phy.T @ py + Phz.T @ pz)
+            b_v = 2 * (Pbx.T @ qx + Pby.T @ qy)
+
+            if self.base_type == "magnetic":
+
+                return f._hDeriv(src, None, h_v + b_v, adjoint=True)
+
+            else:
+
+                fu_b_v, fm_b_v = f._eDeriv(src, None, b_v, adjoint=True)
+                fu_h_v, fm_h_v = f._hDeriv(src, None, h_v, adjoint=True)
+                return fu_b_v + fu_h_v, fm_b_v + fm_h_v
+
+        # JVEC
+        dh_v = f._hDeriv(src, du_dm_v, v, adjoint=False)
+        dhx_v = Phx @ dh_v
+        dhy_v = Phy @ dh_v
+        dhz_v = Phz @ dh_v
+
+        if self.base_type == "magnetic":
+            db_v = dh_v
+        else:
+            db_v = f._eDeriv(src, du_dm_v, v, adjoint=False)
+
+        dbx_v = Pbx @ db_v
+        dby_v = Pby @ db_v
+
+        # When taking derivative of hh* wrt the model, imaginary components
+        # cancel and its 2x the real of the conjugate x the deriv
+        dtop_v = (
+            (
+                2
+                * vec_h11
+                * (
+                    hx[:, 1].conjugate() * dhx_v[:, 1]
+                    + hy[:, 1].conjugate() * dhy_v[:, 1]
+                    + hz[:, 1].conjugate() * dhz_v[:, 1]
+                )
+            ).real
+            + (
+                2
+                * vec_h22
+                * (
+                    hx[:, 0].conjugate() * dhx_v[:, 0]
+                    + hy[:, 0].conjugate() * dhy_v[:, 0]
+                    + hz[:, 0].conjugate() * dhz_v[:, 0]
+                )
+            ).real
+            - (
+                2
+                * vec_h12.conjugate()
+                * (
+                    hx[:, 1].conjugate() * dhx_v[:, 0]
+                    + hy[:, 1].conjugate() * dhy_v[:, 0]
+                    + hz[:, 1].conjugate() * dhz_v[:, 0]
+                    + hx[:, 0] * dhx_v[:, 1].conjugate()
+                    + hy[:, 0] * dhy_v[:, 1].conjugate()
+                    + hz[:, 0] * dhz_v[:, 1].conjugate()
+                )
+            ).real
+        )
+
+        dbot_v = (
+            (
+                2
+                * vec_b11
+                * (
+                    bx[:, 1].conjugate() * dbx_v[:, 1]
+                    + by[:, 1].conjugate() * dby_v[:, 1]
+                )
+            ).real
+            + (
+                2
+                * vec_b22
+                * (
+                    bx[:, 0].conjugate() * dbx_v[:, 0]
+                    + by[:, 0].conjugate() * dby_v[:, 0]
+                )
+            ).real
+            - (
+                2
+                * vec_b12.conjugate()
+                * (
+                    bx[:, 1].conjugate() * dbx_v[:, 0]
+                    + by[:, 1].conjugate() * dby_v[:, 0]
+                    + bx[:, 0] * dbx_v[:, 1].conjugate()
+                    + by[:, 0] * dby_v[:, 1].conjugate()
+                )
+            ).real
+        )
+
+        return scale * (bot * dtop_v - top * dbot_v) / (bot * bot)
+
+    def _eval_cross_product_amplitude(self, src, mesh, f):
+
+        if mesh.dim < 3:
+            raise NotImplementedError(
+                "'CrossProductAmplitude' transfer function only for 3D simulation."
+            )
+
+        h = f[src, "h"]
+        hx = self.getP(mesh, "Fx", 0) @ h
+        hy = self.getP(mesh, "Fy", 0) @ h
+        hz = self.getP(mesh, "Fz", 0) @ h
+
+        if self.base_type == "magnetic":
+            bx = self.getP(mesh, "Fx", 1) @ h
+            by = self.getP(mesh, "Fy", 1) @ h
+
+        else:
+            e = f[src, "e"]
+            bx = self.getP(mesh, "Ex", 1) @ e
+            by = self.getP(mesh, "Ey", 1) @ e
+
+        top_12 = (
+            np.abs(hx[:, 0] * hy[:, 1] - hy[:, 0] * hx[:, 1]) ** 2
+        )  # abs(det(H12))**2
+        top_13 = (
+            np.abs(hx[:, 0] * hz[:, 1] - hz[:, 0] * hx[:, 1]) ** 2
+        )  # abs(det(H13))**2
+        top_23 = (
+            np.abs(hy[:, 0] * hz[:, 1] - hz[:, 0] * hy[:, 1]) ** 2
+        )  # abs(det(H23))**2
+
+        # abs(det(B B*)) = abs(det(B))**2
+        bot = np.abs(bx[:, 0] * by[:, 1] - bx[:, 1] * by[:, 0]) ** 2
+
+        return np.sqrt((top_12 + top_13 + top_23) / bot)
+
+    def _eval_cross_product_amplitude_deriv(
+        self, src, mesh, f, du_dm_v=None, v=None, adjoint=False
+    ):
+
+        if mesh.dim < 3:
+            raise NotImplementedError(
+                "'AmplitudeSquared' transfer function only for 3D simulation."
+            )
+
+        h = f[src, "h"]
+        Phx = self.getP(mesh, "Fx", 0)
+        Phy = self.getP(mesh, "Fy", 0)
+        Phz = self.getP(mesh, "Fz", 0)
+
+        hx = Phx @ h
+        hy = Phy @ h
+        hz = Phz @ h
+
+        if self.base_type == "magnetic":
+
+            Pbx = self.getP(mesh, "Fx", 1)
+            Pby = self.getP(mesh, "Fy", 1)
+
+            bx = Pbx @ h
+            by = Pby @ h
+
+        else:
+
+            Pbx = self.getP(mesh, "Ex", 1)
+            Pby = self.getP(mesh, "Ey", 1)
+
+            e = f[src, "e"]
+            bx = Pbx @ e
+            by = Pby @ e
+
+        # Entries of HH*. Note that vec_h21 = conj(vec_h12)
+        det_h12 = hx[:, 0] * hy[:, 1] - hy[:, 0] * hx[:, 1]  # det(H12)
+        det_h13 = hx[:, 0] * hz[:, 1] - hz[:, 0] * hx[:, 1]  # det(H13)
+        det_h23 = hy[:, 0] * hz[:, 1] - hz[:, 0] * hy[:, 1]  # det(H23)
+        top = np.abs(det_h12) ** 2 + np.abs(det_h13) ** 2 + np.abs(det_h23) ** 2
+
+        # abs(det(B B*)) = abs(det(B))**2
+        det_b = bx[:, 0] * by[:, 1] - bx[:, 1] * by[:, 0]
+        bot = np.abs(det_b) ** 2
+
+        scale = 0.5 / np.sqrt(top / bot)
+        # Scale by w*mu_0
+        if isinstance(self, ApparentConductivity):
+            scale /= _alpha(src)
+
+        # ADJOINT
+        if adjoint:
+
+            # J_T * v = d_top_T * a_v + d_bot_T * b
+            a_v = scale * v / bot  # term 1
+            b_v = -scale * top * v / bot**2  # term 2
+
+            a_v = np.repeat(mkvc(a_v, n_dims=2), 2, axis=-1)
+            b_v = np.repeat(mkvc(b_v, n_dims=2), 2, axis=-1)
+
+            # derivatives for det(HH*)
+            px = (
+                np.c_[
+                    det_h12.conjugate() * hy[:, 1] + det_h13.conjugate() * hz[:, 1],
+                    -det_h12.conjugate() * hy[:, 0] - det_h13.conjugate() * hz[:, 0],
+                ]
+                * a_v
+            )
+            py = (
+                np.c_[
+                    -det_h12.conjugate() * hx[:, 1] + det_h23.conjugate() * hz[:, 1],
+                    det_h12.conjugate() * hx[:, 0] - det_h23.conjugate() * hz[:, 0],
+                ]
+                * a_v
+            )
+            pz = (
+                np.c_[
+                    -det_h13.conjugate() * hx[:, 1] - det_h23.conjugate() * hy[:, 1],
+                    det_h13.conjugate() * hx[:, 0] + det_h23.conjugate() * hy[:, 0],
+                ]
+                * a_v
+            )
+
+            # derivatives for det(BB*)
+            qx = (
+                np.c_[det_b.conjugate() * by[:, 1], -det_b.conjugate() * by[:, 0]] * b_v
+            )
+            qy = (
+                np.c_[-det_b.conjugate() * bx[:, 1], det_b.conjugate() * bx[:, 0]] * b_v
+            )
+
+            h_v = 2 * (Phx.T @ px + Phy.T @ py + Phz.T @ pz)
+            b_v = 2 * (Pbx.T @ qx + Pby.T @ qy)
+
+            if self.base_type == "magnetic":
+
+                return f._hDeriv(src, None, h_v + b_v, adjoint=True)
+
+            else:
+
+                fu_b_v, fm_b_v = f._eDeriv(src, None, b_v, adjoint=True)
+                fu_h_v, fm_h_v = f._hDeriv(src, None, h_v, adjoint=True)
+                return fu_b_v + fu_h_v, fm_b_v + fm_h_v
+
+        # JVEC
+        dh_v = f._hDeriv(src, du_dm_v, v, adjoint=False)
+        dhx_v = Phx @ dh_v
+        dhy_v = Phy @ dh_v
+        dhz_v = Phz @ dh_v
+
+        if self.base_type == "magnetic":
+            db_v = dh_v
+        else:
+            db_v = f._eDeriv(src, du_dm_v, v, adjoint=False)
+
+        dbx_v = Pbx @ db_v
+        dby_v = Pby @ db_v
+
+        # cancel and its 2x the real of the conjugate x the deriv
+        dtop_v = (
+            2
+            * (
+                det_h12.conjugate()
+                * (
+                    dhx_v[:, 0] * hy[:, 1]
+                    + hx[:, 0] * dhy_v[:, 1]
+                    - dhy_v[:, 0] * hx[:, 1]
+                    - hy[:, 0] * dhx_v[:, 1]
+                )
+                + det_h13.conjugate()
+                * (
+                    dhx_v[:, 0] * hz[:, 1]
+                    + hx[:, 0] * dhz_v[:, 1]
+                    - dhz_v[:, 0] * hx[:, 1]
+                    - hz[:, 0] * dhx_v[:, 1]
+                )
+                + det_h23.conjugate()
+                * (
+                    dhy_v[:, 0] * hz[:, 1]
+                    + hy[:, 0] * dhz_v[:, 1]
+                    - dhz_v[:, 0] * hy[:, 1]
+                    - hz[:, 0] * dhy_v[:, 1]
+                )
+            ).real
+        )
+
+        dbot_v = (
+            2
+            * (
+                det_b.conjugate()
+                * (
+                    dbx_v[:, 0] * by[:, 1]
+                    + bx[:, 0] * dby_v[:, 1]
+                    - dby_v[:, 0] * bx[:, 1]
+                    - by[:, 0] * dbx_v[:, 1]
+                )
+            ).real
+        )
+
+        return scale * (bot * dtop_v - top * dbot_v) / (bot * bot)
+
+    def _eval_horizontal_determinant(self, src, mesh, f):
+
+        if mesh.dim < 3:
+            raise NotImplementedError(
+                "'AmplitudeRatio' transfer function only for 3D simulation."
+            )
+
+        h = f[src, "h"]
+        hx = self.getP(mesh, "Fx", 0) @ h
+        hy = self.getP(mesh, "Fy", 0) @ h
+
+        if self.base_type == "magnetic":
+            bx = self.getP(mesh, "Fx", 1) @ h
+            by = self.getP(mesh, "Fy", 1) @ h
+
+        else:
+            e = f[src, "e"]
+            bx = self.getP(mesh, "Ex", 1) @ e
+            by = self.getP(mesh, "Ey", 1) @ e
+
+        top = hx[:, 0] * hy[:, 1] - hx[:, 1] * hy[:, 0]
+        bot = bx[:, 0] * by[:, 1] - bx[:, 1] * by[:, 0]
+
+        return top / bot
+
+    def _eval_horizontal_determinant_deriv(
+        self, src, mesh, f, du_dm_v=None, v=None, adjoint=False
+    ):
+
+        if mesh.dim < 3:
+            raise NotImplementedError(
+                "'HorizontalDeterminant' transfer function only for 3D simulation."
+            )
+
+        h = f[src, "h"]
+        Phx = self.getP(mesh, "Fx", 0)
+        Phy = self.getP(mesh, "Fy", 0)
+
+        hx = Phx @ h
+        hy = Phy @ h
+
+        if self.base_type == "magnetic":
+
+            Pbx = self.getP(mesh, "Fx", 1)
+            Pby = self.getP(mesh, "Fy", 1)
+
+            bx = Pbx @ h
+            by = Pby @ h
+
+        else:
+
+            Pbx = self.getP(mesh, "Ex", 1)
+            Pby = self.getP(mesh, "Ey", 1)
+
+            e = f[src, "e"]
+            bx = Pbx @ e
+            by = Pby @ e
+
+        top = hx[:, 0] * hy[:, 1] - hx[:, 1] * hy[:, 0]
+        bot = bx[:, 0] * by[:, 1] - bx[:, 1] * by[:, 0]
+
+        # ADJOINT
+        if adjoint:
+
+            if isinstance(self, ApparentConductivity):
+                scale = _alpha(src) ** -1 * top / bot
+                v = (scale.real - 1j * scale.imag) * v / np.abs(top / bot)
+            elif self.component == "amp":
+                scale = _alpha(src) ** -1 * top / bot
+                v = (scale.real - 1j * scale.imag) * v / np.abs(scale)
+            elif self.component == "imag":
+                v = -1j * v
+
+            # J_T * v = d_top_T * a_v + d_bot_T * b
+            a_v = v / bot  # term 1
+            b_v = -top * v / bot**2  # term 2
+
+            hx_v = np.c_[hy[:, 1], -hy[:, 0]] * a_v[:, None]  # terms dex in bot
+            hy_v = np.c_[-hx[:, 1], hx[:, 0]] * a_v[:, None]  # terms dey in bot
+            h_v = Phx.T @ hx_v + Phy.T @ hy_v
+
+            bx_v = np.c_[by[:, 1], -by[:, 0]] * b_v[:, None]  # terms dex in bot
+            by_v = np.c_[-bx[:, 1], bx[:, 0]] * b_v[:, None]  # terms dey in bot
+            b_v = Pbx.T @ bx_v + Pby.T @ by_v
+
+            if self.base_type == "magnetic":
+
+                return f._hDeriv(src, None, h_v + b_v, adjoint=True)
+
+            else:
+
+                fu_b_v, fm_b_v = f._eDeriv(src, None, b_v, adjoint=True)
+                fu_h_v, fm_h_v = f._hDeriv(src, None, h_v, adjoint=True)
+                return fu_b_v + fu_h_v, fm_b_v + fm_h_v
+
+        # JVEC
+        dh_v = f._hDeriv(src, du_dm_v, v, adjoint=False)
+        dhx_v = Phx @ dh_v
+        dhy_v = Phy @ dh_v
+
+        if self.base_type == "magnetic":
+            db_v = dh_v
+        else:
+            db_v = f._eDeriv(src, du_dm_v, v, adjoint=False)
+
+        dbx_v = Pbx @ db_v
+        dby_v = Pby @ db_v
+
+        dtop_v = (
+            hx[:, 0] * dhy_v[:, 1]
+            + dhx_v[:, 0] * hy[:, 1]
+            - hy[:, 0] * dhx_v[:, 1]
+            - dhy_v[:, 0] * hx[:, 1]
+        )
+        dbot_v = (
+            bx[:, 0] * dby_v[:, 1]
+            + dbx_v[:, 0] * by[:, 1]
+            - by[:, 0] * dbx_v[:, 1]
+            - dby_v[:, 0] * bx[:, 1]
+        )
+
+        deriv = (bot * dtop_v - top * dbot_v) / (bot * bot)
+
+        if isinstance(self, ApparentConductivity):
+            scale = _alpha(src) ** -1 * top / bot
+            return (scale.real * deriv.real + scale.imag * deriv.imag) / np.abs(
+                top / bot
+            )
+        elif self.component == "amp":
+            scale = top / bot
+            return (scale.real * deriv.real + scale.imag * deriv.imag) / np.abs(scale)
+        else:
+            return getattr(deriv, self.component)
+
+
+# class RootGramDeterminant(BaseNaturalSourceRx):
+class RootGramDeterminant(_BaseOrientationInvariant):
+    r"""Orientation invariant transfer function using the root Gram matrix determinant.
+
+    Receiver class for simulating a data that are invariant to sensor orientation
+    for either an electric or magnetic base station. The datum is based on taking
+    the amplitude of the determinant of Gram matrix for transfer functions
+    derived from three-component airborne magnetic fields. For a magnetic base
+    station the quantity is unitless. For an electric base station, the units
+    are A$^2$/V$^2$. See the *Notes* section for a formal definition of the datum.
+
+    Notes
+    -----
+    Consider an acquisition system that measures 3-component magnetic fields
+    in the air and magnetic fields at a base station. The fundamental set of
+    transfer functions (i.e. tippers) that can be generated from these
+    measurements is given by:
+
+    .. math::
+        \begin{bmatrix}
+        T_{xx} & T_{yx} & T_{zx} \\ T_{xy} & T_{yy} & T_{zy}
+        \end{bmatrix} = \begin{bmatrix}
+        H_x^{(x)} & H_y^{(x)} \\ H_x^{(y)} & H_y^{(y)}
+        \end{bmatrix}_b^{-1} \, \begin{bmatrix}
+        H_x^{(x)} & H_y^{(x)} & H_z^{(x)} \\ H_x^{(y)} & H_y^{(y)} & H_z^{(y)}
+        \end{bmatrix}_r
+
+    where subscript :math:`b` denotes the base station location and subscript
+    :math:`r` denotes the mobile receiver location.
+
+    For this system, the orientation invariant transfer function is defined as:
+
+    .. math::
+        \widehat{\mathbf{T}} = \bigg (
+        \dfrac{det (\mathbf{H_r H_r^\dagger}) }{det (\mathbf{H_b H_b^\dagger})}
+        \bigg )^{1/2}
+
+    where $\dagger$ denotes the Hermitian.
+
+    Now consider an acquisition system that measures 3-component magnetic fields
+    in the air and electric fields at a base station. The fundamental set of
+    transfer functions (i.e. admittances) that can be generated from these
+    measurements is given by:
+
+    .. math::
+        \begin{bmatrix}
+        Y_{xx} & Y_{yx} & Y_{zx} \\ Y_{xy} & Y_{yy} & Y_{zy}
+        \end{bmatrix} = \begin{bmatrix}
+        E_x^{(x)} & E_y^{(x)} \\ E_x^{(y)} & E_y^{(y)}
+        \end{bmatrix}_b^{-1} \, \begin{bmatrix}
+        H_x^{(x)} & H_y^{(x)} & H_z^{(x)} \\ H_x^{(y)} & H_y^{(y)} & H_z^{(y)}
+        \end{bmatrix}_r
+
+    For this system, the orientation invariant transfer function is defined as:
+
+    .. math::
+        \widehat{\mathbf{Y}} = \bigg (
+        \dfrac{det (\mathbf{H_r H_r^\dagger}) }{det (\mathbf{E_b E_b^\dagger})}
+        \bigg )^{1/2}
+
+    Parameters
+    ----------
+    locations_h : (n_loc, n_dim) array_like
+        Locations where the roving magnetic fields are measured.
+    locations_base : (n_loc, n_dim) array_like, optional
+        Locations where the base station magnetic fields are measured. Defaults to
+        the same locations as the roving magnetic fields measurements,
+        `locations_r`.
+    base_type : {'magnetic', 'electric'}
+        Whether magnetic or electric fields are measured at the base station.
+        For magnetic fields, the quantity is unitless. For electric fields,
+        the quantity has units A/V.
+    storeProjections : bool
+        Whether to cache to internal projection matrices.
+    """
+
+    _loc_names = ("Roving magnetic field", "Base station field")
+
+    def __init__(  # noqa: D107
+        self,
+        locations_h,
+        locations_base=None,
+        base_type="magnetic",
+        storeProjections=False,
+    ):
+        if locations_base is None:
+            locations_base = locations_h
+        super().__init__(
+            locations1=locations_h,
+            locations2=locations_base,
+            storeProjections=storeProjections,
+        )
+        self.base_type = base_type
+
+    @property
+    def locations_h(self):
+        """Roving magnetic field measurement locations.
+
+        Returns
+        -------
+        numpy.ndarray
+            Roving locations where the magnetic field is measured for all receiver data.
+        """
+        return self._locations[0]
+
+    @property
+    def locations_base(self):
+        """Base station magnetic field measurement locations.
+
+        Returns
+        -------
+        numpy.ndarray
+            Base station locations where the horizontal magnetic fields are measured.
+        """
+        return self._locations[1]
+
+    def eval(self, src, mesh, f):  # noqa: D102 A003
+        # Docstring inherited from parent class (BaseNaturalSourceRX).
+        # return self._eval_transfer_function(src, mesh, f)
+        return self._eval_root_gram_determinant(src, mesh, f)
+
+    def evalDeriv(  # noqa: D102
+        self, src, mesh, f, du_dm_v=None, v=None, adjoint=False
+    ):
+        # Docstring inherited from parent class (BaseNaturalSourceRX).
+        # return self._eval_transfer_function_deriv(
+        #     src, mesh, f, du_dm_v=du_dm_v, v=v, adjoint=adjoint
+        # )
+        return self._eval_root_gram_determinant_deriv(
+            src, mesh, f, du_dm_v=du_dm_v, v=v, adjoint=adjoint
+        )
+
+
+class CrossProductAmplitude(RootGramDeterminant):
+    r"""Orientation invariant transfer function from the cross-product amplitude.
+
+    Receiver class for simulating a data that are invariant to sensor orientation
+    for either an electric or magnetic base station. The datum is based on taking
+    the amplitude of the determinant of the cross-product of transfer functions
+    derived from three-component airborne magnetic fields. For a magnetic base
+    station the quantity is unitless. For an electric base station, the units
+    are A$^2$/V$^2$. See the *Notes* section for a formal definition of the datum.
+
+    Notes
+    -----
+    Consider an acquisition system that measures 3-component magnetic fields
+    in the air and magnetic fields at a base station. The fundamental set of
+    transfer functions (i.e. tippers) that can be generated from these
+    measurements is given by:
+
+    .. math::
+        \begin{bmatrix}
+        T_{xx} & T_{yx} & T_{zx} \\ T_{xy} & T_{yy} & T_{zy}
+        \end{bmatrix} = \begin{bmatrix}
+        H_x^{(x)} & H_y^{(x)} \\ H_x^{(y)} & H_y^{(y)}
+        \end{bmatrix}_b^{-1} \, \begin{bmatrix}
+        H_x^{(x)} & H_y^{(x)} & H_z^{(x)} \\ H_x^{(y)} & H_y^{(y)} & H_z^{(y)}
+        \end{bmatrix}_r
+
+    where subscript :math:`b` denotes the base station location and subscript
+    :math:`r` denotes the mobile receiver location.
+
+    For this system, the orientation invariant transfer function is defined as:
+
+    .. math::
+        | \mathbf{T} | = \bigg (
+        p_x p_x^\ast + p_y p_y^\ast + p_z p_z^\ast
+        \bigg )^{1/2}
+
+    where $\ast$ denotes the complex conjugate and
+
+    .. math::
+        \begin{split}
+        p_x &= T_{yx}T_{zy} - T_{zx}T_{yy}\\
+        p_y &= T_{zx}T_{xy} - T_{xx}T_{zy}\\
+        p_z &= T_{xx}T_{yy} - T_{yx}T_{xy}
+        \end{split}
+
+    Now consider an acquisition system that measures 3-component magnetic fields
+    in the air and electric fields at a base station. The fundamental set of
+    transfer functions (i.e. admittances) that can be generated from these
+    measurements is given by:
+
+    .. math::
+        \begin{bmatrix}
+        Y_{xx} & Y_{yx} & Y_{zx} \\ Y_{xy} & Y_{yy} & Y_{zy}
+        \end{bmatrix} = \begin{bmatrix}
+        E_x^{(x)} & E_y^{(x)} \\ E_x^{(y)} & E_y^{(y)}
+        \end{bmatrix}_b^{-1} \, \begin{bmatrix}
+        H_x^{(x)} & H_y^{(x)} & H_z^{(x)} \\ H_x^{(y)} & H_y^{(y)} & H_z^{(y)}
+        \end{bmatrix}_r
+
+    For this system, the orientation invariant transfer function is defined as:
+
+    .. math::
+        | \mathbf{Y} | = \bigg (
+        q_x q_x^\ast + q_y q_y^\ast + q_z q_z^\ast
+        \bigg )^{1/2}
+
+    where $\ast$ denotes the complex conjugate and
+
+    .. math::
+        \begin{split}
+        p_x &= Y_{yx}Y_{zy} - Y_{zx}Y_{yy}\\
+        p_y &= Y_{zx}Y_{xy} - Y_{xx}Y_{zy}\\
+        p_z &= Y_{xx}Y_{yy} - Y_{yx}Y_{xy}
+        \end{split}
+
+    Parameters
+    ----------
+    locations_h : (n_loc, n_dim) array_like
+        Locations where the roving magnetic fields are measured.
+    locations_base : (n_loc, n_dim) array_like, optional
+        Locations where the base station magnetic fields are measured. Defaults to
+        the same locations as the roving magnetic fields measurements,
+        `locations_r`.
+    base_type : {'magnetic', 'electric'}
+        Whether magnetic or electric fields are measured at the base station.
+        For magnetic fields, the quantity is unitless. For electric fields,
+        the quantity has units A/V.
+    storeProjections : bool
+        Whether to cache to internal projection matrices.
+    """
+
+    _loc_names = ("Roving magnetic field", "Base station field")
+
+    def __init__(  # noqa: D107
+        self,
+        locations_h,
+        locations_base=None,
+        base_type="magnetic",
+        storeProjections=False,
+    ):
+        super().__init__(
+            locations_h=locations_h,
+            locations_base=locations_base,
+            base_type=base_type,
+            storeProjections=storeProjections,
+        )
+
+    def eval(self, src, mesh, f):  # noqa: D102 A003
+        # Docstring inherited from parent class (BaseNaturalSourceRX).
+        # return self._eval_transfer_function(src, mesh, f)
+        return self._eval_cross_product_amplitude(src, mesh, f)
+
+    def evalDeriv(  # noqa: D102
+        self, src, mesh, f, du_dm_v=None, v=None, adjoint=False
+    ):
+        # Docstring inherited from parent class (BaseNaturalSourceRX).
+        # return self._eval_transfer_function_deriv(
+        #     src, mesh, f, du_dm_v=du_dm_v, v=v, adjoint=adjoint
+        # )
+        return self._eval_cross_product_amplitude_deriv(
+            src, mesh, f, du_dm_v=du_dm_v, v=v, adjoint=adjoint
+        )
+
+
+class HorizontalDeterminant(RootGramDeterminant):
+    r"""Determinant of the horizontal transfer functions.
+
+    Receiver class for simulating a data that are invariant to airborne sensor
+    orientation about the tow cable for either an electric or magnetic base station.
+    The datum is derived by taking the determinant of the horizontal transfer
+    functions. For a magnetic base station the quantity is unitless. For an electric
+    base station, the units are A$^2$/V$^2$. See the *Notes* section for a formal
+    definition of the datum.
+
+    Notes
+    -----
+
+    Consider an acquisition system that measures 3-component magnetic fields
+    in the air and magnetic fields at a base station. The fundamental set of
+    transfer functions (i.e. tippers) that can be generated from these
+    measurements is given by:
+
+    .. math::
+        \begin{bmatrix}
+        T_{xx} & T_{yx} & T_{zx} \\ T_{xy} & T_{yy} & T_{zy}
+        \end{bmatrix} = \begin{bmatrix}
+        H_x^{(x)} & H_y^{(x)} \\ H_x^{(y)} & H_y^{(y)}
+        \end{bmatrix}_b^{-1} \, \begin{bmatrix}
+        H_x^{(x)} & H_y^{(x)} & H_z^{(x)} \\ H_x^{(y)} & H_y^{(y)} & H_z^{(y)}
+        \end{bmatrix}_r
+
+    where subscript :math:`b` denotes the base station location and subscript
+    :math:`r` denotes the mobile receiver location.
+
+    For this system, the horizontal determinant transfer function is defined as:
+
+    .. math::
+        det(T_H) = T_{xx}T_{yy} - T_{yx}T_{xy}
+
+    Now consider an acquisition system that measures 3-component magnetic fields
+    in the air and electric fields at a base station. The fundamental set of
+    transfer functions (i.e. admittances) that can be generated from these
+    measurements is given by:
+
+    .. math::
+        \begin{bmatrix}
+        Y_{xx} & Y_{yx} & Y_{zx} \\ Y_{xy} & Y_{yy} & Y_{zy}
+        \end{bmatrix} = \begin{bmatrix}
+        E_x^{(x)} & E_y^{(x)} \\ E_x^{(y)} & E_y^{(y)}
+        \end{bmatrix}_b^{-1} \, \begin{bmatrix}
+        H_x^{(x)} & H_y^{(x)} & H_z^{(x)} \\ H_x^{(y)} & H_y^{(y)} & H_z^{(y)}
+        \end{bmatrix}_r
+
+    For this system, the horizontal determinant transfer function is defined as:
+
+    .. math::
+        det(Y_H) = Y_{xx}Y_{yy} - Y_{yx}Y_{xy}
+
+    Parameters
+    ----------
+    locations_h : (n_loc, n_dim) array_like
+        Locations where the roving magnetic fields are measured.
+    locations_base : (n_loc, n_dim) array_like, optional
+        Locations where the base station magnetic fields are measured. Defaults to
+        the same locations as the roving magnetic fields measurements,
+        `locations_r`.
+    base_type : {'magnetic', 'electric'}
+        Whether magnetic or electric fields are measured at the base station.
+        For magnetic fields, the quantity is unitless. For electric fields,
+        the quantity has units $A^2/V^2$.
+    component : {'real', 'imag'}
+        Define the receiver to measure the real or imaginary component:
+        - 'real': Real component
+        - 'imag': Imaginary component
+    storeProjections : bool
+        Whether to cache to internal projection matrices.
+    """
+    _loc_names = ("Roving magnetic field", "Base station field")
+
+    def __init__(  # noqa: D107
+        self,
+        locations_h,
+        locations_base=None,
+        base_type="magnetic",
+        component="real",
+        storeProjections=False,
+    ):
+        super().__init__(
+            locations_h=locations_h,
+            locations_base=locations_base,
+            base_type=base_type,
+            storeProjections=storeProjections,
+        )
+        self.component = component
+
+    @property
+    def component(self):
+        r"""Data type; i.e. "real", "imag", "amp".
+
+        The `component` property specifies
+        whether the data are:
+        - 'real': Real component
+        - 'imag': Imaginary component
+        - 'amp': Amplitude
+
+        Returns
+        -------
+        str
+            Data type; i.e. "real", "imag", "amp"
+        """
+        return self._component
+
+    @component.setter
+    def component(self, var):
+        self._component = validate_string(
+            "component",
+            var,
+            [
+                ("real", "re", "in-phase", "in phase"),
+                ("imag", "imaginary", "im", "out-of-phase", "out of phase"),
+                ("amp", "ampl", "amplitude"),
+            ],
+        )
+
+    def eval(self, src, mesh, f):  # noqa: A003 D102
+        # Doctring inherited from parent class (BaseNaturalSourceRx
+        # vals = self._eval_transfer_function(src, mesh, f)
+        vals = self._eval_horizontal_determinant(src, mesh, f)
+        if self.component == "complex":
+            return vals
+        elif self.component == "amp":
+            return np.abs(vals)
+        else:
+            return getattr(vals, self.component)
+
+    def evalDeriv(  # noqa: D102
+        self, src, mesh, f, du_dm_v=None, v=None, adjoint=False
+    ):
+        # Doctring inherited from parent class (BaseNaturalSourceRx)
+        if self.component == "complex":
+            raise NotImplementedError(
+                "complex valued data derivative is not implemented."
+            )
+
+        return self._eval_horizontal_determinant_deriv(
+            src, mesh, f, du_dm_v=du_dm_v, v=v, adjoint=adjoint
+        )
+
+
+class ApparentConductivity(_BaseOrientationInvariant):
     r"""Receiver class for simulating apparent conductivity data (3D problems only).
 
-    This class is used to simulate an apparent conductivity datum, in S/m, as defined by:
-
-    .. math::
-        \sigma_{app} = \mu_0 \omega \dfrac{\bar{H}^2}{ \bar{E} ^2}
-
-    where :math:`\omega` is the angular frequency in rad/s,
-
-    .. math::
-        \bar{H} \big |^2 = \big | \vec{H}^{(x)} \big |^2 + \big | \vec{H}^{(y)} \big |^2
-
-    and
-
-    .. math::
-        \bar{E}^2= \Big [ \big | E_x^{(x)} \big |^2 + \big | E_y^{(x)} \big |^2 \Big ]
-        = \Big [ \big | E_x^{(y)} \big |^2 + \big | E_y^{(y)} \big |^2 \Big ]
+    This class is used to simulate an apparent conductivity datum, in S/m.
 
     Parameters
     ----------
@@ -1158,180 +2146,110 @@ class ApparentConductivity(_ElectricAndMagneticReceiver):
     locations_h : (n_loc, n_dim) array_like, optional
         Locations where the magnetic fields are measured. Defaults to the same
         locations as electric field measurements, `locations_e`.
+    component : {"root_gram_determinant", "cross_product_amplitude", "horizontal_determinant"}
+        The method used to generate the appparent conductivity datum.
     storeProjections : bool
         Whether to cache to internal projection matrices.
-
-    Notes
-    -----
-    It is important to take the amplitudes of the fields resulting from x and y planewave
-    polarizations separately, then summing. Adding the fields from x and y planewaves then
-    summing can result in simulated anomalies which do not presented entirely over
-    conductive/resistive targets.
     """
 
-    def __init__(self, locations_e, locations_h=None, storeProjections=False):
+    def __init__(
+        self,
+        locations_e,
+        locations_h=None,
+        component="cross_product_amplitude",
+        storeProjections=False,
+    ):  # noqa: D102
         if locations_h is None:
             locations_h = locations_e
         super().__init__(
-            locations1=locations_e,
-            locations2=locations_h,
+            locations1=locations_h,
+            locations2=locations_e,
+            base_type="electric",
             storeProjections=storeProjections,
         )
+        self.component = component
 
-    def _eval_apparent_conductivity(self, src, mesh, f):
-        if mesh.dim < 3:
-            raise NotImplementedError(
-                "ApparentConductivity receiver not implemented for dim < 3."
+    @property
+    def locations_h(self):
+        """Roving magnetic field measurement locations.
+
+        Returns
+        -------
+        numpy.ndarray
+            Locations where the magnetic fields are measured.
+        """
+        return self._locations[0]
+
+    @property
+    def locations_e(self):
+        """Electric field measurement locations.
+
+        Returns
+        -------
+        numpy.ndarray
+            Locations where the horizontal electric fields are measured.
+        """
+        return self._locations[1]
+
+    @property
+    def component(self):
+        r"""Equation used to generate the apparent conductivity datum.
+
+        The `component` property specifies
+        whether the data are derived using:
+        - 'root_gram_determinant': Root Gram determinant of the admittance matrix
+        - 'cross_product_amplitude': Cross product amplitude of the admittance matrix
+        - 'horizontal_determinant': Determinant of the horizontal admittances
+
+        Returns
+        -------
+        str
+            Data type; i.e. "root_gram_determinant", "cross_product_amplitude", or
+            "horizontal_determinant".
+        """
+        return self._component
+
+    @component.setter
+    def component(self, var):
+        self._component = validate_string(
+            "component",
+            var,
+            [
+                "root_gram_determinant",
+                "cross_product_amplitude",
+                "horizontal_determinant",
+            ],
+        )
+
+    def eval(self, src, mesh, f):  # noqa: A003 D102
+        # Docstring inherited from parent class
+        if self._component == "root_gram_determinant":
+            return _alpha(src) ** -1 * self._eval_root_gram_determinant(src, mesh, f)
+        elif self._component == "cross_product_amplitude":
+            return _alpha(src) ** -1 * self._eval_cross_product_amplitude(src, mesh, f)
+        elif self._component == "horizontal_determinant":
+            return _alpha(src) ** -1 * np.abs(
+                self._eval_horizontal_determinant(src, mesh, f)
             )
 
-        e = f[src, "e"]
-        h = f[src, "h"]
-
-        ex = self.getP(mesh, "Ex", 0) @ e
-        ey = self.getP(mesh, "Ey", 0) @ e
-        hx = self.getP(mesh, "Fx", 1) @ h
-        hy = self.getP(mesh, "Fy", 1) @ h
-        hz = self.getP(mesh, "Fz", 1) @ h
-
-        top = np.sum(np.abs(hx) ** 2 + np.abs(hy) ** 2 + np.abs(hz) ** 2, axis=-1)
-        bot = np.sum(np.abs(ex) ** 2 + np.abs(ey) ** 2, axis=-1)
-
-        return (2 * np.pi * src.frequency * mu_0) * top / bot
-
-    def _eval_apparent_conductivity_deriv(
+    def evalDeriv(  # noqa: A003 D102
         self, src, mesh, f, du_dm_v=None, v=None, adjoint=False
     ):
-        if mesh.dim < 3:
-            raise NotImplementedError(
-                "Admittance receiver not implemented for dim < 3."
+        # Docstring inherited from parent class
+        # scaling by w*mu_0 happens inside function
+        if self._component == "root_gram_determinant":
+            return self._eval_root_gram_determinant_deriv(
+                src, mesh, f, du_dm_v=du_dm_v, v=v, adjoint=adjoint
+            )
+        elif self._component == "cross_product_amplitude":
+            return self._eval_cross_product_amplitude_deriv(
+                src, mesh, f, du_dm_v=du_dm_v, v=v, adjoint=adjoint
+            )
+        elif self._component == "horizontal_determinant":
+            return self._eval_horizontal_determinant_deriv(
+                src, mesh, f, du_dm_v=du_dm_v, v=v, adjoint=adjoint
             )
 
-        # Compute admittances
-        e = f[src, "e"]
-        h = f[src, "h"]
-
-        Pex = self.getP(mesh, "Ex", 0)
-        Pey = self.getP(mesh, "Ey", 0)
-        Phx = self.getP(mesh, "Fx", 1)
-        Phy = self.getP(mesh, "Fy", 1)
-        Phz = self.getP(mesh, "Fz", 1)
-
-        ex = Pex @ e
-        ey = Pey @ e
-        hx = Phx @ h
-        hy = Phy @ h
-        hz = Phz @ h
-
-        fact = 2 * np.pi * src.frequency * mu_0
-        top = np.sum(np.abs(hx) ** 2 + np.abs(hy) ** 2 + np.abs(hz) ** 2, axis=-1)
-        bot = np.sum(np.abs(ex) ** 2 + np.abs(ey) ** 2, axis=-1)
-
-        # ADJOINT
-        if adjoint:
-            # Compute: J_T * v = d_top_T * a_v + d_bot_T * b
-            a_v = fact * v / bot  # term 1
-            b_v = -fact * top * v / bot**2  # term 2
-
-            a_v = np.repeat(mkvc(a_v, n_dims=2), 2, axis=-1)
-            b_v = np.repeat(mkvc(b_v, n_dims=2), 2, axis=-1)
-
-            hx *= a_v
-            hy *= a_v
-            hz *= a_v
-            ex *= b_v
-            ey *= b_v
-
-            e_v = 2 * (Pex.T @ ex + Pey.T @ ey).conjugate()
-            h_v = 2 * (Phx.T @ hx + Phy.T @ hy + Phz.T @ hz).conjugate()
-
-            fu_e_v, fm_e_v = f._eDeriv(src, None, e_v, adjoint=True)
-            fu_h_v, fm_h_v = f._hDeriv(src, None, h_v, adjoint=True)
-
-            return fu_e_v + fu_h_v, fm_e_v + fm_h_v
-
-        # JVEC
-        de_v = f._eDeriv(src, du_dm_v, v, adjoint=False)
-        dh_v = f._hDeriv(src, du_dm_v, v, adjoint=False)
-
-        dex_v = Pex @ de_v
-        dey_v = Pey @ de_v
-        dhx_v = Phx @ dh_v
-        dhy_v = Phy @ dh_v
-        dhz_v = Phz @ dh_v
-
-        # Imaginary components cancel and its 2x the real of the conjugate x the deriv
-        dtop_v = 2 * np.sum(
-            (
-                hx.conjugate() * dhx_v + hy.conjugate() * dhy_v + hz.conjugate() * dhz_v
-            ).real,
-            axis=-1,
-        )
-        dbot_v = 2 * np.sum(
-            (ex.conjugate() * dex_v + ey.conjugate() * dey_v).real, axis=-1
-        )
-
-        return fact * (bot * dtop_v - top * dbot_v) / (bot * bot)
-
-    def eval(self, src, mesh, f):  # noqa: A003
-        """Compute receiver data from the discrete field solution.
-
-        Parameters
-        ----------
-        src : .frequency_domain.sources.BaseFDEMSrc
-            NSEM source.
-        mesh : discretize.TensorMesh
-            Mesh on which the discretize solution is obtained.
-        f : simpeg.electromagnetics.frequency_domain.fields.FieldsFDEM
-            NSEM fields object of the source.
-
-        Returns
-        -------
-        numpy.ndarray
-            Evaluated data for the receiver.
-        """
-        return self._eval_apparent_conductivity(src, mesh, f)
-
-    def evalDeriv(self, src, mesh, f, du_dm_v=None, v=None, adjoint=False):
-        r"""Derivative of data with respect to the fields.
-
-        Let :math:`\mathbf{d}` represent the data corresponding the receiver object.
-        And let :math:`\mathbf{u}` represent the discrete numerical solution of the
-        fields on the mesh. Where :math:`\mathbf{P}` is a projection function that
-        maps from the fields to the data, i.e.:
-
-        .. math::
-            \mathbf{d} = \mathbf{P}(\mathbf{u})
-
-        this method computes and returns the derivative:
-
-        .. math::
-            \dfrac{\partial \mathbf{d}}{\partial \mathbf{u}} =
-            \dfrac{\partial [ \mathbf{P} (\mathbf{u}) ]}{\partial \mathbf{u}}
-
-        Parameters
-        ----------
-        src : .frequency_domain.sources.BaseFDEMSrc
-            The NSEM source.
-        mesh : discretize.TensorMesh
-            Mesh on which the discretize solution is obtained.
-        f : simpeg.electromagnetics.frequency_domain.fields.FieldsFDEM
-            NSEM fields object for the source.
-        du_dm_v : None, optional
-            Supply pre-computed derivative?
-        v : numpy.ndarray, optional
-            Vector of size
-        adjoint : bool, optional
-            Whether to compute the ajoint operation.
-
-        Returns
-        -------
-        numpy.ndarray
-            Calculated derivative (n_data,) if `adjoint` is ``False``,
-            and (n_param, 2) if `adjoint` is ``True``, for both polarizations.
-        """
-        return self._eval_apparent_conductivity_deriv(
-            src, mesh, f, du_dm_v=du_dm_v, v=v, adjoint=adjoint
-        )
 
 
 @deprecate_class(removal_version="0.24.0", error=True, replace_docstring=False)

--- a/simpeg/electromagnetics/natural_source/receivers.py
+++ b/simpeg/electromagnetics/natural_source/receivers.py
@@ -2062,6 +2062,7 @@ class HorizontalDeterminant(RootGramDeterminant):
     storeProjections : bool
         Whether to cache to internal projection matrices.
     """
+
     _loc_names = ("Roving magnetic field", "Base station field")
 
     def __init__(  # noqa: D107

--- a/simpeg/electromagnetics/natural_source/receivers.py
+++ b/simpeg/electromagnetics/natural_source/receivers.py
@@ -2252,7 +2252,6 @@ class ApparentConductivity(_BaseOrientationInvariant):
             )
 
 
-
 @deprecate_class(removal_version="0.24.0", error=True, replace_docstring=False)
 class PointNaturalSource(Impedance):
     """

--- a/tests/em/nsem/forward/test_Simulation3D_vs_Analytic_pytest.py
+++ b/tests/em/nsem/forward/test_Simulation3D_vs_Analytic_pytest.py
@@ -7,30 +7,40 @@ from simpeg.utils import model_builder, mkvc, get_default_solver
 from simpeg import maps
 
 REL_TOLERANCE = 0.05
-ABS_TOLERANCE = 1e-13
+ABS_TOLERANCE = 1e-9
+REL_TOLERANCE_2 = 0.1
+ABS_TOLERANCE_2 = 1e-7
 
 
 @pytest.fixture
 def mesh():
-    # Mesh for testing
-    return TensorMesh(
+    """Get test mesh."""
+    mesh = TensorMesh(
         [
-            [(200, 6, -1.5), (200.0, 4), (200, 6, 1.5)],
-            [(200, 6, -1.5), (200.0, 4), (200, 6, 1.5)],
-            [(200, 8, -1.5), (200.0, 8), (200, 8, 1.5)],
+            [(200, 10, -1.5), (200.0, 6), (200, 10, 1.5)],
+            [(200, 10, -1.5), (200.0, 6), (200, 10, 1.5)],
+            [(200, 10, -1.5), (200.0, 10), (200, 10, 1.5)],
         ],
         "CCC",
     )
+    mesh.origin[-1] -= 200.0
+    return mesh
 
 
 @pytest.fixture
 def mapping(mesh):
+    """Get test mapping."""
     return maps.IdentityMap(mesh)
 
 
 def get_model(mesh, model_type):
-    # Model used for testing
+    """Get test model."""
     model = 1e-8 * np.ones(mesh.nC)
+
+    if mesh.dim == 1:
+        model[mesh.cell_centers < 0.0] = 1e-2
+        return model
+
     model[mesh.cell_centers[:, 2] < 0.0] = 1e-2
 
     if model_type == "layer":
@@ -42,13 +52,14 @@ def get_model(mesh, model_type):
             mesh.cell_centers,
         )
         model[ind_block] = 1e-1
+        # pass
 
     return model
 
 
 @pytest.fixture
 def locations():
-    # Receiver locations
+    """Get test locations."""
     elevation = 0.0
     v = np.r_[-350.0, -150.0, 150.0, 350.0]  # needs to be symmetric
     rx_x, rx_y = np.meshgrid(v, v)
@@ -59,11 +70,12 @@ def locations():
 
 @pytest.fixture
 def frequencies():
-    # Frequencies being evaluated
+    """Get test frequencies."""
     return [1e-1, 2e-1]
 
 
-def get_survey(locations, frequencies, survey_type, component):
+def get_survey(locations, frequencies, survey_type, component, base_type):
+    """Get test survey."""
     source_list = []
 
     for f in frequencies:
@@ -108,14 +120,49 @@ def get_survey(locations, frequencies, survey_type, component):
             ]
 
         elif survey_type == "apparent_conductivity":
-            rx_list = [nsem.receivers.ApparentConductivity(locations)]
+            rx_list = [
+                nsem.receivers.ApparentConductivity(
+                    locations_h=locations,
+                    locations_e=locations,
+                    component=component,
+                )
+            ]
+
+        elif survey_type == "det_horizontal":
+            rx_list = [
+                nsem.receivers.HorizontalDeterminant(
+                    locations_h=locations,
+                    locations_base=locations,
+                    base_type=base_type,
+                    component=component,
+                )
+            ]
+
+        elif survey_type == "gram_amp":
+            rx_list = [
+                nsem.receivers.RootGramDeterminant(
+                    locations_h=locations,
+                    locations_base=locations,
+                    base_type=base_type,
+                )
+            ]
+
+        elif survey_type == "cross_amp":
+            rx_list = [
+                nsem.receivers.CrossProductAmplitude(
+                    locations_h=locations,
+                    locations_base=locations,
+                    base_type=base_type,
+                )
+            ]
 
         source_list.append(nsem.sources.PlanewaveXYPrimary(rx_list, f))
 
     return nsem.survey.Survey(source_list)
 
 
-def get_analytic_halfspace_solution(sigma, f, survey_type, component):
+def get_analytic_halfspace_solution(sigma, f, survey_type, component, base_type):
+    """Get analytic halfpsace solution."""
     # MT data types (Zxx, Zxy, Zyx, Zyy)
     if survey_type == "impedance":
         if component in ["real", "imag"]:
@@ -145,29 +192,65 @@ def get_analytic_halfspace_solution(sigma, f, survey_type, component):
     elif survey_type == "apparent_conductivity":
         return sigma
 
+    elif survey_type == "det_horizontal":
+        if base_type == "magnetic":
+            if component == "imag":
+                return np.r_[0.0]
+            else:
+                return np.r_[1.0]
+        elif base_type == "electric":
+            if component == "real":
+                return (
+                    0.025 * sigma / (2 * np.pi * f * mu_0)
+                )  # np.r_[0.] <-- analytically
+            elif component == "imag":
+                return -sigma / (2 * np.pi * f * mu_0)
+            else:
+                return sigma / (2 * np.pi * f * mu_0)
+
+    elif survey_type == "gram_amp":
+        if base_type == "magnetic":
+            return np.r_[1.0]
+        elif base_type == "electric":
+            return sigma / (2 * np.pi * f * mu_0)
+
+    elif survey_type == "cross_amp":
+        if base_type == "magnetic":
+            return np.r_[1.0]
+        elif base_type == "electric":
+            return sigma / (2 * np.pi * f * mu_0)
+
 
 # Validate impedances, tippers and admittances against analytic
 # solution for a halfspace.
 
 CASES_LIST_HALFSPACE = [
-    ("impedance", "real"),
-    ("impedance", "imag"),
-    ("impedance", "app_res"),
-    ("impedance", "phase"),
-    ("tipper", "real"),
-    ("tipper", "imag"),
-    ("admittance", "real"),
-    ("admittance", "imag"),
-    ("apparent_conductivity", None),
+    ("impedance", "real", None),
+    ("impedance", "imag", None),
+    ("tipper", "real", None),
+    ("tipper", "imag", None),
+    ("admittance", "real", None),
+    ("admittance", "imag", None),
+    ("det_horizontal", "real", "magnetic"),
+    ("det_horizontal", "imag", "magnetic"),
+    ("det_horizontal", "amp", "magnetic"),
+    ("det_horizontal", "real", "electric"),
+    ("det_horizontal", "imag", "electric"),
+    ("det_horizontal", "amp", "electric"),
+    ("cross_amp", None, "electric"),
+    ("gram_amp", None, "magnetic"),
+    ("cross_amp", None, "electric"),
+    ("gram_amp", None, "magnetic"),
 ]
 
 
-@pytest.mark.parametrize("survey_type, component", CASES_LIST_HALFSPACE)
+@pytest.mark.parametrize("survey_type, component, base_type", CASES_LIST_HALFSPACE)
 def test_analytic_halfspace_solution(
-    survey_type, component, frequencies, locations, mesh, mapping
+    survey_type, component, base_type, frequencies, locations, mesh, mapping
 ):
+    """Analytic halfspace solution tests."""
     # Numerical solution
-    survey = get_survey(locations, frequencies, survey_type, component)
+    survey = get_survey(locations, frequencies, survey_type, component, base_type)
     model_hs = get_model(mesh, "halfspace")  # 1e-2 halfspace
     sim = nsem.simulation.Simulation3DPrimarySecondary(
         mesh,
@@ -183,24 +266,89 @@ def test_analytic_halfspace_solution(
     n_locations = np.shape(locations)[0]
     analytic_solution = np.hstack(
         [
-            get_analytic_halfspace_solution(sigma_hs, f, survey_type, component)
+            get_analytic_halfspace_solution(
+                sigma_hs, f, survey_type, component, base_type
+            )
             for f in frequencies
         ]
     )
     analytic_solution = np.repeat(analytic_solution, n_locations)
 
-    # # Error
-    err = np.abs(
-        (numeric_solution - analytic_solution) / (analytic_solution + ABS_TOLERANCE)
+    if (
+        (survey_type == "det_horizontal")
+        & (component == "real")
+        & (base_type == "electric")
+    ):
+        np.testing.assert_array_less(
+            np.abs(numeric_solution), np.abs(analytic_solution)
+        )
+    else:
+        np.testing.assert_allclose(
+            analytic_solution, numeric_solution, rtol=REL_TOLERANCE, atol=ABS_TOLERANCE
+        )
+
+
+CASES_LIST_CROSSCHECK = [
+    ("gram_amp", "root_gram_determinant"),
+    ("cross_amp", "cross_product_amplitude"),
+    ("det_horizontal", "horizontal_determinant"),
+]
+
+
+# PRIMARY-SECONDARY DOESN'T SEEM TO WORK UNLESS THE PADDING IS EXTREME.
+@pytest.mark.parametrize("survey_type, component", CASES_LIST_CROSSCHECK)
+def test_apparent_conductivity_crosscheck(
+    survey_type, component, frequencies, locations, mesh, mapping
+):
+    """Cross check test for apparent conductivity data."""
+    # Numerical solution
+    survey_1 = get_survey(
+        locations,
+        frequencies,
+        "apparent_conductivity",
+        component,
+        None,
+    )
+    survey_2 = get_survey(locations, frequencies, survey_type, "amp", "electric")
+
+    model_block = get_model(mesh, "block")
+    model_hs = get_model(mesh, "halfspace")  # 1e-2 halfspace
+
+    sim_1 = nsem.simulation.Simulation3DPrimarySecondary(
+        mesh,
+        survey=survey_1,
+        sigmaPrimary=model_hs,
+        sigmaMap=mapping,
+        solver=get_default_solver(),
+    )
+    sim_2 = nsem.simulation.Simulation3DPrimarySecondary(
+        mesh,
+        survey=survey_2,
+        sigmaPrimary=model_hs,
+        sigmaMap=mapping,
+        solver=get_default_solver(),
     )
 
-    assert np.all(err < REL_TOLERANCE)
+    dpred_1 = sim_1.dpred(model_block)
+
+    alpha = 2 * np.pi * np.kron(frequencies, np.ones(len(locations))) * mu_0
+    dpred_2 = alpha * sim_2.dpred(model_block)
+
+    np.testing.assert_allclose(
+        dpred_1, dpred_2, rtol=REL_TOLERANCE_2, atol=ABS_TOLERANCE_2
+    )
 
 
 def test_symmetry_for_appcon(frequencies, locations, mesh, mapping):
     """Test the app con is symmetric across the y-axis."""
     # Numerical solution
-    survey = get_survey(locations, frequencies, "apparent_conductivity", None)
+    survey = get_survey(
+        locations,
+        frequencies,
+        "apparent_conductivity",
+        "cross_product_amplitude",
+        None,
+    )
     model_hs = get_model(mesh, "halfspace")  # 1e-2 halfspace
     model_block = get_model(mesh, "block")
     sim = nsem.simulation.Simulation3DPrimarySecondary(

--- a/tests/em/nsem/inversion/test_NSEM_3D_jvecjtvecadj_pytest.py
+++ b/tests/em/nsem/inversion/test_NSEM_3D_jvecjtvecadj_pytest.py
@@ -190,7 +190,8 @@ CASES_LIST = [
 
 @pytest.mark.parametrize("survey_type, orientations, components", CASES_LIST)
 class TestDerivatives:
-    """Perofrm derivative convergence test."""
+    """Perform derivative convergence test."""
+
     def get_setup_objects(
         self,
         survey_type,

--- a/tests/em/nsem/inversion/test_NSEM_3D_jvecjtvecadj_pytest.py
+++ b/tests/em/nsem/inversion/test_NSEM_3D_jvecjtvecadj_pytest.py
@@ -1,18 +1,19 @@
+"""Derivative and adjoint tests for 3D simulations."""
+
 import pytest
 import numpy as np
 from discretize import TensorMesh, tests
-from simpeg import (
-    maps,
-    data_misfit,
-)
+from simpeg import maps, data_misfit
 from simpeg.utils import mkvc, model_builder, get_default_solver
 from simpeg.electromagnetics import natural_source as nsem
 
-ADJ_RTOL = 1e-10
+ADJ_RTOL = 1e-8
+ADJ_ATOL = 1e-11
 
 
 @pytest.fixture
 def mesh():
+    """Return test mesh."""
     return TensorMesh(
         [
             [(200, 6, -1.5), (200.0, 4), (200, 6, 1.5)],
@@ -25,26 +26,21 @@ def mesh():
 
 @pytest.fixture
 def active_cells(mesh):
+    """Return active cells."""
     return mesh.cell_centers[:, 2] < 0.0
 
 
 @pytest.fixture
 def mapping(mesh, active_cells):
+    """Return mapping."""
     return maps.InjectActiveCells(mesh, active_cells, 1e-8) * maps.ExpMap(
         nP=np.sum(active_cells)
     )
 
 
 @pytest.fixture
-def sigma_hs(mesh, active_cells):
-    sigma_hs = 1e-8 * np.ones(mesh.nC)
-    sigma_hs[active_cells] = 1e1
-    return sigma_hs
-
-
-@pytest.fixture
 def locations():
-    # Receiver locations
+    """Return receiver locations."""
     elevation = 0.0
     rx_x, rx_y = np.meshgrid(np.arange(-350, 350, 200), np.arange(-350, 350, 200))
     return np.hstack(
@@ -54,11 +50,20 @@ def locations():
 
 @pytest.fixture
 def frequencies():
-    # Frequencies being evaluated
+    """Return frequencies."""
     return [1e-1, 2e-1]
 
 
+@pytest.fixture
+def sigma_hs(mesh, active_cells):
+    """Return background conductivity."""
+    sigma_hs = 1e-8 * np.ones(mesh.nC)
+    sigma_hs[active_cells] = 1e1
+    return sigma_hs
+
+
 def get_survey(survey_type, orientations, components, locations, frequencies):
+    """Return test survey."""
     if not isinstance(orientations, list):
         orientations = [orientations]
 
@@ -105,7 +110,8 @@ def get_survey(survey_type, orientations, components, locations, frequencies):
                 rx_list.extend(
                     [
                         nsem.receivers.Admittance(
-                            locations,
+                            locations_h=locations,
+                            locations_e=np.zeros_like(locations),
                             orientation=orient,
                             component=comp,
                         )
@@ -115,7 +121,47 @@ def get_survey(survey_type, orientations, components, locations, frequencies):
 
         # MobileMT is app_cond
         elif survey_type == "apparent_conductivity":
-            rx_list.extend([nsem.receivers.ApparentConductivity(locations)])
+            rx_list.extend(
+                [
+                    nsem.receivers.ApparentConductivity(
+                        locations_h=locations,
+                        locations_e=np.zeros_like(locations),
+                        component=components[0],
+                    )
+                ]
+            )
+
+        # Horizontal determinanet
+        elif survey_type == "det_horizontal":
+            rx_list = [
+                nsem.receivers.HorizontalDeterminant(
+                    locations_h=locations,
+                    locations_base=np.zeros_like(locations),
+                    base_type=orientations[0],
+                    component=comp,
+                )
+                for comp in components
+            ]
+
+        # Determinant ampliutde of the Gram matrix
+        elif survey_type == "gram_amp":
+            rx_list = [
+                nsem.receivers.RootGramDeterminant(
+                    locations,
+                    locations_base=np.zeros_like(locations),
+                    base_type=orientations[0],
+                )
+            ]
+
+        # Determinant amplitude of the cross product
+        elif survey_type == "cross_amp":
+            rx_list = [
+                nsem.receivers.CrossProductAmplitude(
+                    locations,
+                    locations_base=np.zeros_like(locations),
+                    base_type=orientations[0],
+                )
+            ]
 
         source_list.append(nsem.sources.PlanewaveXYPrimary(rx_list, f))
 
@@ -134,12 +180,17 @@ CASES_LIST = [
     ("admittance", ["xy", "yx"], ["real", "imag"]),
     ("admittance", ["xx", "yy"], ["real", "imag"]),
     ("admittance", ["zx", "zy"], ["real", "imag"]),
-    ("apparent_conductivity", None, None),
+    ("det_horizontal", "electric", ["real", "imag", "amp"]),
+    ("det_horizontal", "magnetic", ["real", "imag", "amp"]),
+    ("apparent_conductivity", None, "root_gram_determinant"),
+    ("apparent_conductivity", None, "cross_product_amplitude"),
+    ("apparent_conductivity", None, "horizontal_determinant"),
 ]
 
 
 @pytest.mark.parametrize("survey_type, orientations, components", CASES_LIST)
 class TestDerivatives:
+    """Perofrm derivative convergence test."""
     def get_setup_objects(
         self,
         survey_type,
@@ -152,6 +203,7 @@ class TestDerivatives:
         mapping,
         sigma_hs,
     ):
+        """Get test objections."""
         survey = get_survey(
             survey_type, orientations, components, locations, frequencies
         )
@@ -196,6 +248,7 @@ class TestDerivatives:
         mapping,
         sigma_hs,
     ):
+        """Test data misfit."""
         m0, dmis = self.get_setup_objects(
             survey_type,
             orientations,
@@ -231,6 +284,7 @@ class TestDerivatives:
         mapping,
         sigma_hs,
     ):
+        """Perform adjoint test."""
         m0, dmis = self.get_setup_objects(
             survey_type,
             orientations,


### PR DESCRIPTION
#### Summary
This PR is intended to add the complete suite of rotation invariant transfer transfer functions to our receiver classes. These are primarily used for airborne NSEM systems but that can be used for general survey configurations.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Supplementary math
Consider an AirMT system that measures three-component airborne magnetic fields. For a magnetic base station, we can generate the fundamental set of transfer functions $\mathbf{T}$, where $\mathbf{T}$ is a 2x3 matrix. Likewise, for an electric base station, we can generate the fundamental admittance tensor $\mathbf{Y}$. A multitude of orientation invariant transfer functions can be derived from the fundamental set. These are helpful when receiver orientation cannot be precisely resolved.

**Root Gram Determinant:** $\widehat{\mathbf{T}} = \sqrt{\mathbf{TT^\dagger}}$ where $\dagger$ represents the Hermitian. Similarly, the root Gram determinant can be generated for an electric base station $\widehat{\mathbf{Y}} = \sqrt{\mathbf{YY^\dagger}}$

**Cross Product Amplitude:** Orientation invariant transfer functions $|T|$ and $|Y|$ can be generated by taking the amplitude of the cross-product of the two rows of $\mathbf{T}$ and $\mathbf{Y}$, respectively. See Mackie and Soyer (2026).

**Horizontal Determinant:** Taking the determinant of the horizontal transfer functions provides something invariant to z-axis rotation $det(T_H) = T_{xx} T_{yy} - T_{xy} T_{yx}$ and $det(Y_H) = Y_{xx} Y_{yy} - Y_{xy} Y_{yx}$.

**Apparent Conductivity:** For an electric base station, all of these approaches can be used to generate apparent conductivity data.

* $\omega \mu_0 \widehat{Y}$
* $\omega \mu_0 |Y|$
* $\omega \mu_0 |det(Y_H)|$

This PR adds all the aforementioned transfer functions.

#### What is being added

A ``_BaseOrientationInvariant`` will host the underlying functionality for taking the root Gram determinant, cross product amplitude and horizontal determinant. There will be a property that sets whether an electric or magnetic base station is used.

From this, I created child classes ``RootGramDeterminant``, ``CrossProductAmplitude`` and ``HorizontalDeterminant`` that users can interact with.

There is also an ``ApparentConductivity`` class. Here, the component property is used to set the approach used to generate the apparent conductivity datum