### PR TITLE
Better map shapes

### DIFF
--- a/simpeg/maps/_base.py
+++ b/simpeg/maps/_base.py
@@ -465,13 +465,15 @@ class ComboMap(IdentityMap):
 
     @property
     def maps(self):
-        r"""The list of mappings being combined.
+        r"""The mappings being combined.
 
         Returns
         -------
-        list of simpeg.maps.IdentityMap
-            The list of mappings, ordered from last applied to first
-            applied.
+        tuple of simpeg.maps.IdentityMap
+            The mappings, ordered from last applied to first applied. This
+            is a ``tuple`` (rather than a ``list``) so it cannot be mutated
+            in a way that would make the cached :py:attr:`shape` stale;
+            assign a new value to ``maps`` instead.
         """
         return self._maps
 
@@ -502,8 +504,8 @@ class ComboMap(IdentityMap):
 
             resolved.append(m)
 
-        self._maps = resolved
-        self._shape = _resolve_combo_shape(resolved)
+        self._maps = tuple(resolved)
+        self._shape = _resolve_combo_shape(self._maps)
 
     @property
     def shape(self):
@@ -830,18 +832,21 @@ class SumMap(ComboMap):
 
     @property
     def maps(self):
-        r"""The list of mappings being summed.
+        r"""The mappings being summed.
 
         Returns
         -------
-        list of simpeg.maps.IdentityMap
-            The list of mappings being summed together.
+        tuple of simpeg.maps.IdentityMap
+            The mappings being summed together. This is a ``tuple``
+            (rather than a ``list``) so it cannot be mutated in a way
+            that would make the cached :py:attr:`shape` stale; assign a
+            new value to ``maps`` instead.
         """
         return self._maps
 
     @maps.setter
     def maps(self, value):
-        value = validate_list_of_types("maps", value, IdentityMap, min_n=1)
+        value = tuple(validate_list_of_types("maps", value, IdentityMap, min_n=1))
 
         shape0, shape1 = value[0].shape
         for ii, m in enumerate(value):

--- a/simpeg/maps/_base.py
+++ b/simpeg/maps/_base.py
@@ -354,6 +354,53 @@ class IdentityMap:
         return True
 
 
+def _shapes_compatible(shape_a, shape_b):
+    r"""Check whether two mapping shapes agree, treating ``'*'`` as a wildcard."""
+    return all(x == "*" or y == "*" or x == y for x, y in zip(shape_a, shape_b))
+
+
+def _resolve_combo_shape(maps):
+    r"""Infer the overall shape of a chain of mappings.
+
+    ``maps`` must be ordered the same way they are stored on a
+    :class:`ComboMap`: from the mapping applied last to the mapping
+    applied first. A mapping with shape (``*``, ``*``) can act on a
+    vector of any length, so when a concrete dimension is known on one
+    side of such a mapping (because a neighboring mapping fixes it),
+    that dimension is propagated through it.
+
+    Returns
+    -------
+    (2) tuple of int or ``*``
+        The resolved (output, input) shape of the combined mapping.
+    """
+    n = len(maps)
+    # junctions[0] is the output size of the combination; junctions[n] is
+    # the input size (nP); junctions[i] in between is the size flowing
+    # between maps[i] (applied earlier) and maps[i - 1] (applied later).
+    junctions = [None] * (n + 1)
+    junctions[0] = maps[0].shape[0]
+    junctions[n] = maps[-1].shape[1]
+    for i in range(1, n):
+        out_dim = maps[i - 1].shape[1]
+        in_dim = maps[i].shape[0]
+        junctions[i] = out_dim if out_dim != "*" else in_dim
+
+    def is_free(m):
+        return m.shape == ("*", "*")
+
+    # propagate known dimensions through free maps toward the output...
+    for i in range(n - 1, -1, -1):
+        if is_free(maps[i]) and junctions[i] == "*" and junctions[i + 1] != "*":
+            junctions[i] = junctions[i + 1]
+    # ...and toward the input.
+    for i in range(n):
+        if is_free(maps[i]) and junctions[i + 1] == "*" and junctions[i] != "*":
+            junctions[i + 1] = junctions[i]
+
+    return (junctions[0], junctions[n])
+
+
 class ComboMap(IdentityMap):
     r"""Combination mapping constructed by joining a set of other mappings.
 
@@ -414,37 +461,49 @@ class ComboMap(IdentityMap):
 
     def __init__(self, maps, **kwargs):
         super().__init__(mesh=None, **kwargs)
+        self.maps = maps
 
-        self.maps = []
-        for ii, m in enumerate(maps):
-            assert isinstance(m, IdentityMap), "Unrecognized data type, "
-            "inherit from an IdentityMap or ComboMap!"
+    @property
+    def maps(self):
+        r"""The list of mappings being combined.
 
