### PR TITLE
Remove deprecated properties of optimizers

### DIFF
--- a/simpeg/optimization.py
+++ b/simpeg/optimization.py
@@ -72,7 +72,6 @@ Iteration Printers and Stoppers
 
 """
 
-import warnings
 from collections.abc import Callable
 from typing import Any, Optional
 
@@ -1050,18 +1049,9 @@ class InexactCG(object):
         cg_maxiter: int = 5,
         **kwargs,
     ):
-
-        if (val := kwargs.pop("tolCG", None)) is not None:
-            self.tolCG = val  # Deprecated cg_rtol
-        else:
-            self.cg_rtol = cg_rtol
+        self.cg_rtol = cg_rtol
         self.cg_atol = cg_atol
-
-        if (val := kwargs.pop("maxIterCG", None)) is not None:
-            self.maxIterCG = val
-        else:
-            self.cg_maxiter = cg_maxiter
-
+        self.cg_maxiter = cg_maxiter
         super().__init__(**kwargs)
 
     @property
@@ -1124,10 +1114,10 @@ class InexactCG(object):
         self._cg_maxiter = validate_integer("cg_maxiter", value, min_val=1)
 
     maxIterCG = deprecate_property(
-        cg_maxiter, old_name="maxIterCG", removal_version="0.26.0", future_warn=True
+        cg_maxiter, old_name="maxIterCG", removal_version="0.26.0", error=True
     )
     tolCG = deprecate_property(
-        cg_rtol, old_name="tolCG", removal_version="0.26.0", future_warn=True
+        cg_rtol, old_name="tolCG", removal_version="0.26.0", error=True
     )
 
 
@@ -1524,46 +1514,14 @@ class ProjectedGNCG(Bounded, InexactGaussNewton):
         lower: None | float | npt.NDArray[np.float64] = -np.inf,
         upper: None | float | npt.NDArray[np.float64] = np.inf,
         cg_maxiter: int = 5,
-        cg_rtol: float = None,
-        cg_atol: float = None,
+        cg_rtol: float = 1e-3,
+        cg_atol: float = 0.0,
         step_active_set: bool = True,
         active_set_grad_scale: float = 1e-2,
         **kwargs,
     ):
-        if (val := kwargs.pop("tolCG", None)) is not None:
-            # Deprecated path when tolCG is passed.
-            self.tolCG = val
-            cg_atol = val
-            cg_rtol = 0.0
-        elif cg_rtol is None and cg_atol is None:
-            # Note these defaults match previous settings...
-            # but they're not good in general...
-            # Ideally they will change to cg_rtol=1E-3 and cg_atol=0.0
-            warnings.warn(
-                "The defaults for ProjectedGNCG will change in SimPEG 0.26.0. If you want to maintain the "
-                "previous behavior, explicitly set 'cg_atol=1E-3' and 'cg_rtol=0.0'.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            cg_atol = 1e-3
-            cg_rtol = 0.0
-        # defaults for if someone passes just cg_rtol or just cg_atol (to be removed on deprecation removal)
-        # These will likely be the future defaults
-        elif cg_atol is None:
-            cg_atol = 0.0
-        elif cg_rtol is None:
-            cg_rtol = 1e-3
-
-        if (val := kwargs.pop("stepActiveSet", None)) is not None:
-            self.stepActiveSet = val
-        else:
-            self.step_active_set = step_active_set
-
-        if (val := kwargs.pop("stepOffBoundsFact", None)) is not None:
-            self.stepOffBoundsFact = val
-        else:
-            self.active_set_grad_scale = active_set_grad_scale
-
+        self.step_active_set = step_active_set
+        self.active_set_grad_scale = active_set_grad_scale
         super().__init__(
             lower=lower,
             upper=upper,
@@ -1714,14 +1672,14 @@ class ProjectedGNCG(Bounded, InexactGaussNewton):
         step_active_set,
         old_name="stepActiveSet",
         removal_version="0.26.0",
-        future_warn=True,
+        error=True,
     )
 
     stepOffBoundsFact = deprecate_property(
         active_set_grad_scale,
         old_name="stepOffBoundsFact",
         removal_version="0.26.0",
-        future_warn=True,
+        error=True,
     )
 
     # This was the weird part from before... the default tolerance was used as an absolute tolerance...
@@ -1729,5 +1687,5 @@ class ProjectedGNCG(Bounded, InexactGaussNewton):
         InexactGaussNewton.cg_atol,
         old_name="tolCG",
         removal_version="0.26.0",
-        future_warn=True,
+        error=True,
     )

--- a/tests/base/test_optimizers.py
+++ b/tests/base/test_optimizers.py
@@ -337,48 +337,33 @@ class TestInexactGaussNewton:
             optimization.InexactGaussNewton(10)
 
     @pytest.mark.parametrize("on_init", [True, False], ids=["init", "attribute setter"])
-    def test_deprecated_tolCG(self, on_init):
-        match = ".*tolCG has been deprecated.*cg_rtol.*"
+    def test_removed_tolCG(self, on_init):
+        match = ".*tolCG has been removed.*cg_rtol.*"
         if on_init:
-            with pytest.warns(FutureWarning, match=match):
-                opt = optimization.InexactGaussNewton(tolCG=1e-3)
+            with pytest.raises(NotImplementedError, match=match):
+                optimization.InexactGaussNewton(tolCG=1e-3)
         else:
             opt = optimization.InexactGaussNewton()
-            with pytest.warns(FutureWarning, match=match):
+            with pytest.raises(NotImplementedError, match=match):
                 opt.tolCG = 1e-3
 
-        with pytest.warns(FutureWarning, match=match):
-            assert opt.tolCG == 1e-3
-        assert opt.cg_atol == 0.0
-        assert opt.cg_rtol == 1e-3
-
-        # test setting new changes old
-        opt.cg_rtol = 1e-4
-
-        with pytest.warns(FutureWarning, match=match):
-            assert opt.tolCG == 1e-4
+            with pytest.raises(NotImplementedError, match=match):
+                assert opt.tolCG
 
     @pytest.mark.parametrize("on_init", [True, False], ids=["init", "attribute setter"])
-    def test_deprecated_maxIterCG(self, on_init):
+    def test_removed_maxIterCG(self, on_init):
 
-        match = ".*maxIterCG has been deprecated.*"
+        match = ".*maxIterCG has been removed.*"
         if on_init:
-            with pytest.warns(FutureWarning, match=match):
-                opt = optimization.InexactGaussNewton(maxIterCG=3)
+            with pytest.raises(NotImplementedError, match=match):
+                optimization.InexactGaussNewton(maxIterCG=3)
         else:
             opt = optimization.InexactGaussNewton()
-            with pytest.warns(FutureWarning, match=match):
+            with pytest.raises(NotImplementedError, match=match):
                 opt.maxIterCG = 3
 
-        with pytest.warns(FutureWarning, match=match):
-            assert opt.maxIterCG == 3
-
-        assert opt.cg_maxiter == 3
-
-        # test setting new changes old
-        opt.cg_maxiter = 8
-        with pytest.warns(FutureWarning, match=match):
-            assert opt.maxIterCG == 8
+            with pytest.raises(NotImplementedError, match=match):
+                assert opt.maxIterCG
 
 
 class TestProjectedGNCG:

--- a/tests/base/test_optimizers.py
+++ b/tests/base/test_optimizers.py
@@ -246,17 +246,12 @@ class TestInexactCGParams:
         ):
             optimization.InexactCG(1e-3)
 
-    def test_deprecated(self):
-        with pytest.warns(FutureWarning, match=".*tolCG has been deprecated.*"):
-            cg_pars = optimization.InexactCG(tolCG=1e-3)
-        assert cg_pars.cg_atol == 0.0
-        assert cg_pars.cg_rtol == 1e-3
-
-        with pytest.warns(FutureWarning, match=".*maxIterCG has been deprecated.*"):
-            cg_pars = optimization.InexactCG(maxIterCG=3)
-        assert cg_pars.cg_atol == 0.0
-        assert cg_pars.cg_rtol == 1e-1
-        assert cg_pars.cg_maxiter == 3
+    def test_removed(self):
+        """Test error after removed deprecated properties."""
+        with pytest.raises(TypeError):
+            optimization.InexactCG(tolCG=1e-3)
+        with pytest.raises(TypeError):
+            optimization.InexactCG(maxIterCG=3)
 
 
 class TestProjectedGradient:

--- a/tests/base/test_optimizers.py
+++ b/tests/base/test_optimizers.py
@@ -380,14 +380,11 @@ class TestProjectedGNCG:
             opt = optimization.ProjectedGNCG(cg_rtol=1e-4)
             assert opt.cg_atol == 0.0
             assert opt.cg_rtol == 1e-4
-        # test the old defaults
+        # test the new defaults
         else:
-            with pytest.warns(
-                FutureWarning, match="The defaults for ProjectedGNCG will change.*"
-            ):
-                opt = optimization.ProjectedGNCG()
-            assert opt.cg_rtol == 0.0
-            assert opt.cg_atol == 1e-3
+            opt = optimization.ProjectedGNCG()
+            assert opt.cg_rtol == 1e-3
+            assert opt.cg_atol == 0.0
         assert opt.cg_maxiter == 5
         assert np.isneginf(opt.lower)
         assert np.isposinf(opt.upper)
@@ -412,59 +409,26 @@ class TestProjectedGNCG:
             optimization.ProjectedGNCG(10)
 
     @pytest.mark.parametrize("on_init", [True, False], ids=["init", "attribute setter"])
-    def test_deprecated_tolCG(self, on_init):
-        if on_init:
-            with pytest.warns(
-                FutureWarning, match=".*tolCG has been deprecated.*cg_atol.*"
-            ):
-                opt = optimization.ProjectedGNCG(tolCG=1e-5)
-        else:
-            opt = optimization.ProjectedGNCG()
-            with pytest.warns(
-                FutureWarning, match=".*tolCG has been deprecated.*cg_atol.*"
-            ):
-                opt.tolCG = 1e-5
-
-        with pytest.warns(FutureWarning, match=".*tolCG has been deprecated.*"):
-            assert opt.tolCG == 1e-5
-
-        assert opt.cg_atol == 1e-5
-        assert opt.cg_rtol == 0.0
-
-        # test setting new changes old
-        opt.cg_atol = 1e-4
-
-        with pytest.warns(FutureWarning, match=".*tolCG has been deprecated.*"):
-            assert opt.tolCG == 1e-4
-
-    @pytest.mark.parametrize("on_init", [True, False], ids=["init", "attribute setter"])
     @pytest.mark.parametrize(
-        ("old_name", "new_name", "val1", "val2"),
+        ("old_name", "new_name", "value"),
         [
-            ("maxIterCG", "cg_maxiter", 3, 8),
-            ("stepActiveSet", "step_active_set", True, False),
-            ("stepOffBoundsFact", "active_set_grad_scale", 1.2, 1.4),
+            ("tolCG", "cg_atol", 1e-5),
+            ("maxIterCG", "cg_maxiter", 3),
+            ("stepActiveSet", "step_active_set", True),
+            ("stepOffBoundsFact", "active_set_grad_scale", 1.2),
         ],
-        ids=["maxIterCG", "stepActiveSet", "stepOffBoundsFact"],
+        ids=["tolCG", "maxIterCG", "stepActiveSet", "stepOffBoundsFact"],
     )
-    def test_deprecated_maxIterCG(self, on_init, old_name, new_name, val1, val2):
+    def test_removed_properties(self, on_init, old_name, new_name, value):
 
-        match = f".*{old_name} has been deprecated.*"
+        match = f".*{old_name} has been removed.*{new_name}.*"
         if on_init:
-            with pytest.warns(FutureWarning, match=match):
-                opt = optimization.ProjectedGNCG(**{old_name: val1})
+            with pytest.raises(NotImplementedError, match=match):
+                opt = optimization.ProjectedGNCG(**{old_name: value})
         else:
             opt = optimization.ProjectedGNCG()
-            with pytest.warns(FutureWarning, match=match):
-                setattr(opt, old_name, val1)
-                opt.maxIterCG = 3
+            with pytest.raises(NotImplementedError, match=match):
+                setattr(opt, old_name, value)
 
-        with pytest.warns(FutureWarning, match=match):
-            assert getattr(opt, old_name) == val1
-
-        assert getattr(opt, old_name) == val1
-
-        setattr(opt, new_name, val2)
-
-        with pytest.warns(FutureWarning, match=match):
-            assert getattr(opt, old_name) == val2
+            with pytest.raises(NotImplementedError, match=match):
+                getattr(opt, old_name)

--- a/tests/base/test_optimizers.py
+++ b/tests/base/test_optimizers.py
@@ -295,7 +295,7 @@ class TestProjectedGradient:
                 opt.tolCG = 1e-3
 
             with pytest.raises(NotImplementedError, match=match):
-                assert opt.tolCG
+                opt.tolCG
 
     @pytest.mark.parametrize("on_init", [True, False], ids=["init", "attribute setter"])
     def test_removed_maxIterCG(self, on_init):
@@ -310,7 +310,7 @@ class TestProjectedGradient:
                 opt.maxIterCG = 3
 
             with pytest.raises(NotImplementedError, match=match):
-                assert opt.maxIterCG
+                opt.maxIterCG
 
 
 class TestInexactGaussNewton:
@@ -348,7 +348,7 @@ class TestInexactGaussNewton:
                 opt.tolCG = 1e-3
 
             with pytest.raises(NotImplementedError, match=match):
-                assert opt.tolCG
+                opt.tolCG
 
     @pytest.mark.parametrize("on_init", [True, False], ids=["init", "attribute setter"])
     def test_removed_maxIterCG(self, on_init):
@@ -363,7 +363,7 @@ class TestInexactGaussNewton:
                 opt.maxIterCG = 3
 
             with pytest.raises(NotImplementedError, match=match):
-                assert opt.maxIterCG
+                opt.maxIterCG
 
 
 class TestProjectedGNCG:

--- a/tests/base/test_optimizers.py
+++ b/tests/base/test_optimizers.py
@@ -284,48 +284,33 @@ class TestProjectedGradient:
             optimization.ProjectedGradient(10)
 
     @pytest.mark.parametrize("on_init", [True, False], ids=["init", "attribute setter"])
-    def test_deprecated_tolCG(self, on_init):
-        match = ".*tolCG has been deprecated.*cg_rtol.*"
+    def test_removed_tolCG(self, on_init):
+        match = ".*tolCG has been removed.*cg_rtol.*"
         if on_init:
-            with pytest.warns(FutureWarning, match=match):
-                opt = optimization.ProjectedGradient(tolCG=1e-3)
+            with pytest.raises(NotImplementedError, match=match):
+                optimization.ProjectedGradient(tolCG=1e-3)
         else:
             opt = optimization.ProjectedGradient()
-            with pytest.warns(FutureWarning, match=match):
+            with pytest.raises(NotImplementedError, match=match):
                 opt.tolCG = 1e-3
 
-        with pytest.warns(FutureWarning, match=match):
-            assert opt.tolCG == 1e-3
-        assert opt.cg_atol == 0.0
-        assert opt.cg_rtol == 1e-3
-
-        # test setting new changes old
-        opt.cg_rtol = 1e-4
-
-        with pytest.warns(FutureWarning, match=match):
-            assert opt.tolCG == 1e-4
+            with pytest.raises(NotImplementedError, match=match):
+                assert opt.tolCG
 
     @pytest.mark.parametrize("on_init", [True, False], ids=["init", "attribute setter"])
-    def test_deprecated_maxIterCG(self, on_init):
+    def test_removed_maxIterCG(self, on_init):
 
-        match = ".*maxIterCG has been deprecated.*"
+        match = ".*maxIterCG has been removed.*"
         if on_init:
-            with pytest.warns(FutureWarning, match=match):
-                opt = optimization.ProjectedGradient(maxIterCG=3)
+            with pytest.raises(NotImplementedError, match=match):
+                optimization.ProjectedGradient(maxIterCG=3)
         else:
             opt = optimization.ProjectedGradient()
-            with pytest.warns(FutureWarning, match=match):
+            with pytest.raises(NotImplementedError, match=match):
                 opt.maxIterCG = 3
 
-        with pytest.warns(FutureWarning, match=match):
-            assert opt.maxIterCG == 3
-
-        assert opt.cg_maxiter == 3
-
-        # test setting new changes old
-        opt.cg_maxiter = 8
-        with pytest.warns(FutureWarning, match=match):
-            assert opt.maxIterCG == 8
+            with pytest.raises(NotImplementedError, match=match):
+                assert opt.maxIterCG
 
 
 class TestInexactGaussNewton:


### PR DESCRIPTION
#### Summary

Remove the deprecated `tolCG`, `maxIterCG`, `stepActiveSet`, and `setpOffBoundsFact` properties from optimizers.
Remove the `FutureWarning` that let users know about the change in default values in the default tolerances.  Update tests for the  `ProjectedGNCG`, `InexactGaussNewton`, `ProjectedGradient`, and `InexactCG` optimizer.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
