### PR TITLE
Remove deprecated properties from directives

### DIFF
--- a/simpeg/directives/_directives.py
+++ b/simpeg/directives/_directives.py
@@ -2102,16 +2102,13 @@ class SaveOutputDictEveryIteration(SaveEveryIteration):
 
     # Initialize the output dict
     def __init__(self, on_disk=False, **kwargs):
-        if (save_on_disk := kwargs.pop("saveOnDisk", None)) is not None:
-            self.saveOnDisk = save_on_disk
-            on_disk = self.saveOnDisk
         super().__init__(on_disk=on_disk, **kwargs)
 
     saveOnDisk = deprecate_property(
         SaveEveryIteration.on_disk,
         "saveOnDisk",
         removal_version="0.26.0",
-        future_warn=True,
+        error=True,
     )
 
     @property

--- a/simpeg/directives/_directives.py
+++ b/simpeg/directives/_directives.py
@@ -1766,12 +1766,8 @@ class SaveEveryIteration(InversionDirective, metaclass=ABCMeta):
 
     @property
     def fileName(self):
-        warnings.warn(
-            "'fileName' has been deprecated and will be removed in SimPEG 0.26.0 use 'file_abs_path'",
-            FutureWarning,
-            stacklevel=2,
-        )
-        return self.file_abs_path.stem
+        msg = "'fileName' has been removed, use 'file_abs_path' instead."
+        raise AttributeError(msg)
 
     @property
     @abstractmethod

--- a/simpeg/directives/_directives.py
+++ b/simpeg/directives/_directives.py
@@ -1857,9 +1857,6 @@ class SaveOutputEveryIteration(SaveEveryIteration):
     """
 
     def __init__(self, on_disk=True, **kwargs):
-        if (save_txt := kwargs.pop("save_txt", None)) is not None:
-            self.save_txt = save_txt
-            on_disk = self.save_txt
         super().__init__(on_disk=on_disk, **kwargs)
 
     def initialize(self):
@@ -1900,7 +1897,7 @@ class SaveOutputEveryIteration(SaveEveryIteration):
         SaveEveryIteration.on_disk,
         "save_txt",
         removal_version="0.26.0",
-        future_warn=True,
+        error=True,
     )
 
     def endIter(self):

--- a/tests/base/test_directives.py
+++ b/tests/base/test_directives.py
@@ -841,13 +841,10 @@ class TestSaveEveryIteration:
         time_name = directive._time_file_name.name
         assert directive._time_iter_file_name.name == time_name + "_###"
 
-    def test_deprecated_fileName(self):
+    def test_removed_fileName(self):
         directive = DummySaveEveryIteration(name="dummy")
-
-        with pytest.warns(FutureWarning, match=r"'fileName' has been deprecated .*"):
-            f_name = directive.fileName
-
-        assert f_name == "dummy"
+        with pytest.raises(AttributeError, match=r"'fileName' has been removed.*"):
+            directive.fileName
 
 
 class TestSaveModelEveryIteration:


### PR DESCRIPTION
#### Summary

Remove `saveOnDisk` argument from `SaveOutputDictEveryIteration`. Remove the `save_txt` argument from `SaveOutputEveryIteration`. Remove the `fileName` property from `SaveEveryIteration`.


#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