-            if (
-                ii > 0
-                and not (self.shape[1] == "*" or m.shape[0] == "*")
-                and not self.shape[1] == m.shape[0]
-            ):
-                prev = self.maps[-1]
+        Returns
+        -------
+        list of simpeg.maps.IdentityMap
+            The list of mappings, ordered from last applied to first
+            applied.
+        """
+        return self._maps
 
-                raise ValueError(
-                    "Dimension mismatch in map[{0!s}] ({1!s}, {2!s}) "
-                    "and map[{3!s}] ({4!s}, {5!s}).".format(
-                        prev.__class__.__name__,
-                        prev.shape[0],
-                        prev.shape[1],
-                        m.__class__.__name__,
-                        m.shape[0],
-                        m.shape[1],
+    @maps.setter
+    def maps(self, value):
+        value = validate_list_of_types("maps", value, IdentityMap, min_n=1)
+
+        resolved = []
+        for ii, m in enumerate(value):
+            if ii > 0:
+                prev_shape = _resolve_combo_shape(resolved)
+                if (
+                    not (prev_shape[1] == "*" or m.shape[0] == "*")
+                    and not prev_shape[1] == m.shape[0]
+                ):
+                    prev = resolved[-1]
+                    raise ValueError(
+                        "Dimension mismatch in map[{0!s}] ({1!s}, {2!s}) "
+                        "and map[{3!s}] ({4!s}, {5!s}).".format(
+                            prev.__class__.__name__,
+                            prev.shape[0],
+                            prev.shape[1],
+                            m.__class__.__name__,
+                            m.shape[0],
+                            m.shape[1],
+                        )
                     )
-                )
 
-            if np.any([isinstance(m, SumMap), isinstance(m, IdentityMap)]):
-                self.maps += [m]
-            elif isinstance(m, ComboMap):
-                self.maps += m.maps
-            else:
-                raise ValueError("Map[{0!s}] not supported", m.__class__.__name__)
+            resolved.append(m)
+
+        self._maps = resolved
+        self._shape = _resolve_combo_shape(resolved)
 
     @property
     def shape(self):
@@ -453,14 +512,18 @@ class ComboMap(IdentityMap):
         For a list of SimPEG mappings [:math:`\mathbf{f}_n,...,\mathbf{f}_1`]
         that have been joined to create a ``ComboMap``, this method returns
         the dimensions of the combination mapping. Recall that the ordering
-        of the list of mappings is from last to first.
+        of the list of mappings is from last to first. This is computed once
+        when the mapping's ``maps`` are set and reused afterward.
 
         Returns
         -------
         (2) tuple of int
-            Dimensions of the mapping operator.
+            Dimensions of the mapping operator. If a dimension cannot be
+            resolved from the chain of mappings (e.g. every mapping in
+            the chain has shape (``*``, ``*``)), ``*`` is returned for
+            that dimension instead.
         """
-        return (self.maps[0].shape[0], self.maps[-1].shape[1])
+        return self._shape
 
     @property
     def nP(self):
@@ -468,10 +531,10 @@ class ComboMap(IdentityMap):
 
         Returns
         -------
-        int
+        int or ``*``
             Number of parameters that the mapping acts on.
         """
-        return self.maps[-1].nP
+        return self.shape[1]
 
     def _transform(self, m):
         for map_i in reversed(self.maps):
@@ -761,37 +824,47 @@ class SumMap(ComboMap):
     """
 
     def __init__(self, maps, **kwargs):
-        maps = validate_list_of_types("maps", maps, IdentityMap)
-
         # skip ComboMap's init
         super(ComboMap, self).__init__(mesh=None, **kwargs)
+        self.maps = maps
 
-        self.maps = []
-        for ii, m in enumerate(maps):
-            if not isinstance(m, IdentityMap):
-                raise TypeError(
-                    "Unrecognized data type {}, inherit from an "
-                    "IdentityMap!".format(type(m))
-                )
+    @property
+    def maps(self):
+        r"""The list of mappings being summed.
 
-            if (
-                ii > 0
-                and not (self.shape == "*" or m.shape == "*")
-                and not self.shape == m.shape
-            ):
-                raise ValueError(
-                    "Dimension mismatch in map[{0!s}] ({1!s}, {2!s}) "
-                    "and map[{3!s}] ({4!s}, {5!s}).".format(
-                        self.maps[0].__class__.__name__,
-                        self.maps[0].shape[0],
-                        self.maps[0].shape[1],
-                        m.__class__.__name__,
-                        m.shape[0],
-                        m.shape[1],
+        Returns
+        -------
+        list of simpeg.maps.IdentityMap
+            The list of mappings being summed together.
+        """
+        return self._maps
+
+    @maps.setter
+    def maps(self, value):
+        value = validate_list_of_types("maps", value, IdentityMap, min_n=1)
+
+        shape0, shape1 = value[0].shape
+        for ii, m in enumerate(value):
+            if ii > 0:
+                if not _shapes_compatible((shape0, shape1), m.shape):
+                    raise ValueError(
+                        "Dimension mismatch in map[{0!s}] ({1!s}, {2!s}) "
+                        "and map[{3!s}] ({4!s}, {5!s}).".format(
+                            value[0].__class__.__name__,
+                            value[0].shape[0],
+                            value[0].shape[1],
+                            m.__class__.__name__,
+                            m.shape[0],
+                            m.shape[1],
+                        )
                     )
