### PR TITLE
Remove the `warn` argument in `get_default_solver`

### DIFF
--- a/simpeg/utils/solver_utils.py
+++ b/simpeg/utils/solver_utils.py
@@ -12,7 +12,6 @@ from pymatsolver import (
 )
 from pymatsolver.solvers import Base
 from .code_utils import deprecate_function
-import warnings
 from typing import Type
 
 __all__ = [
@@ -44,30 +43,14 @@ else:
     _DEFAULT_SOLVER = SolverLU
 
 
-def get_default_solver(warn=False) -> Type[Base]:
+def get_default_solver() -> Type[Base]:
     """Return the default solver used by simpeg.
-
-    Parameters
-    ----------
-    warn : bool, optional
-
-        .. deprecated:: 0.25.0
-
-           Argument ``warn`` is deprecated and will be removed in
-           SimPEG v0.26.0.
 
     Returns
     -------
     solver
         The default solver class used by simpeg's simulations.
     """
-    if warn:
-        warnings.warn(
-            "The `warn` argument has been deprecated and will be "
-            "removed in SimPEG v0.26.0.",
-            FutureWarning,
-            stacklevel=2,
-        )
     return _DEFAULT_SOLVER
 
 

--- a/tests/utils/test_default_solver.py
+++ b/tests/utils/test_default_solver.py
@@ -1,5 +1,4 @@
 import re
-import warnings
 import pytest
 from pymatsolver import SolverCG
 
@@ -36,15 +35,8 @@ def test_default_error():
     assert initial_default is after_default
 
 
-def test_deprecation_warning():
-    """Test deprecation warning for the warn argument."""
-    regex = re.escape("The `warn` argument has been deprecated and will be removed in")
-    with pytest.warns(FutureWarning, match=regex):
+def test_no_warn_argument():
+    """Test removal of the warn argument."""
+    regex = re.escape("get_default_solver() got an unexpected keyword argument")
+    with pytest.raises(TypeError, match=regex):
         get_default_solver(warn=True)
-
-
-def test_no_deprecation_warning():
-    """Test if no deprecation warning is issued with default parameters."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # raise error if warning was raised
-        get_default_solver()


### PR DESCRIPTION
#### Summary

Update test to check for a `TypeError` if the `warn` argument is passed.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
