### PR TITLE
Create a new `test` target in `Makefile`

### DIFF
--- a/.ci/azure/run_tests_with_coverage.sh
+++ b/.ci/azure/run_tests_with_coverage.sh
@@ -2,7 +2,7 @@
 set -x #echo on
 
 source activate simpeg-test
-pytest $TEST_TARGET --cov --cov-config=pyproject.toml -v -W ignore::DeprecationWarning
+make TEST_TARGET=${TEST_TARGET} test
 pytest_retval=$?
 coverage xml
 exit $pytest_retval

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 STYLE_CHECK_FILES = simpeg examples tutorials tests
 GITHUB_ACTIONS=.github/workflows
-TEST_TARGET=test
+TEST_TARGET=tests
 
 .PHONY: help docs clean check black flake flake-all check-actions test
 
@@ -40,4 +40,4 @@ check-actions:
 	zizmor ${GITHUB_ACTIONS}
 
 test:
-	pytest -v --cov --cov-config="pyproject.toml" -W "ignore::DeprecationWarning" ${TEST_TARGET}
+	pytest -v --cov --cov-config="pyproject.toml" -W "ignore::DeprecationWarning" "${TEST_TARGET}"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 STYLE_CHECK_FILES = simpeg examples tutorials tests
 GITHUB_ACTIONS=.github/workflows
+TEST_TARGET=test
 
-.PHONY: help docs clean check black flake flake-all check-actions
+.PHONY: help docs clean check black flake flake-all check-actions test
 
 help:
 	@echo "Commands:"
@@ -11,6 +12,7 @@ help:
 	@echo "  flake         checks code style with flake8"
 	@echo "  flake-all     checks code style with flake8 (full set of rules)"
 	@echo "  check-actions lint GitHub Actions workflows (with zizmor)"
+	@echo "  test          run all tests with pytest"
 	@echo ""
 
 docs:
@@ -36,3 +38,6 @@ flake-all:
 
 check-actions:
 	zizmor ${GITHUB_ACTIONS}
+
+test:
+	pytest -v --cov --cov-config="pyproject.toml" -W "ignore::DeprecationWarning" ${TEST_TARGET}


### PR DESCRIPTION
#### Summary

Add a new `test` target to the `Makefile` that runs the tests on the whole project, including performing a coverage report and ignoring `DeprecatedWarning`. Use the new make target to run the tests in CI, changing the `TEST_TARGET` variable to limit the scope of tests.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

A bit related to #1793: prepares the ground to include doctests in the new `test` target.

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