-                )
+                if shape0 == "*":
+                    shape0 = m.shape[0]
+                if shape1 == "*":
+                    shape1 = m.shape[1]
 
-            self.maps += [m]
+        self._maps = value
+        self._shape = (shape0, shape1)
 
     @property
     def shape(self):
@@ -800,9 +873,12 @@ class SumMap(ComboMap):
         Returns
         -------
         tuple
-            The dimensions of the mapping. A tuple of the form (``int``,``int``)
+            The dimensions of the mapping. A tuple of the form (``int``,``int``).
+            If none of the summed mappings fix a given dimension, ``*`` is
+            returned for that dimension instead. This is computed once when
+            the mapping's ``maps`` are set and reused afterward.
         """
-        return (self.maps[0].shape[0], self.maps[0].shape[1])
+        return self._shape
 
     @property
     def nP(self):
@@ -810,10 +886,10 @@ class SumMap(ComboMap):
 
         Returns
         -------
-        int
+        int or ``*``
             Number of parameters that the mapping acts on.
         """
-        return self.maps[-1].shape[1]
+        return self.shape[1]
 
     def _transform(self, m):
         for ii, map_i in enumerate(self.maps):

--- a/tests/base/test_maps.py
+++ b/tests/base/test_maps.py
@@ -108,6 +108,103 @@ def test_IdentityMap_init():
         maps.IdentityMap(nP="x")
 
 
+def test_combomap_shape_propagation():
+    # A map created without a fixed nP has shape ('*', '*') and should
+    # pick up a concrete dimension from a neighboring mapping.
+    free_map = maps.ExpMap()
+    fixed_map = maps.Projection(1, np.zeros(5, dtype=int))
+
+    combo = maps.ComboMap([free_map, fixed_map])
+    assert combo.shape == (5, 1)
+    assert combo.nP == 1
+
+    # propagation should cascade through several free maps chained together
+    combo = maps.ComboMap([maps.ExpMap(), maps.ExpMap(), fixed_map])
+    assert combo.shape == (5, 1)
+
+    # a chain made entirely of free maps stays unresolved
+    combo = maps.ComboMap([maps.ExpMap(), maps.ExpMap()])
+    assert combo.shape == ("*", "*")
+    assert combo.nP == "*"
+
+    # nesting an already-resolved ComboMap inside another should not lose
+    # the resolved dimension
+    inner = maps.ComboMap([maps.ExpMap(), fixed_map])
+    outer = maps.ComboMap([maps.ExpMap(), inner])
+    assert outer.shape == (5, 1)
+
+    # genuine mismatches between fixed dimensions must still raise, even
+    # when a free map sits between them
+    with pytest.raises(ValueError):
+        maps.ComboMap(
+            [maps.Projection(3, np.zeros(2, dtype=int)), maps.ExpMap(), fixed_map]
+        )
+
+
+def test_combomap_shape_is_cached():
+    fixed_map = maps.Projection(1, np.zeros(5, dtype=int))
+    combo = maps.ComboMap([maps.ExpMap(), fixed_map])
+    assert combo.shape == (5, 1)
+
+    # reassigning .maps must recompute (and re-cache) the shape
+    combo.maps = [maps.IdentityMap(nP=3)]
+    assert combo.shape == (3, 3)
+
+    # .maps is a tuple, so it can't be mutated in place in a way that
+    # would make the cached shape stale; reassignment is required instead
+    assert isinstance(combo.maps, tuple)
+    with pytest.raises(AttributeError):
+        combo.maps.append(maps.ExpMap())
+
+    # mutating the original list passed in does not affect the stored maps
+    original = [maps.ExpMap(), fixed_map]
+    combo = maps.ComboMap(original)
+    original.append(maps.IdentityMap(nP=99))
+    assert combo.shape == (5, 1)
+    assert len(combo.maps) == 2
+
+
+def test_combomap_maps_validation():
+    with pytest.raises(ValueError):
+        maps.ComboMap([])
+
+    with pytest.raises(TypeError):
+        maps.ComboMap([maps.ExpMap(), "not a map"])
+
+    with pytest.raises(ValueError):
+        maps.ComboMap([maps.IdentityMap(nP=3), maps.IdentityMap(nP=5)])
+
+    # a single mapping (not wrapped in a list) is also accepted
+    combo = maps.ComboMap(maps.ExpMap(nP=4))
+    assert combo.shape == (4, 4)
+
+
+def test_summap_shape_propagation():
+    summap = maps.SumMap([maps.ExpMap(), maps.IdentityMap(nP=7)])
+    assert summap.shape == (7, 7)
+    assert summap.nP == 7
+
+    summap = maps.SumMap([maps.ExpMap(), maps.ExpMap()])
+    assert summap.shape == ("*", "*")
+    assert summap.nP == "*"
+
+    # .maps is an immutable tuple, decoupled from the list passed in
+    assert isinstance(summap.maps, tuple)
+    original = [maps.ExpMap(), maps.IdentityMap(nP=7)]
+    summap = maps.SumMap(original)
+    original.append(maps.IdentityMap(nP=99))
+    assert summap.shape == (7, 7)
+    assert len(summap.maps) == 2
+
+
+def test_summap_maps_validation():
+    with pytest.raises(ValueError):
+        maps.SumMap([])
+
+    with pytest.raises(ValueError):
+        maps.SumMap([maps.IdentityMap(nP=3), maps.IdentityMap(nP=5)])
+
+
 class MapTests(unittest.TestCase):
     def setUp(self):
         maps2test2D = [M for M in dir(maps) if M not in MAPS_TO_EXCLUDE_2D]


