### PR TITLE
Drop support for Python 3.11

### DIFF
--- a/.ci/azure/docs.yml
+++ b/.ci/azure/docs.yml
@@ -5,7 +5,7 @@ jobs:
     pool:
       vmImage: ubuntu-latest
     variables:
-      python.version: "3.11"
+      python.version: "3.12"
     timeoutInMinutes: 240
     steps:
       # Checkout simpeg repo.

--- a/.ci/azure/pypi.yml
+++ b/.ci/azure/pypi.yml
@@ -12,7 +12,7 @@ jobs:
 
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: "3.11"
+          versionSpec: "3.12"
         displayName: "Setup Python"
 
       - bash: |
@@ -57,7 +57,7 @@ jobs:
 
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: "3.11"
+          versionSpec: "3.12"
         displayName: "Setup Python"
 
       - bash: |

--- a/.ci/azure/style.yml
+++ b/.ci/azure/style.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: "3.11"
+          versionSpec: "3.12"
       - bash: .ci/install_style.sh
         displayName: "Install dependencies to run the checks"
       - script: make black
@@ -19,7 +19,7 @@ jobs:
     steps:
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: "3.11"
+          versionSpec: "3.12"
       - bash: .ci/install_style.sh
         displayName: "Install dependencies to run the checks"
       - script: make flake
@@ -32,7 +32,7 @@ jobs:
     steps:
       - task: UsePythonVersion@0
         inputs:
-          versionSpec: "3.11"
+          versionSpec: "3.12"
       - bash: .ci/install_style.sh
         displayName: "Install dependencies to run the checks"
       - script: make flake-all

--- a/.ci/azure/test.yml
+++ b/.ci/azure/test.yml
@@ -1,6 +1,6 @@
 parameters:
   os : ['ubuntu-latest']
-  py_vers: ['3.11']
+  py_vers: ['3.12']
   test: ['tests/em',
          'tests/base tests/flow tests/seis tests/utils',
          'tests/meta',

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Python env
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies to run the flake8 checks
         run: .ci/install_style.sh
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Python env
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install dependencies to run the black checks
         run: .ci/install_style.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,12 +3,12 @@ repos:
     rev: 24.3.0
     hooks:
       - id: black
-        language_version: python3.11
+        language_version: python3
   - repo: https://github.com/pycqa/flake8
     rev: 7.0.0
     hooks:
       - id: flake8
-        language_version: python3.11
+        language_version: python3
         additional_dependencies:
           - flake8-bugbear==23.12.2
           - flake8-builtins==2.2.0

--- a/docs/content/user-guide/getting-started/version-compatibility.rst
+++ b/docs/content/user-guide/getting-started/version-compatibility.rst
@@ -36,3 +36,5 @@ following releases to ensure compatibility:
       - 0.22.2
     * - 3.10
       - 0.24.0
+    * - 3.11
+      - 0.25.2

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
 # dependencies
-  - python=3.11
+  - python=3.12
   - numpy>=1.22
   - scipy>=1.12
   - pymatsolver>=0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 name = 'simpeg'
 description = "SimPEG: Simulation and Parameter Estimation in Geophysics"
 readme = 'README.rst'
-requires-python = '>=3.11'
+requires-python = '>=3.12'
 authors = [
   {name = 'SimPEG developers', email = 'rowanc1@gmail.com'},
 ]


### PR DESCRIPTION
#### Summary

Since Python 3.11 will reach its EOL on October 2026, we are dropping support for it. Require Python 3.12 as the minimum compatible version for SimPEG. Update Python version in `environment.yml` and CI configurations and scripts. Add entry to version compatibility table: list SimPEG v0.25.2 as the last version compatible with Python 3.11. Go back to using `python3` as Python version in `pre-commit` config.

#### PR Checklist
* [ ] If this is a work in progress PR, set as a Draft PR
* [ ] Linted my code according to the [style guides](https://docs.simpeg.xyz/latest/content/getting_started/contributing/code-style.html).
* [ ] Added [tests](https://docs.simpeg.xyz/latest/content/getting_started/contributing/testing.html) to verify changes to the code.
* [ ] Added necessary documentation to any new functions/classes following the
      expect [style](https://docs.simpeg.xyz/latest/content/getting_started/contributing/documentation.html).
* [ ] Marked as ready for review (if this is was a draft PR), and converted
      to a Pull Request
* [ ] Tagged ``@simpeg/simpeg-developers`` when ready for review.

#### Reference issue
<!--Example: write "Closes #NNNN" to automatically close that issue on merge.-->

In this PR I'm restoring the `pre-commit` configuration to use any Python version available. Such change was introduced in c12b527d21d1b11d515531f60990d86384fe7b3e, but explicit Python versions were restored in c37536ce0757ea9dfe38ec470f6ea2d79ba2a297.

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->


<!--
Once all tests pass and the code has been reviewed and approved, it will be merged into main
-->
