### PR TITLE
Document how to set Pardiso thread counts

### DIFF
--- a/docs/content/user-guide/how-to-guide/choosing-solvers.rst
+++ b/docs/content/user-guide/how-to-guide/choosing-solvers.rst
@@ -25,6 +25,9 @@ for SimPEG, but be aware that direct solvers have much larger memory requirement
 - The :class:`~pymatsolver.SolverLU` wraps SciPy's :func:`scipy.sparse.linalg.splu`. The performance of this solver is not up to the level of :class:`~pymatsolver.Mumps` and :class:`~pymatsolver.Pardiso`. Usage of the :class:`~pymatsolver.SolveLU` is recommended only when it's not possible to use other faster solvers.
 
 
+For control over Pardiso's CPU usage, see :ref:`pardiso-threads`.
+
+
 The default solver
 ------------------
 
@@ -100,4 +103,3 @@ MUMPS in our DC resistivity simulation, we can import
 Ultimately, choosing the best solver is a mixture of the problem you are solving
 and your current system. Experiment with different solvers yourself to choose
 the best.
-

--- a/docs/content/user-guide/how-to-guide/pardiso-threads.rst
+++ b/docs/content/user-guide/how-to-guide/pardiso-threads.rst
@@ -1,0 +1,73 @@
+.. _pardiso-threads:
+
+Setting the number of Pardiso threads
+=====================================
+
+The :class:`pymatsolver.Pardiso` solver can use multiple threads to solve a
+linear system. This guide shows how to set its thread count from a SimPEG
+simulation. It requires an x86_64 machine with ``pydiso`` installed; see
+:ref:`choosing-solvers` for other solver options.
+
+Pass the ``n_threads`` option through the simulation's ``solver_opts``
+dictionary. For example, the following DC simulation requests two threads:
+
+.. code:: python
+
+   import numpy as np
+   from discretize import TensorMesh
+   from pymatsolver import Pardiso
+   import simpeg.electromagnetics.static.resistivity as dc
+
+   h = [(1.0, 10)]
+   mesh = TensorMesh([h, h, h], origin="CCC")
+   receiver = dc.receivers.Dipole(locations_m=(-1, 0, 0), locations_n=(1, 0, 0))
+   source = dc.sources.Dipole(
+       receiver_list=[receiver], location_a=(-2, 0, 0), location_b=(2, 0, 0)
+   )
+   survey = dc.Survey([source])
+
+   simulation = dc.Simulation3DNodal(
+       mesh=mesh,
+       survey=survey,
+       sigma=np.full(mesh.n_cells, 1e-2),
+       solver=Pardiso,
+       solver_opts={"n_threads": 2},
+   )
+   predicted_data = simulation.dpred()
+
+SimPEG passes ``solver_opts`` to the solver when it creates a solver instance.
+In this example, that happens while computing ``predicted_data``, not when
+constructing the simulation. Setting ``solver_opts`` does not change a solver
+instance that the simulation has already created.
+
+.. important::
+
+   Pardiso's thread setting is shared by all Pardiso solver instances in the
+   same Python process. It is not a separate limit for each simulation.
+   Creating another Pardiso solver with a different ``n_threads`` value changes
+   the setting for existing instances too. Separate Python processes each have
+   their own setting.
+
+You can also inspect or change the setting through an existing Pardiso solver's
+``n_threads`` property. The following example illustrates its process-wide
+effect with two small linear systems:
+
+.. code:: python
+
+   from scipy.sparse import eye
+
+   matrix = eye(3, format="csr")
+   first_solver = Pardiso(matrix, n_threads=2)
+   second_solver = Pardiso(matrix, n_threads=1)
+   assert first_solver.n_threads == second_solver.n_threads == 1
+
+   first_solver.n_threads = 2
+   assert first_solver.n_threads == second_solver.n_threads == 2
+
+   first_solver.clean()
+   second_solver.clean()
+
+Choose a positive thread count appropriate for the resources available to your
+process. More threads do not necessarily make a small problem faster. If you
+run simulations in multiple processes, account for the threads used by every
+process to avoid requesting more CPU resources than are available.

--- a/docs/content/user-guide/index.rst
+++ b/docs/content/user-guide/index.rst
@@ -26,6 +26,7 @@ For details on the available classes and functions in SimPEG, please visit the
   :caption: How to Guide
 
   how-to-guide/choosing-solvers
+  how-to-guide/pardiso-threads
   how-to-guide/move-mesh-to-survey.rst
 
 .. toctree::


### PR DESCRIPTION
#### Summary

Add a how-to guide for setting Pardiso's thread count using `solver_opts={"n_threads": ...}` and link it from the user guide and solver selection guide.

#### PR Checklist

- [x] Added documentation with executable examples.
- [x] Built the HTML documentation with gallery execution disabled.
- [x] Executed both code blocks with real Pardiso on Linux x86_64 under emulation.

#### Reference issue

Closes #1730.

#### What does this implement/fix?

The guide includes a complete DC simulation, explains when SimPEG applies `solver_opts`, and demonstrates inspecting/changing the process-wide thread count via the solver's `n_threads` property. It explicitly notes that different Pardiso instances in one process do not have independent thread limits, as clarified in the issue discussion.

#### Additional information

Validation used the current SimPEG checkout with Python 3.12, pymatsolver 0.4.0 and pydiso 0.2.0 in an x86_64 container. Both examples passed, including a finite DC prediction and assertions showing the shared thread setting. The emulated environment used `MKL_NUM_THREADS=2`, `OMP_WAIT_POLICY=PASSIVE`, and `KMP_BLOCKTIME=0`.

`sphinx-build -D plot_gallery=0 -b html docs <output> -j 2` completed successfully. The full documentation emits existing warnings/errors in unrelated API/release pages; the final incremental build emits none for the new guide or the modified solver-selection page. No simulation code is changed.