### PR DESCRIPTION
#### Summary

`ComboMap`/`SumMap` shapes now propagate through neighboring maps that have an unconstrained shape (`("*", "*")`) instead of reporting `"*"` when it's actually resolvable. `maps` is also now a validated, cached property on both classes.

#### PR Checklist
* [x] If this is a work in progress PR, set as a Draft PR
* [x] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [x] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [x] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [x] Marked as ready for review (if this is was a draft PR), and converted 
      to a Pull Request
* [x] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
N/A

#### What does this implement/fix?

- `ComboMap`/`SumMap` shape resolution now propagates a known dimension through neighboring maps with shape `("*", "*")`, rather than leaving it as `"*"`.
- Fixes a `SumMap` bug (comparing a shape tuple to the string `"*"`) that made it wrongly reject valid combinations of unconstrained + fixed-shape maps.
- `maps` is now a validated property: an empty list or non-`IdentityMap` entry raises immediately (`ValueError`/`TypeError`), instead of failing later with a confusing `IndexError`/`AttributeError`.
- `shape` is computed once when `maps` is set and cached; `.maps` is stored as an immutable `tuple`.
- **Compatibility note:** shape mismatches are now detected through the full resolved chain rather than just adjacent raw shapes, so some internally-inconsistent `ComboMap`s that used to construct fine (and only fail later when applied) now raise at construction time — see example 3.

**1. Resolving shape through an unconstrained map**
```python
>>> combo = ComboMap([ExpMap(), Projection(1, np.zeros(5, dtype=int))])
>>> combo.shape
```
`main`: `('*', 1)` &nbsp;→&nbsp; this branch: `(5, 1)`

**2. `SumMap` used to crash on a valid combination**
```python
>>> SumMap([ExpMap(), IdentityMap(nP=7)])
```
`main`: raises `ValueError: Dimension mismatch in map[ExpMap] (*, *) and map[IdentityMap] (7, 7).` &nbsp;→&nbsp; this branch: succeeds, `.shape == (7, 7)`.

**3. Inconsistent chain now fails at construction, not at use**
```python
>>> maps_list = [IdentityMap(), IdentityMap(nP=5), IdentityMap(), IdentityMap(nP=10)]
>>> combo = ComboMap(maps_list)
```
`main`: construction succeeds (`shape == ('*', 10)`); only `combo * np.ones(10)` reveals the problem, raising `ValueError: Dimension mismatch in IdentityMap(5,5) and np.ndarray(10,)`.
this branch: `ComboMap(maps_list)` itself raises `ValueError: Dimension mismatch in map[IdentityMap] (*, *) and map[IdentityMap] (10, 10).`

**4. Misusing `.maps` fails fast**
```python
>>> c = ComboMap([IdentityMap(nP=3)])
>>> c.maps = []
```
`main`: accepted silently; `c.shape` later raises `IndexError`. &nbsp;→&nbsp; this branch: `c.maps = []` itself raises `ValueError: 'maps' must have at least 1 item.`

#### Additional information

Found myself wanting this functionality to validate input sizes in #1601, so split it off as it is a good change on its own!