### PR TITLE
Remove non-existing function from API reference

### DIFF
--- a/simpeg/electromagnetics/utils/__init__.py
+++ b/simpeg/electromagnetics/utils/__init__.py
@@ -16,7 +16,6 @@ Current Utilities
   getStraightLineCurrentIntegral
   segmented_line_current_source_term
   line_through_faces
-  getSourceTermLineCurrentPolygon
 
 Waveform Utilities
 ==================


### PR DESCRIPTION
#### Summary

Remove the `getSourceTermLineCurrentPolygon` function listed in the `simpeg/electromagnetics/utils.py` API reference.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
